### PR TITLE
Update Readme with blocks info   AIO-56

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # Feeds
 
 The repo contains the work to migrate partner feeds to [arc-fusion](https://github.com/WPMedia/fusion) compatible [blocks](https://github.com/WPMedia/fusion-news-theme-blocks).
-This [Monorepo](https://monorepo.guide)'s versioning and changelogs are managed by tools from [changset](https://github.com/atlassian/changesets). Once a block's development is complete, it is published to wapo's private github NPM registry where it can be used in clients feature pack repos.
+This [Monorepo](https://monorepo.guide)'s versioning and changelogs are managed by tools from [changset](https://github.com/atlassian/changesets) and [yarn](https://classic.yarnpkg.com/en/docs/cli/workspaces/). Once a block's development is complete, it is published to wapo's private github NPM registry where it can be used in clients feature pack repos.
 
 ## Standard Out Of the Box Feeds
+
 The most commonly used feeds from partner-feeds will be migrated to fusion as blocks. This work is in progress and each feed will be built in order of usage.
+
 - sitemap
 - news-sitemap
 - video-sitemap


### PR DESCRIPTION
Sorry, I should have paid more attention to the original PR, but now that I'm not as distracted I actually gave it a critical read.  The readme says almost nothing about the purpose of the repo.  All the text I removed was copied from changeset and is not about our repo.  We link to it so that should suffice.

I also moved the diagram up as I think it's helpful to talk about what a block is. 

I've tried to explain what this repo is and how it fits within the blocks architecture, but it still needs work.