### PR TITLE
Update sitemap-news-feature name

### DIFF
--- a/blocks/sitemap-news-feature-block/package.json
+++ b/blocks/sitemap-news-feature-block/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@wpmedia/sitemaps-news-feature-block",
+  "name": "@wpmedia/sitemap-news-feature-block",
   "version": "0.1.1",
   "description": "Fusion components for building news sitemaps",
   "main": "index.js",
@@ -10,7 +10,7 @@
   "repository": {
     "type": "git",
     "url": "git+ssh://git@github.com/WPMedia/feed-components.git",
-    "directory": "blocks/sitemaps-feature-block"
+    "directory": "blocks/sitemap-news-feature-block"
   },
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/",


### PR DESCRIPTION
The name of the package was wrongly named as `sitemaps-news-feature-block` and referenced a wrong directory.
This PR would update the name and the directory reference to the correct one  