### PR TITLE
Move channelPath out of propInfo

### DIFF
--- a/.changeset/rotten-carrots-jog.md
+++ b/.changeset/rotten-carrots-jog.md
@@ -1,0 +1,6 @@
+---
+'@wpmedia/rss-feature-block': minor
+'@wpmedia/feeds-prop-types': minor
+---
+
+Move channelPath out of propInfo

--- a/blocks/rss-feature-block/features/rss/xml.js
+++ b/blocks/rss-feature-block/features/rss/xml.js
@@ -165,6 +165,13 @@ export function Rss({ globalContent, customFields, arcSite }) {
 
 Rss.propTypes = {
   customFields: PropTypes.shape({
+    channelPath: PropTypes.string.tag({
+      label: 'Path',
+      group: 'Channel',
+      description:
+        'Path to the feed, excluding the domain, defaults to /arcio/rss',
+      defaultValue: '/arcio/rss/',
+    }),
     ...generatePropsForFeed('rss', PropTypes),
   }),
 }

--- a/utils/prop-types/src/__snapshots__/props.test.js.snap
+++ b/utils/prop-types/src/__snapshots__/props.test.js.snap
@@ -38,15 +38,6 @@ Object {
     },
     "type": "string",
   },
-  "channelPath": Object {
-    "tags": Object {
-      "defaultValue": "/arcio/rss",
-      "description": "Path to the feed excluding the domain, defaults to /arcio/rss",
-      "group": "Channel",
-      "label": "Path",
-    },
-    "type": "string",
-  },
   "channelTTL": Object {
     "tags": Object {
       "defaultValue": "1",

--- a/utils/prop-types/src/generatePropsForFeed.js
+++ b/utils/prop-types/src/generatePropsForFeed.js
@@ -11,7 +11,7 @@ import { propInfo } from './propInfo'
 export const generatePropsForFeed = (feedType, PropTypes, omit = []) => {
   const feed = propInfo[feedType]
   if (!feed) {
-    throw new Error(`${feedType} is not a valid feed`)
+    throw new Error(`${feedType} is not a valid feed propType`)
   }
 
   const functionalPropTypes = [

--- a/utils/prop-types/src/propInfo.js
+++ b/utils/prop-types/src/propInfo.js
@@ -100,16 +100,6 @@ export const propInfo = {
         defaultValue: '',
       },
     },
-    channelPath: {
-      type: 'string',
-      tag: {
-        label: 'Path',
-        group: 'Channel',
-        description:
-          'Path to the feed excluding the domain, defaults to /arcio/rss',
-        defaultValue: '/arcio/rss',
-      },
-    },
     channelCopyright: {
       type: 'string',
       tag: {


### PR DESCRIPTION
- channelPath will need a different defaulr for each feed so it shouldn't be
in the package
- update error message to make it source clearer