### PR TITLE
Added new parameters AIO-170

### DIFF
--- a/.changeset/warm-cooks-notice.md
+++ b/.changeset/warm-cooks-notice.md
@@ -1,0 +1,5 @@
+---
+'@wpmedia/feeds-source-content-api-block': minor
+---
+
+Added section, author, keywords, tags params

--- a/blocks/feeds-source-content-api-block/sources/feeds-content-api.js
+++ b/blocks/feeds-source-content-api-block/sources/feeds-content-api.js
@@ -3,7 +3,6 @@ import { CONTENT_BASE } from 'fusion:environment'
 const resolve = function resolve(key) {
   const requestUri = `${CONTENT_BASE}/content/v4/search/published`
   const uriParams = [
-    `q=${key['Feed-Query'] || 'type:story+AND+revision.published:true'}`,
     `website=${key['arc-site']}`,
     `size=${key['Feed-Size'] || '100'}`,
     `from=${key['Feed-Offset'] || '0'}`,
@@ -11,14 +10,137 @@ const resolve = function resolve(key) {
     `sort=${key.Sort || 'publish_date:desc'}`,
   ].join('&')
 
-  return `${requestUri}?${uriParams}`
+  // basic ES query
+  const body = {
+    query: {
+      bool: {
+        must: [],
+      },
+    },
+  }
+
+  // process the must query terms passed as json string
+  // if nothing passed or not valid json use [{"term": {"type":"story"}}, {"term": {"revision.published":true}}]
+  let feedQuery
+  if (key['Include-Terms']) {
+    try {
+      feedQuery = JSON.parse(key['Include-Terms'])
+    } catch (error) {
+      console.log(`Failed to parse Include-Terms: ${key['Include-Terms']}`)
+    }
+  }
+
+  // default query
+  if (!feedQuery) {
+    feedQuery = [
+      {
+        term: { type: 'story' },
+      },
+      { term: { 'revision.published': true } },
+    ]
+  }
+
+  body.query.bool.must = feedQuery
+
+  // process the not query terms passed as object
+  const excludeTerms = key['Exclude-Terms']
+  if (excludeTerms) {
+    try {
+      body.query.bool.must_not = JSON.parse(excludeTerms)
+    } catch (error) {
+      console.log(`Failed to parse Exclude-Terms: ${key['Exclude-Terms']}`)
+    }
+  }
+
+  // Append Author to basic query
+  const { Author } = key
+  if (Author) {
+    const author = Author.replace(/^\//, '')
+
+    body.query.bool.must.push({
+      term: {
+        'credits.by._id': author,
+      },
+    })
+  }
+
+  // Append Keywords to basic query
+  const { Keywords } = key
+  if (Keywords) {
+    const keywords = Keywords.replace(/^\//, '')
+
+    body.query.bool.must.push({
+      terms: {
+        'taxonomy.seo_keywords': keywords.split(','),
+      },
+    })
+  }
+
+  // Append Tags text to basic query
+  const tagsText = key['Tags-Text']
+  if (tagsText) {
+    const cleanTagsText = tagsText.replace(/^\//, '')
+
+    body.query.bool.must.push({
+      terms: {
+        'taxonomy.tags.text': cleanTagsText.split(','),
+      },
+    })
+  }
+
+  // Append Tags slug to basic query
+  const tagsSlug = key['Tags-Slug']
+  if (tagsSlug) {
+    const cleanTagsSlug = tagsSlug.replace(/^\//, '')
+
+    body.query.bool.must.push({
+      terms: {
+        'taxonomy.tags.slug': cleanTagsSlug.split(','),
+      },
+    })
+  }
+
+  // if Section append section query to basic query
+  const { Section } = key
+  if (Section && Section !== '/') {
+    let section = Section.replace(/\/$/, '')
+    if (!section.startsWith('/')) {
+      section = `/${section}`
+    }
+
+    body.query.bool.must.push({
+      nested: {
+        path: 'taxonomy.sections',
+        query: {
+          bool: {
+            must: [
+              {
+                term: {
+                  'taxonomy.sections._id': `${section}`,
+                },
+              },
+            ],
+          },
+        },
+      },
+    })
+  }
+
+  const encodedBody = encodeURI(JSON.stringify(body))
+  return `${requestUri}?body=${encodedBody}&${uriParams}`
 }
 
 export default {
   resolve,
   schemaName: 'feeds',
   params: {
-    'Feed-Query': 'text',
+    Section: 'text',
+    Author: 'text',
+    Keywords: 'text',
+    'Tags-Text': 'text',
+    'Tags-Slug': 'text',
+    'Include-Terms': 'text',
+    'Exclude-Terms': 'text',
     'Feed-Size': 'text',
     'Feed-Offset': 'text',
     'Source-Exclude': 'text',

--- a/blocks/feeds-source-content-api-block/sources/feeds-content-api.test.js
+++ b/blocks/feeds-source-content-api-block/sources/feeds-content-api.test.js
@@ -1,0 +1,163 @@
+// eslint-disable-next-line no-unused-vars
+import Consumer from 'fusion:consumer'
+const resolver = require('./feeds-content-api')
+
+it('validate schemaName', () => {
+  expect(resolver.default.schemaName).toBe('feeds')
+})
+
+it('validate params', () => {
+  expect(resolver.default.params).toStrictEqual({
+    Section: 'text',
+    Author: 'text',
+    Keywords: 'text',
+    'Tags-Text': 'text',
+    'Tags-Slug': 'text',
+    'Include-Terms': 'text',
+    'Exclude-Terms': 'text',
+    'Feed-Size': 'text',
+    'Feed-Offset': 'text',
+    'Source-Exclude': 'text',
+    Sort: 'text',
+  })
+})
+
+it('returns query with default values', () => {
+  const query = resolver.default.resolve({
+    Section: '',
+    Author: '',
+    Keywords: '',
+    'Tags-Text': '',
+    'Tags-Slug': '',
+    'arc-site': 'demo',
+    'Include-Terms': '',
+    'Exclude-Terms': '',
+    'Feed-Size': '',
+    'Feed-Offset': '',
+    'Source-Exclude': '',
+    Sort: '',
+  })
+  expect(query).toBe(
+    'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22term%22:%7B%22revision.published%22:true%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&_sourceExclude=related_content&sort=publish_date:desc',
+  )
+})
+
+it('returns query by section', () => {
+  const query = resolver.default.resolve({
+    Section: 'sports',
+    Author: '',
+    Keywords: '',
+    'Tags-Text': '',
+    'Tags-Slug': '',
+    'arc-site': 'demo',
+    'Include-Terms': '',
+    'Exclude-Terms': '',
+    'Feed-Size': '',
+    'Feed-Offset': '',
+    'Source-Exclude': '',
+    Sort: '',
+  })
+  expect(query).toBe(
+    'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22term%22:%7B%22revision.published%22:true%7D%7D,%7B%22nested%22:%7B%22path%22:%22taxonomy.sections%22,%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22taxonomy.sections._id%22:%22/sports%22%7D%7D%5D%7D%7D%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&_sourceExclude=related_content&sort=publish_date:desc',
+  )
+})
+
+it('returns query by section with leading slash', () => {
+  const query = resolver.default.resolve({
+    Section: '/sports',
+    Author: '',
+    Keywords: '',
+    'Tags-Text': '',
+    'Tags-Slug': '',
+    'arc-site': 'demo',
+    'Include-Terms': '',
+    'Exclude-Terms': '',
+    'Feed-Size': '',
+    'Feed-Offset': '',
+    'Source-Exclude': '',
+    Sort: '',
+  })
+  expect(query).toBe(
+    'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22term%22:%7B%22revision.published%22:true%7D%7D,%7B%22nested%22:%7B%22path%22:%22taxonomy.sections%22,%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22taxonomy.sections._id%22:%22/sports%22%7D%7D%5D%7D%7D%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&_sourceExclude=related_content&sort=publish_date:desc',
+  )
+})
+
+it('returns query by author', () => {
+  const query = resolver.default.resolve({
+    Section: '',
+    Author: 'John Smith',
+    Keywords: '',
+    'Tags-Text': '',
+    'Tags-Slug': '',
+    'arc-site': 'demo',
+    'Include-Terms': '',
+    'Exclude-Terms': '',
+    'Feed-Size': '',
+    'Feed-Offset': '',
+    'Source-Exclude': '',
+    Sort: '',
+  })
+  expect(query).toBe(
+    'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22term%22:%7B%22revision.published%22:true%7D%7D,%7B%22term%22:%7B%22credits.by._id%22:%22John%20Smith%22%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&_sourceExclude=related_content&sort=publish_date:desc',
+  )
+})
+
+it('returns query by keywords', () => {
+  const query = resolver.default.resolve({
+    Section: '',
+    Author: '',
+    Keywords: 'football,sports',
+    'Tags-Text': '',
+    'Tags-Slug': '',
+    'arc-site': 'demo',
+    'Include-Terms': '',
+    'Exclude-Terms': '',
+    'Feed-Size': '',
+    'Feed-Offset': '',
+    'Source-Exclude': '',
+    Sort: '',
+  })
+  expect(query).toBe(
+    'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22term%22:%7B%22revision.published%22:true%7D%7D,%7B%22terms%22:%7B%22taxonomy.seo_keywords%22:%5B%22football%22,%22sports%22%5D%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&_sourceExclude=related_content&sort=publish_date:desc',
+  )
+})
+
+it('returns query by tags text', () => {
+  const query = resolver.default.resolve({
+    Section: '',
+    Author: '',
+    Keywords: '',
+    'Tags-Text': 'football,sports',
+    'Tags-Slug': '',
+    'arc-site': 'demo',
+    'Include-Terms': '',
+    'Exclude-Terms': '',
+    'Feed-Size': '',
+    'Feed-Offset': '',
+    'Source-Exclude': '',
+    Sort: '',
+  })
+  expect(query).toBe(
+    'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22term%22:%7B%22revision.published%22:true%7D%7D,%7B%22terms%22:%7B%22taxonomy.tags.text%22:%5B%22football%22,%22sports%22%5D%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&_sourceExclude=related_content&sort=publish_date:desc',
+  )
+})
+
+it('returns query by tags slug', () => {
+  const query = resolver.default.resolve({
+    Section: '',
+    Author: '',
+    Keywords: '',
+    'Tags-Text': '',
+    'Tags-Slug': 'football,sports',
+    'arc-site': 'demo',
+    'Include-Terms': '',
+    'Exclude-Terms': '',
+    'Feed-Size': '',
+    'Feed-Offset': '',
+    'Source-Exclude': '',
+    Sort: '',
+  })
+  expect(query).toBe(
+    'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22term%22:%7B%22revision.published%22:true%7D%7D,%7B%22terms%22:%7B%22taxonomy.tags.slug%22:%5B%22football%22,%22sports%22%5D%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&_sourceExclude=related_content&sort=publish_date:desc',
+  )
+})


### PR DESCRIPTION
Thses are intended to have a value passed from the regex pattern like
`/rss/category(/.*)
section, author, keywords, tags-text, tags-slug
The format of the query had to change to support query by section
To allow changing the default query type:story+revision.published:true
new parameters Include-Terms and Exclude-Terms were added.  These need
to be valid json arrays using the DSL format
[{"term":{"type":"video"}}]