### PR TITLE
Fix github actions  AIO-152

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@prod
+        uses: actions/checkout@master
 
       - name: Setup Node.js 10.x
-        uses: actions/setup-node@prod
+        uses: actions/setup-node@master
         with:
           node-version: 10.x
           registry-url: https://npm.pkg.github.com


### PR DESCRIPTION
changing the actions from @master to @prod broke the scripts.
the action - "uses: actions/checkout@master"
calls the url:
https://api.github.com/repos/actions/checkout/tarball/master
so change the two actions back to @master as they will run against the
default branch.