### PR TITLE
Chosun/fusion changes  AIO-271

### DIFF
--- a/.changeset/happy-poems-count.md
+++ b/.changeset/happy-poems-count.md
@@ -1,0 +1,14 @@
+---
+'@wpmedia/feeds-source-content-api-block': minor
+'@wpmedia/mrss-feature-block': minor
+'@wpmedia/rss-fbia-feature-block': minor
+'@wpmedia/rss-feature-block': minor
+'@wpmedia/rss-flipboard-feature-block': minor
+'@wpmedia/rss-google-news-feature-block': minor
+'@wpmedia/rss-msn-feature-block': minor
+'@wpmedia/sitemap-feature-block': minor
+'@wpmedia/sitemap-index-feature-block': minor
+'@wpmedia/sitemap-video-feature-block': minor
+---
+
+changed default query and use /arc/outboundfeeds/ channelPath

--- a/README.md
+++ b/README.md
@@ -16,9 +16,10 @@ The most commonly used feeds from partner-feeds will be migrated to fusion as bl
 - fb-ia
 - msn
 - flipboard
+- mrss
 - apple-news
 
-Each feature will have customFields to configure the feeds to meet the most common customization requests. If a client needs a customization that is beyond what can be achieved with the customFields they will have to fork the repo and build a custom version.
+Each feature will have customFields to configure the feeds to meet the most common customization requests. If a client needs a customization that is beyond what can be achieved with the customFields they will have to checkout the package and manually add its components into the repo (eject the block) and build a custom version.
 
 ## Block Architecture
 
@@ -44,12 +45,12 @@ Make sure you have [`yarn` classic](https://classic.yarnpkg.com/en/) installed.
 
 ## Local Development
 
-1. link the block to make it available to the skeleton repo. From the blocks/{feature} directory run `npm link`
+1. Install the blocks dependencies to make it available to the skeleton repo. From the blocks/{feature} directory run `npm install`
 2. Clone the [skeleton-fusion-feeds](https://github.com/WPMedia/skeleton-fusion-feeds) project and follow the setup instructions
 3. In `skeleton-fusion-feeds`, add the package you are testing to the `blocks.json` blocks array
 4. Set `useLocal` in `blocks.json` to `true`
-5. In `skeleton-fusion-feeds`, run `npx fusion start-theme --links`
-6. When you are ready to create the PR create a changeset with `yarn changeset add` It will allow you to select which changes you want to include and designate them as major, minor or patch. Add any of the changeset files that were generated to the commit. There is a github action that will handle publishing the package once the PR is merged to master.
+5. In `skeleton-fusion-feeds`, run `npx fusion start`
+6. When you are ready to create the PR create a changeset with `yarn changeset add` It will allow you to select which changes you want to include and designate them as a major, minor or patch release. Add any of the changeset files that were generated to the commit. There is a github action that will handle publishing the package once the PR is merged to the prod branch.
 
 ## Caveats/Gotchas/Workaround
 
@@ -66,7 +67,7 @@ Some features use the same logic, so we've added the ability to create shared mo
 
 We weren't able to find a solution to use the `npm link` approach with shared modules. Instead, we'll use prerelease versions to denote "development" versions of these modules:
 
-- **Before you start work on a shared module, enter prerelease mode.** To enter prerelease mode, run `yarn changeset pre enter {tag}` (see the [changesets prerelease documentation](https://github.com/atlassian/changesets/blob/master/docs/prereleases.md) for more information). To be clear who is doing the development, suggest using your initials as the tag. The packages will be published as `1.0.1-cw.0`.
+- **Before you start work on a shared module, enter prerelease mode.** To enter prerelease mode, run `yarn changeset pre enter {tag}` (see the [changesets prerelease documentation](https://github.com/atlassian/changesets/blob/master/docs/prereleases.md) for more information). To be clear who is doing the development, it is suggested using your initials as the tag. If you use `cw` as the tag, the packages will be published as `1.0.1-cw.0`.
 
 - Use changesets as normal (`changeset add`). When you are ready to publish a prerelease, do a npm run build from the root of the repo, then `changeset version` and then `changetset publish`. Once you have a prerelease version published, you can update block dependencies to use it. You may also need to run these commands with a `GITHUB_TOKEN` env variable (which should be a [personal Github token](https://github.com/settings/tokens)). **Before you publish, run `npm run build` from the monorepo root directory.**
 

--- a/blocks/feeds-source-content-api-block/README.md
+++ b/blocks/feeds-source-content-api-block/README.md
@@ -1,11 +1,30 @@
-# Sitemaps
+# Content-API content source
 
-## Standard
+Creates an ElasticSearch DSL syntax to query Content-API
+
+## Globals
+
+- CONTENT_BASE
+- feedDefaultQuery
+
+## Parameters
+
+- Section: Maps to taxonomy.sections.\_id. It needs to start with a slash “/news”
+- Author: Maps to credits.by.\_id
+- Keywords: Maps to taxonomy.seo_keywords. It can be a comma separated list of values
+- Tags-Text: Maps to taxonomy.tags.text. It can be a comma separated list of values
+- Tags-Slug: Maps to taxonomy.tags.slug
+- Include-Terms: If you don’t want to use the default query you can enter a query here. It must be an array formatted like `[{"term":{"type": "story"}},{"range":{"last_updated_date:{"gte":"now-2d","lte":"now"}}}]`
+- Exclude-Terms: If you need to exclude terms in your query (NOT) enter them here as an array formatted the same as the Include-Terms
+- Feed-Size: Integer 1 to 100. Defaults to 100
+- Feed-Offset: Integer. Defaults to 0
+- Source-Exclude: ANS fields to exclude from the response. Defaults to `related_content`
+- Sort: Comma separated list of fields to sort on. Defaults to `publish_date:desc`
 
 ### Usage
 
-```
-import getSitemap from '@wpmedia/output-type-sitemap'
+Default query: [{"term":{"type": "story"}},{"range":{"last_updated_date:{"gte":"now-2d","lte":"now"}}}]
+You can create a feedDefaultQuery in blocks.json to override the default query.
+If no value in passed in Include-Terms the default query will be used.
 
-export default getSitemap({ changeFreq: false })
-```
+The `/content/v4/search/published` content-api is used

--- a/blocks/feeds-source-content-api-block/sources/feeds-content-api.test.js
+++ b/blocks/feeds-source-content-api-block/sources/feeds-content-api.test.js
@@ -38,7 +38,7 @@ it('returns query with default values', () => {
     Sort: '',
   })
   expect(query).toBe(
-    'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22term%22:%7B%22revision.published%22:true%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&_sourceExclude=related_content&sort=publish_date:desc',
+    'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22range%22:%7B%22last_updated_date%22:%7B%22gte%22:%22now-2d%22,%22lte%22:%22now%22%7D%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&_sourceExclude=related_content&sort=publish_date:desc',
   )
 })
 
@@ -58,7 +58,7 @@ it('returns query by section', () => {
     Sort: '',
   })
   expect(query).toBe(
-    'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22term%22:%7B%22revision.published%22:true%7D%7D,%7B%22nested%22:%7B%22path%22:%22taxonomy.sections%22,%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22taxonomy.sections._id%22:%22/sports%22%7D%7D%5D%7D%7D%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&_sourceExclude=related_content&sort=publish_date:desc',
+    'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22range%22:%7B%22last_updated_date%22:%7B%22gte%22:%22now-2d%22,%22lte%22:%22now%22%7D%7D%7D,%7B%22nested%22:%7B%22path%22:%22taxonomy.sections%22,%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22taxonomy.sections._id%22:%22/sports%22%7D%7D%5D%7D%7D%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&_sourceExclude=related_content&sort=publish_date:desc',
   )
 })
 
@@ -78,7 +78,7 @@ it('returns query by section with leading slash', () => {
     Sort: '',
   })
   expect(query).toBe(
-    'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22term%22:%7B%22revision.published%22:true%7D%7D,%7B%22nested%22:%7B%22path%22:%22taxonomy.sections%22,%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22taxonomy.sections._id%22:%22/sports%22%7D%7D%5D%7D%7D%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&_sourceExclude=related_content&sort=publish_date:desc',
+    'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22range%22:%7B%22last_updated_date%22:%7B%22gte%22:%22now-2d%22,%22lte%22:%22now%22%7D%7D%7D,%7B%22nested%22:%7B%22path%22:%22taxonomy.sections%22,%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22taxonomy.sections._id%22:%22/sports%22%7D%7D%5D%7D%7D%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&_sourceExclude=related_content&sort=publish_date:desc',
   )
 })
 
@@ -98,7 +98,7 @@ it('returns query by author', () => {
     Sort: '',
   })
   expect(query).toBe(
-    'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22term%22:%7B%22revision.published%22:true%7D%7D,%7B%22term%22:%7B%22credits.by._id%22:%22John%20Smith%22%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&_sourceExclude=related_content&sort=publish_date:desc',
+    'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22range%22:%7B%22last_updated_date%22:%7B%22gte%22:%22now-2d%22,%22lte%22:%22now%22%7D%7D%7D,%7B%22term%22:%7B%22credits.by._id%22:%22John%20Smith%22%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&_sourceExclude=related_content&sort=publish_date:desc',
   )
 })
 
@@ -118,7 +118,7 @@ it('returns query by keywords', () => {
     Sort: '',
   })
   expect(query).toBe(
-    'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22term%22:%7B%22revision.published%22:true%7D%7D,%7B%22simple_query_string%22:%7B%22query%22:%22%5C%22washington%20football%5C%22%20%7C%20%5C%22sports%5C%22%22,%22fields%22:%5B%22taxonomy.seo_keywords%22%5D%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&_sourceExclude=related_content&sort=publish_date:desc',
+    'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22range%22:%7B%22last_updated_date%22:%7B%22gte%22:%22now-2d%22,%22lte%22:%22now%22%7D%7D%7D,%7B%22simple_query_string%22:%7B%22query%22:%22%5C%22washington%20football%5C%22%20%7C%20%5C%22sports%5C%22%22,%22fields%22:%5B%22taxonomy.seo_keywords%22%5D%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&_sourceExclude=related_content&sort=publish_date:desc',
   )
 })
 
@@ -138,7 +138,7 @@ it('returns query by tags text', () => {
     Sort: '',
   })
   expect(query).toBe(
-    'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22term%22:%7B%22revision.published%22:true%7D%7D,%7B%22terms%22:%7B%22taxonomy.tags.text.raw%22:%5B%22football%22,%22sports%22%5D%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&_sourceExclude=related_content&sort=publish_date:desc',
+    'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22range%22:%7B%22last_updated_date%22:%7B%22gte%22:%22now-2d%22,%22lte%22:%22now%22%7D%7D%7D,%7B%22terms%22:%7B%22taxonomy.tags.text.raw%22:%5B%22football%22,%22sports%22%5D%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&_sourceExclude=related_content&sort=publish_date:desc',
   )
 })
 
@@ -158,6 +158,6 @@ it('returns query by tags slug', () => {
     Sort: '',
   })
   expect(query).toBe(
-    'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22term%22:%7B%22revision.published%22:true%7D%7D,%7B%22terms%22:%7B%22taxonomy.tags.slug%22:%5B%22football%22,%22sports%22%5D%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&_sourceExclude=related_content&sort=publish_date:desc',
+    'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22range%22:%7B%22last_updated_date%22:%7B%22gte%22:%22now-2d%22,%22lte%22:%22now%22%7D%7D%7D,%7B%22terms%22:%7B%22taxonomy.tags.slug%22:%5B%22football%22,%22sports%22%5D%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&_sourceExclude=related_content&sort=publish_date:desc',
   )
 })

--- a/blocks/mrss-feature-block/README.md
+++ b/blocks/mrss-feature-block/README.md
@@ -11,7 +11,7 @@ feedResizer
 
 channelTitle: defaults to global website name
 channelDescription: defaults to global website name + "News Feed"
-channelPath: defaults to /arcio/mrss/
+channelPath: defaults to /arc/outboundfeeds/mrss/
 channelCopyright: defaults to Copyright YYYY global website name
 channelTTL: number of mins, defaults to 1
 channelUpdatePeriod: update period hours, days, weeks, months, years. Defaults to hours

--- a/blocks/mrss-feature-block/features/mrss/__snapshots__/xml.test.js.snap
+++ b/blocks/mrss-feature-block/features/mrss/__snapshots__/xml.test.js.snap
@@ -8,7 +8,7 @@ Object {
     "@xmlns:media": "http://search.yahoo.com/mrss/",
     "channel": Object {
       "atom:link": Object {
-        "@href": "http://demo-prod.origin.arcpublishing.com/arcio/mrss/",
+        "@href": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/mrss/",
         "@rel": "self",
         "@type": "application/rss+xml",
       },

--- a/blocks/mrss-feature-block/features/mrss/xml.js
+++ b/blocks/mrss-feature-block/features/mrss/xml.js
@@ -178,8 +178,8 @@ Mrss.propTypes = {
       label: 'Path',
       group: 'Channel',
       description:
-        'Path to the feed, excluding the domain, defaults to /arcio/mrss',
-      defaultValue: '/arcio/mrss/',
+        'Path to the feed, excluding the domain, defaults to /arc/outboundfeeds/mrss',
+      defaultValue: '/arc/outboundfeeds/mrss/',
     }),
     selectVideo: PropTypes.kvp.tag({
       label: 'Select video using',

--- a/blocks/mrss-feature-block/features/mrss/xml.test.js
+++ b/blocks/mrss-feature-block/features/mrss/xml.test.js
@@ -166,7 +166,7 @@ it('returns RSS template with default values', () => {
     customFields: {
       channelTitle: '',
       channelDescription: '',
-      channelPath: '/arcio/mrss/',
+      channelPath: '/arc/outboundfeeds/mrss/',
       channelLogo: '',
       imageCaption: 'subheadlines.basic || caption',
       imageCredits: 'credits.by[].name',

--- a/blocks/rss-fbia-feature-block/README.md
+++ b/blocks/rss-fbia-feature-block/README.md
@@ -11,7 +11,7 @@ feedResizer
 
 channelTitle: defaults to global website name
 channelDescription: defaults to global website name + "News Feed"
-channelPath: defaults to /arcio/fb-ia/
+channelPath: defaults to /arc/outboundfeeds/fb-ia/
 channelCopyright: defaults to Copyright YYYY global website name
 channelTTL: number of mins, defaults to 1
 channelUpdatePeriod: update period hours, days, weeks, months, years. Defaults to hours

--- a/blocks/rss-fbia-feature-block/features/rss/__snapshots__/xml.test.js.snap
+++ b/blocks/rss-fbia-feature-block/features/rss/__snapshots__/xml.test.js.snap
@@ -11,7 +11,7 @@ Object {
     "@xmlns:sy": "http://purl.org/rss/1.0/modules/syndication/",
     "channel": Object {
       "atom:link": Object {
-        "@href": "http://demo-prod.origin.arcpublishing.com/arcio/rss/",
+        "@href": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/rss/",
         "@rel": "self",
         "@type": "application/rss+xml",
       },

--- a/blocks/rss-fbia-feature-block/features/rss/xml.js
+++ b/blocks/rss-fbia-feature-block/features/rss/xml.js
@@ -528,8 +528,8 @@ FbiaRss.propTypes = {
       label: 'Path',
       group: 'Channel',
       description:
-        'Path to the feed excluding the domain, defaults to /arcio/fb-ia',
-      defaultValue: '/arcio/fb-ia',
+        'Path to the feed excluding the domain, defaults to /arc/outboundfeeds/fb-ia',
+      defaultValue: '/arc/outboundfeeds/fb-ia',
     }),
     articleStyle: PropTypes.string.tag({
       label: 'Article Style',

--- a/blocks/rss-fbia-feature-block/features/rss/xml.test.js
+++ b/blocks/rss-fbia-feature-block/features/rss/xml.test.js
@@ -45,7 +45,7 @@ it('returns RSS template with default values', () => {
     customFields: {
       channelTitle: '',
       channelDescription: '',
-      channelPath: '/arcio/rss/',
+      channelPath: '/arc/outboundfeeds/rss/',
       channelCopyright: '',
       channelTTL: '1',
       channelUpdatePeriod: 'hourly',

--- a/blocks/rss-feature-block/README.md
+++ b/blocks/rss-feature-block/README.md
@@ -11,7 +11,7 @@ feedResizer
 
 channelTitle: defaults to global website name
 channelDescription: defaults to global website name + "News Feed"
-channelPath: defaults to /arcio/rss/
+channelPath: defaults to /arc/outboundfeeds/rss/
 channelCopyright: defaults to Copyright YYYY global website name
 channelTTL: number of mins, defaults to 1
 channelUpdatePeriod: update period hours, days, weeks, months, years. Defaults to hours

--- a/blocks/rss-feature-block/features/rss/__snapshots__/xml.test.js.snap
+++ b/blocks/rss-feature-block/features/rss/__snapshots__/xml.test.js.snap
@@ -11,7 +11,7 @@ Object {
     "@xmlns:sy": "http://purl.org/rss/1.0/modules/syndication/",
     "channel": Object {
       "atom:link": Object {
-        "@href": "http://demo-prod.origin.arcpublishing.com/arcio/rss/",
+        "@href": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/rss/",
         "@rel": "self",
         "@type": "application/rss+xml",
       },
@@ -89,7 +89,7 @@ Object {
     "@xmlns:sy": "http://purl.org/rss/1.0/modules/syndication/",
     "channel": Object {
       "atom:link": Object {
-        "@href": "http://demo-prod.origin.arcpublishing.com/arcio/rss/",
+        "@href": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/rss/",
         "@rel": "self",
         "@type": "application/rss+xml",
       },

--- a/blocks/rss-feature-block/features/rss/xml.js
+++ b/blocks/rss-feature-block/features/rss/xml.js
@@ -175,8 +175,8 @@ Rss.propTypes = {
       label: 'Path',
       group: 'Channel',
       description:
-        'Path to the feed, excluding the domain, defaults to /arcio/rss',
-      defaultValue: '/arcio/rss/',
+        'Path to the feed, excluding the domain, defaults to /arc/outboundfeeds/rss',
+      defaultValue: '/arc/outboundfeeds/rss/',
     }),
     ...generatePropsForFeed('rss', PropTypes),
   }),

--- a/blocks/rss-feature-block/features/rss/xml.test.js
+++ b/blocks/rss-feature-block/features/rss/xml.test.js
@@ -45,7 +45,7 @@ it('returns RSS template with default values', () => {
     customFields: {
       channelTitle: '',
       channelDescription: '',
-      channelPath: '/arcio/rss/',
+      channelPath: '/arc/outboundfeeds/rss/',
       channelCopyright: '',
       channelTTL: '1',
       channelUpdatePeriod: 'hourly',
@@ -85,7 +85,7 @@ it('returns RSS template with custom values', () => {
     customFields: {
       channelTitle: 'The Daily Prophet',
       channelDescription: "All the news that's fit to print",
-      channelPath: '/arcio/rss/',
+      channelPath: '/arc/outboundfeeds/rss/',
       channelCopyright: '2020 The Washington Post LLC',
       channelTTL: '60',
       channelUpdatePeriod: 'weekly',

--- a/blocks/rss-flipboard-feature-block/README.md
+++ b/blocks/rss-flipboard-feature-block/README.md
@@ -9,7 +9,7 @@ feedResizer
 
 ## Custom Fields
 
-channelPath: defaults to /arcio/google-news-feed/
+channelPath: defaults to /arc/outboundfeeds/flipboard/
 channelTitle: defaults to global website name
 channelDescription: defaults to global website name + "News Feed"
 channelCopyright: defaults to Copyright YYYY global website name

--- a/blocks/rss-flipboard-feature-block/features/rss-flipboard/__snapshots__/xml.test.js.snap
+++ b/blocks/rss-flipboard-feature-block/features/rss-flipboard/__snapshots__/xml.test.js.snap
@@ -11,7 +11,7 @@ Object {
     "@xmlns:sy": "http://purl.org/rss/1.0/modules/syndication/",
     "channel": Object {
       "atom:link": Object {
-        "@href": "http://demo-prod.origin.arcpublishing.com/arcio/rss/",
+        "@href": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/rss/",
         "@rel": "self",
         "@type": "application/rss+xml",
       },
@@ -79,7 +79,7 @@ Object {
     "@xmlns:sy": "http://purl.org/rss/1.0/modules/syndication/",
     "channel": Object {
       "atom:link": Object {
-        "@href": "http://demo-prod.origin.arcpublishing.com/arcio/rss/",
+        "@href": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/rss/",
         "@rel": "self",
         "@type": "application/rss+xml",
       },

--- a/blocks/rss-flipboard-feature-block/features/rss-flipboard/xml.js
+++ b/blocks/rss-flipboard-feature-block/features/rss-flipboard/xml.js
@@ -200,8 +200,8 @@ FlipboardRss.propTypes = {
       label: 'Path',
       group: 'Channel',
       description:
-        'Path to the feed excluding the domain, defaults to /arcio/flipboard',
-      defaultValue: '/arcio/flipboard/',
+        'Path to the feed excluding the domain, defaults to /arc/outboundfeeds/flipboard',
+      defaultValue: '/arc/outboundfeeds/flipboard/',
     }),
     ...generatePropsForFeed('rss', PropTypes, ['channelPath', 'includePromo']),
   }),

--- a/blocks/rss-flipboard-feature-block/features/rss-flipboard/xml.test.js
+++ b/blocks/rss-flipboard-feature-block/features/rss-flipboard/xml.test.js
@@ -53,7 +53,7 @@ it('returns Google News template with default values', () => {
     customFields: {
       channelTitle: '',
       channelDescription: '',
-      channelPath: '/arcio/rss/',
+      channelPath: '/arc/outboundfeeds/rss/',
       channelCopyright: '',
       channelTTL: '1',
       channelUpdatePeriod: 'hourly',
@@ -92,7 +92,7 @@ it('returns RSS template with custom values', () => {
     customFields: {
       channelTitle: 'The Daily Prophet',
       channelDescription: "All the news that's fit to print",
-      channelPath: '/arcio/rss/',
+      channelPath: '/arc/outboundfeeds/rss/',
       channelCopyright: '2020 The Washington Post LLC',
       channelTTL: '60',
       channelUpdatePeriod: 'weekly',

--- a/blocks/rss-google-news-feature-block/README.md
+++ b/blocks/rss-google-news-feature-block/README.md
@@ -1,4 +1,4 @@
-# RSS
+# google-news-feed
 
 ## Globals
 
@@ -9,7 +9,7 @@ feedResizer
 
 ## Custom Fields
 
-channelPath: defaults to /arcio/google-news-feed/
+channelPath: defaults to /arc/outboundfeeds/google-news-feed/
 channelTitle: defaults to global website name
 channelDescription: defaults to global website name + "News Feed"
 channelCopyright: defaults to Copyright YYYY global website name

--- a/blocks/rss-google-news-feature-block/features/google-news-rss/__snapshots__/xml.test.js.snap
+++ b/blocks/rss-google-news-feature-block/features/google-news-rss/__snapshots__/xml.test.js.snap
@@ -11,7 +11,7 @@ Object {
     "@xmlns:sy": "http://purl.org/rss/1.0/modules/syndication/",
     "channel": Object {
       "atom:link": Object {
-        "@href": "http://demo-prod.origin.arcpublishing.com/arcio/rss/",
+        "@href": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/rss/",
         "@rel": "self",
         "@type": "application/rss+xml",
       },
@@ -78,7 +78,7 @@ Object {
     "@xmlns:sy": "http://purl.org/rss/1.0/modules/syndication/",
     "channel": Object {
       "atom:link": Object {
-        "@href": "http://demo-prod.origin.arcpublishing.com/arcio/rss/",
+        "@href": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/rss/",
         "@rel": "self",
         "@type": "application/rss+xml",
       },

--- a/blocks/rss-google-news-feature-block/features/google-news-rss/xml.js
+++ b/blocks/rss-google-news-feature-block/features/google-news-rss/xml.js
@@ -191,8 +191,8 @@ GoogleNewsRss.propTypes = {
       label: 'Path',
       group: 'Channel',
       description:
-        'Path to the feed excluding the domain, defaults to /arcio/google-news-feed',
-      defaultValue: '/arcio/google-news-feed/',
+        'Path to the feed excluding the domain, defaults to /arc/outboundfeeds/google-news-feed',
+      defaultValue: '/arc/outboundfeeds/google-news-feed/',
     }),
     ...generatePropsForFeed('rss', PropTypes, ['channelPath', 'includePromo']),
   }),

--- a/blocks/rss-google-news-feature-block/features/google-news-rss/xml.test.js
+++ b/blocks/rss-google-news-feature-block/features/google-news-rss/xml.test.js
@@ -53,7 +53,7 @@ it('returns Google News template with default values', () => {
     customFields: {
       channelTitle: '',
       channelDescription: '',
-      channelPath: '/arcio/rss/',
+      channelPath: '/arc/outboundfeeds/rss/',
       channelCopyright: '',
       channelTTL: '1',
       channelUpdatePeriod: 'hourly',
@@ -92,7 +92,7 @@ it('returns RSS template with custom values', () => {
     customFields: {
       channelTitle: 'The Daily Prophet',
       channelDescription: "All the news that's fit to print",
-      channelPath: '/arcio/rss/',
+      channelPath: '/arc/outboundfeeds/rss/',
       channelCopyright: '2020 The Washington Post LLC',
       channelTTL: '60',
       channelUpdatePeriod: 'weekly',

--- a/blocks/rss-msn-feature-block/README.md
+++ b/blocks/rss-msn-feature-block/README.md
@@ -1,4 +1,4 @@
-# RSS
+# MSN
 
 ## Globals
 
@@ -9,7 +9,7 @@ feedResizer
 
 ## Custom Fields
 
-channelPath: defaults to /arcio/google-news-feed/
+channelPath: defaults to /arc/outboundfeeds/msn/
 channelTitle: defaults to global website name
 channelDescription: defaults to global website name + "News Feed"
 channelCopyright: defaults to Copyright YYYY global website name

--- a/blocks/rss-msn-feature-block/features/msn-rss/__snapshots__/xml.test.js.snap
+++ b/blocks/rss-msn-feature-block/features/msn-rss/__snapshots__/xml.test.js.snap
@@ -12,7 +12,7 @@ Object {
     "@xmlns:sy": "http://purl.org/rss/1.0/modules/syndication/",
     "channel": Object {
       "atom:link": Object {
-        "@href": "http://demo-prod.origin.arcpublishing.com/arcio/msn/",
+        "@href": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/msn/",
         "@rel": "self",
         "@type": "application/rss+xml",
       },
@@ -82,7 +82,7 @@ Object {
     "@xmlns:sy": "http://purl.org/rss/1.0/modules/syndication/",
     "channel": Object {
       "atom:link": Object {
-        "@href": "http://demo-prod.origin.arcpublishing.com/arcio/rss/",
+        "@href": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/rss/",
         "@rel": "self",
         "@type": "application/rss+xml",
       },

--- a/blocks/rss-msn-feature-block/features/msn-rss/xml.js
+++ b/blocks/rss-msn-feature-block/features/msn-rss/xml.js
@@ -195,8 +195,8 @@ MsnRss.propTypes = {
       label: 'Path',
       group: 'Channel',
       description:
-        'Path to the feed excluding the domain, defaults to /arcio/msn',
-      defaultValue: '/arcio/msn/',
+        'Path to the feed excluding the domain, defaults to /arc/outboundfeeds/msn/',
+      defaultValue: '/arc/outboundfeeds/msn/',
     }),
     ...generatePropsForFeed('rss', PropTypes, ['channelPath', 'includePromo']),
   }),

--- a/blocks/rss-msn-feature-block/features/msn-rss/xml.test.js
+++ b/blocks/rss-msn-feature-block/features/msn-rss/xml.test.js
@@ -53,7 +53,7 @@ it('returns MSN template with default values', () => {
     customFields: {
       channelTitle: '',
       channelDescription: '',
-      channelPath: '/arcio/msn/',
+      channelPath: '/arc/outboundfeeds/msn/',
       channelCopyright: '',
       channelTTL: '1',
       channelUpdatePeriod: 'hourly',
@@ -92,7 +92,7 @@ it('returns RSS template with custom values', () => {
     customFields: {
       channelTitle: 'The Daily Prophet',
       channelDescription: "All the news that's fit to print",
-      channelPath: '/arcio/rss/',
+      channelPath: '/arc/outboundfeeds/rss/',
       channelCopyright: '2020 The Washington Post LLC',
       channelTTL: '60',
       channelUpdatePeriod: 'weekly',

--- a/blocks/sitemap-feature-block/README.md
+++ b/blocks/sitemap-feature-block/README.md
@@ -1,11 +1,13 @@
-# Sitemaps
+# Sitemap
 
-## Standard
+Sitemaps provide search engines with metadata regarding the specific news content on a website. Using the Sitemap, bots can quickly find the news articles contained on a site
+These Sitemaps identify the url and publication date of every article.
 
-### Usage
+## Custom Fields
 
-```
-import getSitemap from '@wpmedia/output-type-sitemap'
-
-export default getSitemap({ changeFreq: false })
-```
+- imageTitle - The title for the image.
+- imageCaption - The caption for the image
+- includePromo - Include featured image in Sitemap
+- lastMod - The date field to use to display the lastmod.
+- priority - What is the priority of the sitemap
+- changeFreq - What is the change frequency of the Sitemap

--- a/blocks/sitemap-feature-block/features/sitemap/xml.js
+++ b/blocks/sitemap-feature-block/features/sitemap/xml.js
@@ -67,15 +67,13 @@ Sitemap.propTypes = {
     imageTitle: PropTypes.string.tag({
       label: 'ANS image title key',
       group: 'Field Mapping',
-      description:
-        'ANS value for associated story used for the <image:title> sitemap tag',
+      description: 'ANS value for the <image:title> sitemap tag',
       defaultValue: 'title',
     }),
     imageCaption: PropTypes.string.tag({
-      label: 'ANS image title key',
+      label: 'ANS image caption key',
       group: 'Field Mapping',
-      description:
-        'ANS value for associated story image used for the <image:caption> sitemap tag',
+      description: 'ANS value for the <image:caption> sitemap tag',
       defaultValue: 'caption',
     }),
     ...generatePropsForFeed('sitemap', PropTypes),

--- a/blocks/sitemap-index-feature-block/README.md
+++ b/blocks/sitemap-index-feature-block/README.md
@@ -10,6 +10,6 @@ This will require that the resolver for the feed it is linking to supports the f
 
 - lastMod - The date field to use to display the lastmod. It will get only the date from the first article returned and repeat that date for every link. Defaults to `last_updated_date`
 
-- feedPath - The path to the format to use. Defaults to `/arcio/sitemap/`
+- feedPath - The path to the format to use. Defaults to `/arc/outboundfeeds/sitemap/`
 
 - feedName - The name of the feed used in the resolver. Defaults to `/sitemap-index/` This is used to split the requestURI to get anything in the path after the feed like a section. If a request is made using `/arc/outboundfeeds/sitemap-index/category/sports`. This will be split on `/sitemap-index/` which results in an array of `['/arc/outboundfeeds', 'category/sports']` the second array element, if any, will be appended to the generated sitemap url.

--- a/blocks/sitemap-index-feature-block/features/sitemap-index/xml.js
+++ b/blocks/sitemap-index-feature-block/features/sitemap-index/xml.js
@@ -95,7 +95,8 @@ SitemapIndex.propTypes = {
     feedPath: PropTypes.string.tag({
       label: 'Sitemap Path',
       group: 'Format',
-      description: 'Path to the sitemap feed',
+      description:
+        'Path to the sitemap feed, defaults to /arc/outboundfeeds/sitemap/',
       defaultValue: '/arc/outboundfeeds/sitemap/',
     }),
     feedName: PropTypes.string.tag({

--- a/blocks/sitemap-video-feature-block/README.md
+++ b/blocks/sitemap-video-feature-block/README.md
@@ -1,10 +1,15 @@
-# Sitemap video
+# video-sitemap
 
-The sitemap-video format returns sitemap for Videos
+The video-sitemap format returns sitemap for Videos
 
 ## Custom Fields
 
 - lastMod - The date field to use to display the lastmod. It will get only the date from the first article returned and repeat that date for every link. Defaults to `last_updated_date`
 
-- videoKeyword - The field to use to get keywords from taxonomy: the options are seo_keywords or tags
 - videoTitle - The field to use to describe video: theoptions are `description and subheadlines basic`
+- videoKeywords - The field to use to get keywords from taxonomy: the options are seo_keywords or tags
+- videoSelect - object used to search streams for video encoding default: { bitrate: 5400, stream_type: 'mp4' }
+- includePromo - Include an image in Sitemap
+- lastMod - The date field to use to display the lastmod.
+- priority - What is the priority of the sitemap
+- changeFreq - What is the change frequency of the Sitemap


### PR DESCRIPTION
- Changed default query [{\"term\":{\"type\":\"story\"}},{\"range\":{\"last_updated_date\":{\"gte\":\"now-2d\",\"lte\":\"now\"}}}]
- Added support for feedDefaultQuery to globally override default query
- Changed all channelPath to /arc/outboundfeeds/
- Updated README.md with latest engine changes
- Updated blocks readmes where needed