### PR TITLE
Update collection CS

### DIFF
--- a/.changeset/silly-tomatoes-check.md
+++ b/.changeset/silly-tomatoes-check.md
@@ -1,0 +1,5 @@
+---
+'@wpmedia/feeds-source-collections-block': minor
+---
+
+Inflate collection content with call to ids

--- a/blocks/feeds-source-collections-block/sources/collections.js
+++ b/blocks/feeds-source-collections-block/sources/collections.js
@@ -6,8 +6,7 @@ const params = {
   content_alias: 'text',
   from: 'text',
   size: 'text',
-  includedFields: 'text',
-  ttl: 'number',
+  included_fields: 'text',
 }
 
 const options = {
@@ -20,10 +19,10 @@ const fetch = (key = {}) => {
   const {
     'arc-site': site,
     _id,
-    contentAlias,
+    content_alias: contentAlias,
     from,
     size,
-    includedFields,
+    included_fields: includedFields,
   } = key
 
   const qs = {
@@ -31,8 +30,9 @@ const fetch = (key = {}) => {
     from: from || 0,
     size: size || 20,
     published: true,
+    ...(_id && { _id: _id }),
+    ...(contentAlias && { content_alias: contentAlias }),
   }
-  _id ? (qs._id = _id) : (qs.content_alias = contentAlias)
 
   return request({
     uri: `${CONTENT_BASE}/content/v4/collections`,
@@ -60,6 +60,7 @@ const fetch = (key = {}) => {
           'last_updated_date',
           'promo_items',
           'publish_date',
+          'source',
           'subheadlines',
           'taxonomy',
           'website_url',

--- a/blocks/feeds-source-collections-block/sources/collections.js
+++ b/blocks/feeds-source-collections-block/sources/collections.js
@@ -1,20 +1,87 @@
+import request from 'request-promise-native'
+import { CONTENT_BASE, ARC_ACCESS_TOKEN } from 'fusion:environment'
+
 const params = {
   _id: 'text',
   content_alias: 'text',
   from: 'text',
   size: 'text',
+  includedFields: 'text',
+  ttl: 'number',
 }
 
-const resolve = (key = {}) => {
-  const { 'arc-site': site, _id, content_alias: contentAlias, from, size } = key
-  return `content/v4/collections?${
-    _id ? `_id=${_id}` : `content_alias=${contentAlias}`
-  }${site ? `&website=${site}` : ''}${from ? `&from=${from}` : ''}${
-    size ? `&size=${size}` : ''
-  }&published=true`
+const options = {
+  gzip: true,
+  json: true,
+  auth: { bearer: ARC_ACCESS_TOKEN },
+}
+
+const fetch = (key = {}) => {
+  const {
+    'arc-site': site,
+    _id,
+    contentAlias,
+    from,
+    size,
+    includedFields,
+  } = key
+
+  const qs = {
+    website: site,
+    from: from || 0,
+    size: size || 20,
+    published: true,
+  }
+  _id ? (qs._id = _id) : (qs.content_alias = contentAlias)
+
+  return request({
+    uri: `${CONTENT_BASE}/content/v4/collections`,
+    qs: qs,
+    ...options,
+  })
+    .then((collectionResp) => {
+      const ids = collectionResp.content_elements
+        .map((item) => {
+          return item._id
+        })
+        .join(',')
+
+      // ids results does not include content_elements unless specified in included_fields
+      const idsIncludedFields =
+        includedFields ||
+        [
+          'content_elements',
+          'created_date',
+          'credits',
+          'description',
+          'display_date',
+          'first_publish_date',
+          'headlines',
+          'last_updated_date',
+          'promo_items',
+          'publish_date',
+          'subheadlines',
+          'taxonomy',
+          'website_url',
+        ].join(',')
+
+      return request({
+        uri: `${CONTENT_BASE}/content/v4/ids`,
+        qs: {
+          ids: ids,
+          website: site,
+          included_fields: idsIncludedFields,
+        },
+        ...options,
+      })
+    })
+    .catch((err) => {
+      throw err
+    })
 }
 
 export default {
+  fetch,
   params,
-  resolve,
+  ttl: 300,
 }

--- a/blocks/feeds-source-collections-block/sources/collections.test.js
+++ b/blocks/feeds-source-collections-block/sources/collections.test.js
@@ -1,36 +1,14 @@
 // eslint-disable-next-line no-unused-vars
 import Consumer from 'fusion:consumer'
-const resolver = require('./collections')
+const fetch = require('./collections')
 
 it('validate params', () => {
-  expect(resolver.default.params).toStrictEqual({
+  expect(fetch.default.params).toStrictEqual({
     _id: 'text',
     content_alias: 'text',
     from: 'text',
     size: 'text',
+    includedFields: 'text',
+    ttl: 'number',
   })
-})
-
-it('returns query search by _id', () => {
-  const query = resolver.default.resolve({
-    _id: 'NBXKZJC3ONEGRB2VPINBMQTNFA',
-    content_alias: '',
-    from: '',
-    size: '',
-  })
-  expect(query).toBe(
-    'content/v4/collections?_id=NBXKZJC3ONEGRB2VPINBMQTNFA&published=true',
-  )
-})
-
-it('returns query by alias', () => {
-  const query = resolver.default.resolve({
-    _id: '',
-    content_alias: 'sports page',
-    from: '5',
-    size: '10',
-  })
-  expect(query).toBe(
-    'content/v4/collections?content_alias=sports page&from=5&size=10&published=true',
-  )
 })

--- a/blocks/feeds-source-collections-block/sources/collections.test.js
+++ b/blocks/feeds-source-collections-block/sources/collections.test.js
@@ -8,7 +8,6 @@ it('validate params', () => {
     content_alias: 'text',
     from: 'text',
     size: 'text',
-    includedFields: 'text',
-    ttl: 'number',
+    included_fields: 'text',
   })
 })


### PR DESCRIPTION
- Inflate collection content so it can be used in RSS
- Hardcode ttl : 300
- Add IncludedFields for the ids call.  By default it will not return
content_elements, it will include the following if left blank
   'content_elements',
   'created_date',
   'credits',
   'description',
   'display_date',
   'first_publish_date',
   'headlines',
   'last_updated_date',
   'promo_items',
   'publish_date',
   'subheadlines',
   'taxonomy',
   'website_url',