### PR TITLE
Update publish action to create snapshot release

### DIFF
--- a/.changeset/rude-donuts-shave.md
+++ b/.changeset/rude-donuts-shave.md
@@ -1,0 +1,5 @@
+---
+'@wpmedia/feeds-source-video-api-block': patch
+---
+
+Update beta release script

--- a/.github/workflows/publish-sandbox.yml
+++ b/.github/workflows/publish-sandbox.yml
@@ -27,11 +27,23 @@ jobs:
           CI: true
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Create Release Pull Request or Publish to npm
-        uses: changesets/action@master
-        with:
-          #  this runs release:<branch name> which calls changeset publish --tag [beta|stable]
-          publish: npm run release:sandbox
+      # Create new branch in order to persist changesets through to prod branch
+      - name: Create snapshot sandbox branch
+        run: git checkout -b sandbox-tag
+
+      - name: Initialize mandatory git config
+        run: |
+          git config user.name "GitHub Actions"
+          git config user.email noreply@github.com
+
+      - name: Create snaphost release for sandbox
+        run: npm run release:snapshot
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish @beta release to npm
+        # Calls changeset publish --tag [beta|stable]
+        run: npm run release:sandbox
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "test": "jest --config=jest.config.js",
     "ci": "npm run build && npm run lint && npm run test",
     "build": "preconstruct build",
+    "release:snapshot": "changeset version --snapshot beta",
     "release:sandbox": "preconstruct build && changeset publish --tag beta",
     "release:prod": "preconstruct build && changeset publish --tag stable"
   }


### PR DESCRIPTION
With this new change the Github action will create a snapshot release for `@beta` and the changesets (.md files) will persist in the `sandbox` branch.

This way, to do a release we will merge `sandbox -> prod` and the changeset action will consume the changesets for the official `@stable` release.