### PR TITLE
Added distributor params  AIO-550

### DIFF
--- a/.changeset/gorgeous-falcons-live.md
+++ b/.changeset/gorgeous-falcons-live.md
@@ -1,0 +1,5 @@
+---
+'@wpmedia/feeds-source-content-api-block': minor
+---
+
+Added distributor params

--- a/blocks/feeds-source-content-api-block/sources/feeds-content-api.js
+++ b/blocks/feeds-source-content-api-block/sources/feeds-content-api.js
@@ -3,13 +3,27 @@ import getProperties from 'fusion:properties'
 
 const resolve = function resolve(key) {
   const requestUri = `${CONTENT_BASE}/content/v4/search/published`
-  const uriParams = [
+  const paramList = [
     `website=${key['arc-site']}`,
     `size=${key['Feed-Size'] || '100'}`,
     `from=${key['Feed-Offset'] || '0'}`,
     `_sourceExclude=${key['Source-Exclude'] || 'related_content'}`,
     `sort=${key.Sort || 'publish_date:desc'}`,
-  ].join('&')
+  ]
+
+  if (key['Source-Include'])
+    paramList.push(`_sourceInclude=${key['Source-Include']}`)
+  if (key['Inc-Distrib-Name']) {
+    paramList.push(`include_distributor_name=${key['Inc-Distrib-Name']}`)
+  } else if (key['Exc-Distrib-Name']) {
+    paramList.push(`exclude_distributor_name=${key['Exc-Distrib-Name']}`)
+  } else if (key['Inc-Distrib-Cat']) {
+    paramList.push(`include_distributor_category=${key['Inc-Distrib-Cat']}`)
+  } else if (key['Exc-Distrib-Cat']) {
+    paramList.push(`exclude_distributor_category=${key['Exc-Distrib-Cat']}`)
+  }
+
+  const uriParams = paramList.join('&')
 
   const { feedDefaultQuery } = getProperties(key['arc-site'])
 
@@ -155,7 +169,13 @@ export default {
     'Exclude-Terms': 'text',
     'Feed-Size': 'text',
     'Feed-Offset': 'text',
-    'Source-Exclude': 'text',
     Sort: 'text',
+    'Source-Exclude': 'text',
+    'Source-Include': 'text',
+    'Inc-Distrib-Name': 'text',
+    'Exc-Distrib-Name': 'text',
+    'Inc-Distrib-Cat': 'text',
+    'Exc-Distrib-Cat': 'text',
   },
+  ttl: 300,
 }

--- a/blocks/feeds-source-content-api-block/sources/feeds-content-api.test.js
+++ b/blocks/feeds-source-content-api-block/sources/feeds-content-api.test.js
@@ -17,8 +17,13 @@ it('validate params', () => {
     'Exclude-Terms': 'text',
     'Feed-Size': 'text',
     'Feed-Offset': 'text',
-    'Source-Exclude': 'text',
     Sort: 'text',
+    'Source-Exclude': 'text',
+    'Source-Include': 'text',
+    'Inc-Distrib-Name': 'text',
+    'Exc-Distrib-Name': 'text',
+    'Inc-Distrib-Cat': 'text',
+    'Exc-Distrib-Cat': 'text',
   })
 })
 
@@ -34,11 +39,37 @@ it('returns query with default values', () => {
     'Exclude-Terms': '',
     'Feed-Size': '',
     'Feed-Offset': '',
-    'Source-Exclude': '',
     Sort: '',
+    'Source-Exclude': '',
+    'Source-Include': '',
   })
   expect(query).toBe(
     'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22range%22:%7B%22last_updated_date%22:%7B%22gte%22:%22now-2d%22,%22lte%22:%22now%22%7D%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&_sourceExclude=related_content&sort=publish_date:desc',
+  )
+})
+
+it('returns query with parameter values', () => {
+  const query = resolver.default.resolve({
+    Section: '',
+    Author: '',
+    Keywords: '',
+    'Tags-Text': '',
+    'Tags-Slug': '',
+    'arc-site': 'demo',
+    'Include-Terms': '',
+    'Exclude-Terms': '',
+    'Feed-Size': '25',
+    'Feed-Offset': '3',
+    Sort: 'display_date:asc',
+    'Source-Exclude': 'headlines,description,website_url',
+    'Source-Include': 'related_items,content_elements,taxonomy',
+    'Inc-Distrib-Name': 'AP',
+    'Exc-Distrib-Name': 'paid',
+    'Inc-Distrib-Cat': 'promotions',
+    'Exc-Distrib-Cat': 'wires',
+  })
+  expect(query).toBe(
+    'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22range%22:%7B%22last_updated_date%22:%7B%22gte%22:%22now-2d%22,%22lte%22:%22now%22%7D%7D%7D%5D%7D%7D%7D&website=demo&size=25&from=3&_sourceExclude=headlines,description,website_url&sort=display_date:asc&_sourceInclude=related_items,content_elements,taxonomy&include_distributor_name=AP',
   )
 })
 
@@ -54,8 +85,9 @@ it('returns query by section', () => {
     'Exclude-Terms': '',
     'Feed-Size': '',
     'Feed-Offset': '',
-    'Source-Exclude': '',
     Sort: '',
+    'Source-Exclude': '',
+    'Source-Include': '',
   })
   expect(query).toBe(
     'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22range%22:%7B%22last_updated_date%22:%7B%22gte%22:%22now-2d%22,%22lte%22:%22now%22%7D%7D%7D,%7B%22nested%22:%7B%22path%22:%22taxonomy.sections%22,%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22taxonomy.sections._id%22:%22/sports%22%7D%7D%5D%7D%7D%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&_sourceExclude=related_content&sort=publish_date:desc',
@@ -74,8 +106,9 @@ it('returns query by section with leading slash', () => {
     'Exclude-Terms': '',
     'Feed-Size': '',
     'Feed-Offset': '',
-    'Source-Exclude': '',
     Sort: '',
+    'Source-Exclude': '',
+    'Source-Include': '',
   })
   expect(query).toBe(
     'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22range%22:%7B%22last_updated_date%22:%7B%22gte%22:%22now-2d%22,%22lte%22:%22now%22%7D%7D%7D,%7B%22nested%22:%7B%22path%22:%22taxonomy.sections%22,%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22taxonomy.sections._id%22:%22/sports%22%7D%7D%5D%7D%7D%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&_sourceExclude=related_content&sort=publish_date:desc',
@@ -94,8 +127,9 @@ it('returns query by author', () => {
     'Exclude-Terms': '',
     'Feed-Size': '',
     'Feed-Offset': '',
-    'Source-Exclude': '',
     Sort: '',
+    'Source-Exclude': '',
+    'Source-Include': '',
   })
   expect(query).toBe(
     'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22range%22:%7B%22last_updated_date%22:%7B%22gte%22:%22now-2d%22,%22lte%22:%22now%22%7D%7D%7D,%7B%22term%22:%7B%22credits.by._id%22:%22John%20Smith%22%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&_sourceExclude=related_content&sort=publish_date:desc',
@@ -114,8 +148,9 @@ it('returns query by keywords', () => {
     'Exclude-Terms': '',
     'Feed-Size': '',
     'Feed-Offset': '',
-    'Source-Exclude': '',
     Sort: '',
+    'Source-Exclude': '',
+    'Source-Include': '',
   })
   expect(query).toBe(
     'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22range%22:%7B%22last_updated_date%22:%7B%22gte%22:%22now-2d%22,%22lte%22:%22now%22%7D%7D%7D,%7B%22simple_query_string%22:%7B%22query%22:%22%5C%22washington%20football%5C%22%20%7C%20%5C%22sports%5C%22%22,%22fields%22:%5B%22taxonomy.seo_keywords%22%5D%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&_sourceExclude=related_content&sort=publish_date:desc',
@@ -134,8 +169,9 @@ it('returns query by tags text', () => {
     'Exclude-Terms': '',
     'Feed-Size': '',
     'Feed-Offset': '',
-    'Source-Exclude': '',
     Sort: '',
+    'Source-Exclude': '',
+    'Source-Include': '',
   })
   expect(query).toBe(
     'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22range%22:%7B%22last_updated_date%22:%7B%22gte%22:%22now-2d%22,%22lte%22:%22now%22%7D%7D%7D,%7B%22terms%22:%7B%22taxonomy.tags.text.raw%22:%5B%22football%22,%22sports%22%5D%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&_sourceExclude=related_content&sort=publish_date:desc',
@@ -154,8 +190,9 @@ it('returns query by tags slug', () => {
     'Exclude-Terms': '',
     'Feed-Size': '',
     'Feed-Offset': '',
-    'Source-Exclude': '',
     Sort: '',
+    'Source-Exclude': '',
+    'Source-Include': '',
   })
   expect(query).toBe(
     'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22range%22:%7B%22last_updated_date%22:%7B%22gte%22:%22now-2d%22,%22lte%22:%22now%22%7D%7D%7D,%7B%22terms%22:%7B%22taxonomy.tags.slug%22:%5B%22football%22,%22sports%22%5D%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&_sourceExclude=related_content&sort=publish_date:desc',


### PR DESCRIPTION
Support additional search parameters in feeds-source-content-api
- sourceInclude
- include_distributor_name
- exclude_distributor_name
- include_distributor_catagory
- exclude_distributor_catagory
- had to truncate the names to fix in PB Editor screen
- only one of the distributor params may be used at a time
- ttl: 300