### PR TITLE
Fix param names  AIO-550

### DIFF
--- a/.changeset/fifty-bags-add.md
+++ b/.changeset/fifty-bags-add.md
@@ -1,0 +1,5 @@
+---
+'@wpmedia/feeds-source-content-api-block': minor
+---
+
+update parameter names

--- a/blocks/feeds-source-content-api-block/sources/feeds-content-api.js
+++ b/blocks/feeds-source-content-api-block/sources/feeds-content-api.js
@@ -13,14 +13,22 @@ const resolve = function resolve(key) {
 
   if (key['Source-Include'])
     paramList.push(`_sourceInclude=${key['Source-Include']}`)
-  if (key['Inc-Distrib-Name']) {
-    paramList.push(`include_distributor_name=${key['Inc-Distrib-Name']}`)
-  } else if (key['Exc-Distrib-Name']) {
-    paramList.push(`exclude_distributor_name=${key['Exc-Distrib-Name']}`)
-  } else if (key['Inc-Distrib-Cat']) {
-    paramList.push(`include_distributor_category=${key['Inc-Distrib-Cat']}`)
-  } else if (key['Exc-Distrib-Cat']) {
-    paramList.push(`exclude_distributor_category=${key['Exc-Distrib-Cat']}`)
+  if (key['Include-Distributor-Name']) {
+    paramList.push(
+      `include_distributor_name=${key['Include-Distributor-Name']}`,
+    )
+  } else if (key['Exclude-Distributor-Name']) {
+    paramList.push(
+      `exclude_distributor_name=${key['Exclude-Distributor-Name']}`,
+    )
+  } else if (key['Include-Distributor-Category']) {
+    paramList.push(
+      `include_distributor_category=${key['Include-Distributor-Category']}`,
+    )
+  } else if (key['Exclude-Distributor-Category']) {
+    paramList.push(
+      `exclude_distributor_category=${key['Exclude-Distributor-Category']}`,
+    )
   }
 
   const uriParams = paramList.join('&')
@@ -172,10 +180,10 @@ export default {
     Sort: 'text',
     'Source-Exclude': 'text',
     'Source-Include': 'text',
-    'Inc-Distrib-Name': 'text',
-    'Exc-Distrib-Name': 'text',
-    'Inc-Distrib-Cat': 'text',
-    'Exc-Distrib-Cat': 'text',
+    'Include-Distributor-Name': 'text',
+    'Exclude-Distributor-Name': 'text',
+    'Include-Distributor-Category': 'text',
+    'Exclude-Distributor-Category': 'text',
   },
   ttl: 300,
 }

--- a/blocks/feeds-source-content-api-block/sources/feeds-content-api.test.js
+++ b/blocks/feeds-source-content-api-block/sources/feeds-content-api.test.js
@@ -20,10 +20,10 @@ it('validate params', () => {
     Sort: 'text',
     'Source-Exclude': 'text',
     'Source-Include': 'text',
-    'Inc-Distrib-Name': 'text',
-    'Exc-Distrib-Name': 'text',
-    'Inc-Distrib-Cat': 'text',
-    'Exc-Distrib-Cat': 'text',
+    'Include-Distributor-Name': 'text',
+    'Exclude-Distributor-Name': 'text',
+    'Include-Distributor-Category': 'text',
+    'Exclude-Distributor-Category': 'text',
   })
 })
 
@@ -63,10 +63,10 @@ it('returns query with parameter values', () => {
     Sort: 'display_date:asc',
     'Source-Exclude': 'headlines,description,website_url',
     'Source-Include': 'related_items,content_elements,taxonomy',
-    'Inc-Distrib-Name': 'AP',
-    'Exc-Distrib-Name': 'paid',
-    'Inc-Distrib-Cat': 'promotions',
-    'Exc-Distrib-Cat': 'wires',
+    'Include-Distributor-Name': 'AP',
+    'Exclude-Distributor-Name': 'paid',
+    'Include-Distributor-Category': 'promotions',
+    'Exclude-Distributor-Category': 'wires',
   })
   expect(query).toBe(
     'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22range%22:%7B%22last_updated_date%22:%7B%22gte%22:%22now-2d%22,%22lte%22:%22now%22%7D%7D%7D%5D%7D%7D%7D&website=demo&size=25&from=3&_sourceExclude=headlines,description,website_url&sort=display_date:asc&_sourceInclude=related_items,content_elements,taxonomy&include_distributor_name=AP',


### PR DESCRIPTION
I had to abbreviate the distributor parameters because they were
getting covered by the text box.  Originally I was using underscode,
but switching to dashs makes the Editor wrap the parameter to fit.