### PR TITLE
Sort collection   AIO-566

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,3 +1,12 @@
 module.exports = {
-  presets: ['@babel/preset-env', '@babel/preset-react'],
+  presets: [
+    [
+      '@babel/preset-env',
+      {
+        useBuiltIns: 'usage',
+        corejs: 3,
+      },
+    ],
+    '@babel/preset-react',
+  ],
 }

--- a/blocks/feeds-source-collections-block/sources/collections.js
+++ b/blocks/feeds-source-collections-block/sources/collections.js
@@ -90,12 +90,12 @@ export default {
     {
       name: 'from',
       displayName: 'From - Integer offset to start from',
-      type: 'text',
+      type: 'number',
     },
     {
       name: 'size',
       displayName: 'Number of records to return, Integer 1 - 20',
-      type: 'text',
+      type: 'number',
     },
     {
       name: 'include_fields',

--- a/blocks/feeds-source-collections-block/sources/collections.js
+++ b/blocks/feeds-source-collections-block/sources/collections.js
@@ -1,21 +1,38 @@
 import request from 'request-promise-native'
 import { CONTENT_BASE, ARC_ACCESS_TOKEN } from 'fusion:environment'
 
-const params = {
-  _id: 'text',
-  content_alias: 'text',
-  from: 'text',
-  size: 'text',
-  included_fields: 'text',
-}
-
 const options = {
   gzip: true,
   json: true,
   auth: { bearer: ARC_ACCESS_TOKEN },
 }
 
-const fetch = (key = {}) => {
+const defaultIncludedFields = [
+  'content_elements',
+  'created_date',
+  'credits',
+  'description',
+  'display_date',
+  'first_publish_date',
+  'headlines',
+  'last_updated_date',
+  'promo_items',
+  'publish_date',
+  'source',
+  'subheadlines',
+  'taxonomy',
+  'website_url',
+].join(',')
+
+const sortStories = (idsResp, collectionResp, ids) => {
+  idsResp.content_elements.forEach((item) => {
+    const storyIndex = ids.indexOf(item._id)
+    collectionResp.content_elements.splice(storyIndex, 1, item)
+  })
+  return collectionResp
+}
+
+const fetch = async (key = {}) => {
   const {
     'arc-site': site,
     _id,
@@ -34,55 +51,57 @@ const fetch = (key = {}) => {
     ...(contentAlias && { content_alias: contentAlias }),
   }
 
-  return request({
+  // ids results does not include content_elements unless specified in included_fields
+  const idsIncludedFields = includedFields || defaultIncludedFields
+
+  const collectionResp = await request({
     uri: `${CONTENT_BASE}/content/v4/collections`,
     qs: qs,
     ...options,
   })
-    .then((collectionResp) => {
-      const ids = collectionResp.content_elements
-        .map((item) => {
-          return item._id
-        })
-        .join(',')
-
-      // ids results does not include content_elements unless specified in included_fields
-      const idsIncludedFields =
-        includedFields ||
-        [
-          'content_elements',
-          'created_date',
-          'credits',
-          'description',
-          'display_date',
-          'first_publish_date',
-          'headlines',
-          'last_updated_date',
-          'promo_items',
-          'publish_date',
-          'source',
-          'subheadlines',
-          'taxonomy',
-          'website_url',
-        ].join(',')
-
-      return request({
-        uri: `${CONTENT_BASE}/content/v4/ids`,
-        qs: {
-          ids: ids,
-          website: site,
-          included_fields: idsIncludedFields,
-        },
-        ...options,
-      })
-    })
-    .catch((err) => {
-      throw err
-    })
+  const ids = await collectionResp.content_elements.map((item) => {
+    return item._id
+  })
+  const idsResp = await request({
+    uri: `${CONTENT_BASE}/content/v4/ids`,
+    qs: {
+      ids: ids.join(','),
+      website: site,
+      included_fields: idsIncludedFields,
+    },
+    ...options,
+  })
+  return await sortStories(idsResp, collectionResp, ids)
 }
 
 export default {
   fetch,
-  params,
+  params: [
+    {
+      name: '_id',
+      displayName: 'Collection ID',
+      type: 'text',
+    },
+    {
+      name: 'content_alias',
+      displayName: 'Collection Alias (Only populate ID or Alias)',
+      type: 'text',
+    },
+    {
+      name: 'from',
+      displayName: 'From - Integer offset to start from',
+      type: 'text',
+    },
+    {
+      name: 'size',
+      displayName: 'Number of records to return, Integer 1 - 20',
+      type: 'text',
+    },
+    {
+      name: 'include_fields',
+      displayName: 'ANS Fields to include, use commas between fields',
+      type: 'text',
+    },
+  ],
   ttl: 300,
 }

--- a/blocks/feeds-source-collections-block/sources/collections.test.js
+++ b/blocks/feeds-source-collections-block/sources/collections.test.js
@@ -1,13 +1,113 @@
-// eslint-disable-next-line no-unused-vars
-import Consumer from 'fusion:consumer'
+import request from 'request-promise-native'
 const fetch = require('./collections')
 
+jest.mock('request-promise-native')
+
 it('validate params', () => {
-  expect(fetch.default.params).toStrictEqual({
-    _id: 'text',
-    content_alias: 'text',
-    from: 'text',
-    size: 'text',
-    included_fields: 'text',
+  expect(fetch.default.params).toStrictEqual([
+    { displayName: 'Collection ID', name: '_id', type: 'text' },
+    {
+      displayName: 'Collection Alias (Only populate ID or Alias)',
+      name: 'content_alias',
+      type: 'text',
+    },
+    {
+      displayName: 'From - Integer offset to start from',
+      name: 'from',
+      type: 'text',
+    },
+    {
+      displayName: 'Number of records to return, Integer 1 - 20',
+      name: 'size',
+      type: 'text',
+    },
+    {
+      displayName: 'ANS Fields to include, use commas between fields',
+      name: 'include_fields',
+      type: 'text',
+    },
+  ])
+})
+
+describe('collections', () => {
+  describe('fetch', () => {
+    beforeEach(() => {
+      request.mockClear()
+    })
+
+    it('Get collection', (done) => {
+      request.mockResolvedValueOnce({
+        type: 'collection',
+        content_elements: [
+          {
+            _id: 'AAAAAAAAAAAAAAAAAAAAAAAAAA',
+            website_url: '/storyA',
+          },
+          {
+            _id: 'BBBBBBBBBBBBBBBBBBBBBBBBBB',
+            website_url: '/storyB',
+          },
+          {
+            _id: 'CCCCCCCCCCCCCCCCCCCCCCCCCC',
+            website_url: '/storyC',
+          },
+          {
+            _id: 'DDDDDDDDDDDDDDDDDDDDDDDDDD',
+            website_url: '/storyD',
+          },
+        ],
+      })
+
+      request.mockResolvedValueOnce({
+        type: 'results',
+        content_elements: [
+          {
+            _id: 'BBBBBBBBBBBBBBBBBBBBBBBBBB',
+            website_url: '/storyB',
+          },
+          {
+            _id: 'AAAAAAAAAAAAAAAAAAAAAAAAAA',
+            website_url: '/storyA',
+          },
+          {
+            _id: 'DDDDDDDDDDDDDDDDDDDDDDDDDD',
+            website_url: '/storyD',
+          },
+          {
+            _id: 'CCCCCCCCCCCCCCCCCCCCCCCCCC',
+            website_url: '/storyC',
+          },
+        ],
+      })
+
+      fetch.default
+        .fetch({
+          id: 'id',
+        })
+        .then((response) => {
+          expect(response).toEqual({
+            type: 'collection',
+            content_elements: [
+              {
+                _id: 'AAAAAAAAAAAAAAAAAAAAAAAAAA',
+                website_url: '/storyA',
+              },
+              {
+                _id: 'BBBBBBBBBBBBBBBBBBBBBBBBBB',
+                website_url: '/storyB',
+              },
+              {
+                _id: 'CCCCCCCCCCCCCCCCCCCCCCCCCC',
+                website_url: '/storyC',
+              },
+              {
+                _id: 'DDDDDDDDDDDDDDDDDDDDDDDDDD',
+                website_url: '/storyD',
+              },
+            ],
+          })
+          done()
+        })
+    })
   })
 })

--- a/package-lock.json
+++ b/package-lock.json
@@ -9331,6 +9331,11 @@
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
     },
+    "core-js": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.9.1.tgz",
+      "integrity": "sha512-gSjRvzkxQc1zjM/5paAmL4idJBFzuJoo+jDjF1tStYFMV2ERfD02HhahhCGXUyHxQRG4yFKVSdO6g62eoRMcDg=="
+    },
     "core-js-compat": {
       "version": "3.9.1",
       "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.9.1.tgz",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@changesets/cli": "^2.7.1",
     "@manypkg/cli": "^0.17.0",
     "@preconstruct/cli": "^2.0.0",
+    "core-js": "^3.9.1",
     "eslint": "^7.2.0",
     "eslint-config-prettier": "^8.0.0",
     "eslint-config-standard": "^16.0.2",


### PR DESCRIPTION
Results from Content-API ids call are in _id order, not the order they
were requested.  Reorder the results to match collection order
Added descriptions to the parameters
Mock collection and C-API calls
Add core-js to handle test with async call