### PR TITLE
Move outputType before from AIO-609

### DIFF
--- a/.changeset/wise-lobsters-eat.md
+++ b/.changeset/wise-lobsters-eat.md
@@ -1,0 +1,5 @@
+---
+'@wpmedia/sitemap-index-feature-block': patch
+---
+
+Don't include from=0

--- a/blocks/sitemap-by-day-feature-block/package-lock.json
+++ b/blocks/sitemap-by-day-feature-block/package-lock.json
@@ -24,6 +24,11 @@
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
     },
+    "moment": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
+    },
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",

--- a/blocks/sitemap-by-day-feature-block/package.json
+++ b/blocks/sitemap-by-day-feature-block/package.json
@@ -23,7 +23,8 @@
   ],
   "homepage": "https://github.com/WPMedia/feed-components#readme",
   "dependencies": {
-    "jmespath": "^0.15.0"
+    "jmespath": "^0.15.0",
+    "moment": "^2.24.0"
   },
   "devDependencies": {
     "prop-types": "^15.7.2"

--- a/blocks/sitemap-index-by-day-feature-block/features/sitemap-index/__snapshots__/xml.test.js.snap
+++ b/blocks/sitemap-index-by-day-feature-block/features/sitemap-index/__snapshots__/xml.test.js.snap
@@ -9,22 +9,22 @@ Object {
         "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap-by-day/latest?outputType=xml",
       },
       Object {
-        "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap-by-day/2021-04-08?outputType=xml",
+        "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap-by-day/2021-04-21?outputType=xml",
       },
       Object {
-        "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap-by-day/2021-04-07?outputType=xml",
+        "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap-by-day/2021-04-20?outputType=xml",
       },
       Object {
-        "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap-by-day/2021-04-06?outputType=xml",
+        "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap-by-day/2021-04-19?outputType=xml",
       },
       Object {
-        "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap-by-day/2021-04-05?outputType=xml",
+        "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap-by-day/2021-04-18?outputType=xml",
       },
       Object {
-        "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap-by-day/2021-04-04?outputType=xml",
+        "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap-by-day/2021-04-17?outputType=xml",
       },
       Object {
-        "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap-by-day/2021-04-03?outputType=xml",
+        "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap-by-day/2021-04-16?outputType=xml",
       },
     ],
   },
@@ -38,6 +38,45 @@ Object {
     "sitemap": Array [
       Object {
         "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap-by-day/latest?outputType=xml",
+      },
+      Object {
+        "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap-by-day/2021-04-21?outputType=xml",
+      },
+      Object {
+        "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap-by-day/2021-04-20?outputType=xml",
+      },
+      Object {
+        "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap-by-day/2021-04-19?outputType=xml",
+      },
+      Object {
+        "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap-by-day/2021-04-18?outputType=xml",
+      },
+      Object {
+        "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap-by-day/2021-04-17?outputType=xml",
+      },
+      Object {
+        "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap-by-day/2021-04-16?outputType=xml",
+      },
+      Object {
+        "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap-by-day/2021-04-15?outputType=xml",
+      },
+      Object {
+        "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap-by-day/2021-04-14?outputType=xml",
+      },
+      Object {
+        "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap-by-day/2021-04-13?outputType=xml",
+      },
+      Object {
+        "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap-by-day/2021-04-12?outputType=xml",
+      },
+      Object {
+        "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap-by-day/2021-04-11?outputType=xml",
+      },
+      Object {
+        "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap-by-day/2021-04-10?outputType=xml",
+      },
+      Object {
+        "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap-by-day/2021-04-09?outputType=xml",
       },
       Object {
         "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap-by-day/2021-04-08?outputType=xml",

--- a/blocks/sitemap-index-by-day-feature-block/package.json
+++ b/blocks/sitemap-index-by-day-feature-block/package.json
@@ -23,7 +23,7 @@
   ],
   "homepage": "https://github.com/WPMedia/feed-components#readme",
   "dependencies": {
-    "moment": "2.29.1"
+    "moment": "^2.24.0"
   },
   "devDependencies": {
     "prop-types": "^15.7.2"

--- a/blocks/sitemap-index-feature-block/features/sitemap-index/__snapshots__/xml.test.js.snap
+++ b/blocks/sitemap-index-feature-block/features/sitemap-index/__snapshots__/xml.test.js.snap
@@ -7,23 +7,23 @@ Object {
     "sitemap": Array [
       Object {
         "lastmod": "2020-04-07T15:02:08.918Z",
-        "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemapcategory/sports?from=0&outputType=xml",
+        "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemapcategory/sports?outputType=xml",
       },
       Object {
         "lastmod": "2020-04-07T15:02:08.918Z",
-        "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemapcategory/sports?from=100&outputType=xml",
+        "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemapcategory/sports?outputType=xml&from=100",
       },
       Object {
         "lastmod": "2020-04-07T15:02:08.918Z",
-        "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemapcategory/sports?from=200&outputType=xml",
+        "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemapcategory/sports?outputType=xml&from=200",
       },
       Object {
         "lastmod": "2020-04-07T15:02:08.918Z",
-        "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemapcategory/sports?from=300&outputType=xml",
+        "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemapcategory/sports?outputType=xml&from=300",
       },
       Object {
         "lastmod": "2020-04-07T15:02:08.918Z",
-        "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemapcategory/sports?from=400&outputType=xml",
+        "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemapcategory/sports?outputType=xml&from=400",
       },
     ],
   },
@@ -37,23 +37,23 @@ Object {
     "sitemap": Array [
       Object {
         "lastmod": "2020-04-07T15:02:08.918Z",
-        "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap?from=0&outputType=xml",
+        "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap?outputType=xml",
       },
       Object {
         "lastmod": "2020-04-07T15:02:08.918Z",
-        "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap?from=100&outputType=xml",
+        "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap?outputType=xml&from=100",
       },
       Object {
         "lastmod": "2020-04-07T15:02:08.918Z",
-        "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap?from=200&outputType=xml",
+        "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap?outputType=xml&from=200",
       },
       Object {
         "lastmod": "2020-04-07T15:02:08.918Z",
-        "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap?from=300&outputType=xml",
+        "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap?outputType=xml&from=300",
       },
       Object {
         "lastmod": "2020-04-07T15:02:08.918Z",
-        "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap?from=400&outputType=xml",
+        "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap?outputType=xml&from=400",
       },
     ],
   },

--- a/blocks/sitemap-index-feature-block/features/sitemap-index/xml.js
+++ b/blocks/sitemap-index-feature-block/features/sitemap-index/xml.js
@@ -11,6 +11,7 @@ const sitemapIndexTemplate = ({
   section,
   domain,
   maxCount,
+  paramList,
   lastModDate,
   buildIndexes,
 }) => ({
@@ -21,7 +22,7 @@ const sitemapIndexTemplate = ({
       domain,
       feedPath,
       section,
-      feedParam,
+      paramList,
       lastModDate,
     ),
   },
@@ -37,6 +38,7 @@ export function SitemapIndex({
   let { count: maxCount = 0 } = globalContent
   // ES7 caps results at 10k, using ?from=10000 will cause an error
   if (maxCount === 10000) maxCount--
+  const paramList = customFields.feedParam.split('&').filter((i) => i)
   const lastModDate = jmespath.search(
     globalContent,
     `content_elements[0]."${customFields.lastMod}"`,
@@ -51,16 +53,18 @@ export function SitemapIndex({
     feedDomainUrl,
     feedPath,
     section,
-    feedParam,
+    paramList,
     lastModDate,
   ) => {
     const arr = []
     if (maxCount) {
       for (let i = 0; i <= maxCount; i += 100) {
+        // only push from param if it's not zero
+        const newParamList = [...paramList, ...(i ? [`from=${i}`] : [])]
         arr.push({
-          loc: `${feedDomainURL}${feedPath}${section}?from=${i}${
-            feedParam || ''
-          }`,
+          loc: `${feedDomainURL}${feedPath}${section}?${newParamList.join(
+            '&',
+          )}`,
           ...(lastModDate && { lastmod: lastModDate }),
         })
       }
@@ -74,6 +78,7 @@ export function SitemapIndex({
     section,
     domain: feedDomainURL,
     maxCount,
+    paramList,
     lastModDate,
     buildIndexes,
   })


### PR DESCRIPTION
lanacionar is getting intermitten 404's on https://www.lanacion.com.ar/arc/outboundfeeds/news-sitemap/?from=0&amp;outputType=xml
Moving outputType to the first parameter seems to fix it.