### PR TITLE
1.1 vesion bump

### DIFF
--- a/blocks/feeds-source-collections-block/package.json
+++ b/blocks/feeds-source-collections-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/feeds-source-collections-block",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Content source to search collections by _id or alias",
   "main": "index.js",
   "files": [

--- a/blocks/feeds-source-content-api-block/package.json
+++ b/blocks/feeds-source-content-api-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/feeds-source-content-api-block",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Fusion components for building sitemaps",
   "main": "index.js",
   "files": [

--- a/blocks/feeds-source-video-api-block/package.json
+++ b/blocks/feeds-source-video-api-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/feeds-source-video-api-block",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Fusion components for building sitemaps",
   "main": "index.js",
   "files": [

--- a/blocks/mrss-feature-block/package.json
+++ b/blocks/mrss-feature-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/mrss-feature-block",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Fusion components for building rss",
   "main": "index.js",
   "files": [

--- a/blocks/rss-fbia-feature-block/package.json
+++ b/blocks/rss-fbia-feature-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/rss-fbia-feature-block",
-  "version": "1.0.2",
+  "version": "1.1.0",
   "description": "Fusion components for building Facebook Instant Articles",
   "main": "index.js",
   "files": [

--- a/blocks/rss-feature-block/package.json
+++ b/blocks/rss-feature-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/rss-feature-block",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Fusion components for building rss",
   "main": "index.js",
   "files": [

--- a/blocks/rss-flipboard-feature-block/package.json
+++ b/blocks/rss-flipboard-feature-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/rss-flipboard-feature-block",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Fusion components for building flipboard-rss",
   "main": "index.js",
   "files": [

--- a/blocks/rss-google-news-feature-block/package.json
+++ b/blocks/rss-google-news-feature-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/rss-google-news-feature-block",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Fusion components for building google-news-rss",
   "main": "index.js",
   "files": [

--- a/blocks/rss-msn-feature-block/package.json
+++ b/blocks/rss-msn-feature-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/rss-msn-feature-block",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Fusion components for building msn-rss",
   "main": "index.js",
   "files": [

--- a/blocks/sitemap-feature-block/package.json
+++ b/blocks/sitemap-feature-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/sitemap-feature-block",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Fusion components for building sitemaps",
   "main": "index.js",
   "files": [

--- a/blocks/sitemap-index-feature-block/package.json
+++ b/blocks/sitemap-index-feature-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/sitemap-index-feature-block",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Fusion components for building sitemap-index",
   "main": "index.js",
   "files": [

--- a/blocks/sitemap-news-feature-block/package.json
+++ b/blocks/sitemap-news-feature-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/sitemap-news-feature-block",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Fusion components for building news sitemaps",
   "main": "index.js",
   "files": [

--- a/blocks/sitemap-section-index-feature-block/package.json
+++ b/blocks/sitemap-section-index-feature-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/sitemap-section-index-feature-block",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "sitemaps section index using Site Service",
   "main": "index.js",
   "files": [

--- a/blocks/sitemap-video-feature-block/package.json
+++ b/blocks/sitemap-video-feature-block/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/sitemap-video-feature-block",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Fusion components for building sitemaps",
   "main": "index.js",
   "files": [


### PR DESCRIPTION
Release 1.1 used version 1.0.1 for all packages.  Bump up the version
number to match so when 1.2 is merged the package versions will match
Note there is no changeset.  That is in the code release