### PR TITLE
Don't parseInt invalid date  AIO-612

### DIFF
--- a/blocks/sitemap-index-by-day-feature-block/features/sitemap-index/__snapshots__/xml.test.js.snap
+++ b/blocks/sitemap-index-by-day-feature-block/features/sitemap-index/__snapshots__/xml.test.js.snap
@@ -58,3 +58,19 @@ Object {
   },
 }
 `;
+
+exports[`returns template with set end date 2`] = `
+Object {
+  "sitemapindex": Object {
+    "@xmlns": "http://www.sitemaps.org/schemas/sitemap/0.9",
+    "sitemap": Array [
+      Object {
+        "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap-news/latest?outputType=xml",
+      },
+      Object {
+        "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap-news/2021-04-08?outputType=xml",
+      },
+    ],
+  },
+}
+`;

--- a/blocks/sitemap-index-by-day-feature-block/features/sitemap-index/xml.js
+++ b/blocks/sitemap-index-by-day-feature-block/features/sitemap-index/xml.js
@@ -45,7 +45,10 @@ export function SitemapIndexByDay({
     const end = moment(customFields.numberOfDays)
     maxDays = start.diff(end, 'days') + 1
   } else {
-    maxDays = parseInt(customFields.numberOfDays) || 2
+    maxDays =
+      (!isNaN(customFields.numberOfDays) &&
+        parseInt(customFields.numberOfDays)) ||
+      2
   }
 
   const buildIndexes = (

--- a/blocks/sitemap-index-by-day-feature-block/features/sitemap-index/xml.test.js
+++ b/blocks/sitemap-index-by-day-feature-block/features/sitemap-index/xml.test.js
@@ -37,3 +37,20 @@ it('returns template with set end date', () => {
   })
   expect(sitemapindex).toMatchSnapshot()
 })
+
+it('invalid date format, should return 2', () => {
+  const sitemapindex = SitemapIndexByDay({
+    arcSite: 'demo',
+    customFields: {
+      feedPath: {
+        0: '/arc/outboundfeeds/sitemap-news/',
+      },
+      feedName: '/sitemap-news-index/',
+      feedParam: 'outputType=xml',
+      numberOfDays: '4/5/21',
+      feedDates2Split: {},
+    },
+    requestUri: '/sitemap-news-index/?outputType=xml',
+  })
+  expect(sitemapindex).toMatchSnapshot()
+})


### PR DESCRIPTION
If the date fails to match regex it was passed to parseInt
parseInt will return 2021 for '2021/05/01'.  Use isNaN try to validate
its a number