### PR TITLE
Improve date validation  AIO-634

### DIFF
--- a/.changeset/friendly-geese-doubt.md
+++ b/.changeset/friendly-geese-doubt.md
@@ -1,0 +1,5 @@
+---
+'@wpmedia/sitemap-index-by-day-feature-block': patch
+---
+
+Improve date validation and fix test

--- a/blocks/sitemap-index-by-day-feature-block/features/sitemap-index/__snapshots__/xml.test.js.snap
+++ b/blocks/sitemap-index-by-day-feature-block/features/sitemap-index/__snapshots__/xml.test.js.snap
@@ -16,6 +16,22 @@ Object {
 }
 `;
 
+exports[`invalid date, should return 2 1`] = `
+Object {
+  "sitemapindex": Object {
+    "@xmlns": "http://www.sitemaps.org/schemas/sitemap/0.9",
+    "sitemap": Array [
+      Object {
+        "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap-news/latest?outputType=xml",
+      },
+      Object {
+        "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap-news/2021-04-08?outputType=xml",
+      },
+    ],
+  },
+}
+`;
+
 exports[`returns template with default values 1`] = `
 Object {
   "sitemapindex": Object {
@@ -32,7 +48,7 @@ Object {
 }
 `;
 
-exports[`returns template with set end date 1`] = `
+exports[`returns template with set end date 2021-04-01 1`] = `
 Object {
   "sitemapindex": Object {
     "@xmlns": "http://www.sitemaps.org/schemas/sitemap/0.9",

--- a/blocks/sitemap-index-by-day-feature-block/features/sitemap-index/xml.js
+++ b/blocks/sitemap-index-by-day-feature-block/features/sitemap-index/xml.js
@@ -41,10 +41,13 @@ export function SitemapIndexByDay({
   // numberOfDays can be an int or a date
   let maxDays
   if (customFields.numberOfDays.match(/\d{4}-\d{2}-\d{2}/)) {
-    const start = moment.utc(new Date())
-    const end = moment(customFields.numberOfDays)
-    maxDays = start.diff(end, 'days') + 1
-  } else {
+    const start = moment.utc(new Date()).startOf('day')
+    const end = moment.utc(customFields.numberOfDays, 'YYYY-MM-DD', true)
+    if (end.isValid() && end.isBefore(start) && end.isAfter('2000')) {
+      maxDays = start.diff(end, 'days') + 1
+    }
+  }
+  if (!maxDays) {
     maxDays =
       (!isNaN(customFields.numberOfDays) &&
         parseInt(customFields.numberOfDays)) ||

--- a/blocks/sitemap-index-by-day-feature-block/features/sitemap-index/xml.test.js
+++ b/blocks/sitemap-index-by-day-feature-block/features/sitemap-index/xml.test.js
@@ -2,7 +2,9 @@
 import Consumer from 'fusion:consumer'
 import { SitemapIndexByDay } from './xml'
 
-jest.useFakeTimers('modern').setSystemTime(new Date('2021-04-09').getTime())
+jest
+  .useFakeTimers('modern')
+  .setSystemTime(new Date('2021-04-09T20:15:39.543Z').getTime())
 
 it('returns template with default values', () => {
   const sitemapindex = SitemapIndexByDay({
@@ -19,7 +21,7 @@ it('returns template with default values', () => {
   expect(sitemapindex).toMatchSnapshot()
 })
 
-it('returns template with set end date', () => {
+it('returns template with set end date 2021-04-01', () => {
   const sitemapindex = SitemapIndexByDay({
     arcSite: 'demo',
     customFields: {
@@ -48,6 +50,23 @@ it('invalid date format, should return 2', () => {
       feedName: '/sitemap-news-index/',
       feedParam: 'outputType=xml',
       numberOfDays: '4/5/21',
+      feedDates2Split: {},
+    },
+    requestUri: '/sitemap-news-index/?outputType=xml',
+  })
+  expect(sitemapindex).toMatchSnapshot()
+})
+
+it('invalid date, should return 2', () => {
+  const sitemapindex = SitemapIndexByDay({
+    arcSite: 'demo',
+    customFields: {
+      feedPath: {
+        0: '/arc/outboundfeeds/sitemap-news/',
+      },
+      feedName: '/sitemap-news-index/',
+      feedParam: 'outputType=xml',
+      numberOfDays: '1234-56-78',
       feedDates2Split: {},
     },
     requestUri: '/sitemap-news-index/?outputType=xml',


### PR DESCRIPTION
- validates date format
- validates date
- validates date is before today
- validates date is after 2000-01-01T:00:00:00

Otherwise return 2 rows
Fix test so it passes locally and in the action