### PR TITLE
Handle empty images  AIO-689

### DIFF
--- a/utils/content-elements/package-lock.json
+++ b/utils/content-elements/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/feeds-content-elements",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -73,17 +73,17 @@
       "integrity": "sha512-Ufpab7G5PfnEhQyy5kDg9C8ltWJjsVT1P/IYqacjstaqydG4Q21HAT2HUZQYBrC/a1ZLKCz87pfydlDvv8y97w=="
     },
     "@wpmedia/feeds-find-video-stream": {
-      "version": "1.0.3",
-      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-find-video-stream/1.0.3/1421c18eef64009dcddf2ca7bf43afd95cd9fce6ddad5e0a08113302a0875a38",
-      "integrity": "sha512-qKbxxQfJEXH9avMI2yb4DhtqemRUE8hYfINCA4TNk0ceYpca3PcYwThS7TUpqFXw8Atze0gAcYmgxJ8irlvIxg==",
+      "version": "1.0.4",
+      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-find-video-stream/1.0.4/b80796c01158c3bb667d3901aa9fe4694e83834c9d069f8c85633692d55c6e0c",
+      "integrity": "sha512-ye4s0pXlRtK16MhP6mn6IneZq/LLUskeE24S9m0po2hEYOa4D+rzXVzoVnz2GTyOzNE1WXrOfWqoTxw8gZ37eg==",
       "requires": {
         "jmespath": "^0.15.0"
       }
     },
     "@wpmedia/feeds-resizer": {
-      "version": "1.0.3",
-      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-resizer/1.0.3/1e40d1939ecc99cf1d16a169c65e89573226a052793e19ba24268ecba871d8f9",
-      "integrity": "sha512-zMOKCGYapel0NURDIJAeVi+k+Yd9OqQKlM7ML2lrAvsVDbOO2pJgQA/jsTcFz4P1TmYJFgqpD+undCEDozrfRg==",
+      "version": "1.0.4",
+      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-resizer/1.0.4/d3b2dcfee851d2b7a148f0b9604d5d2945dd7af10b78a552627a427832f5e5a3",
+      "integrity": "sha512-e1dWHPJ0kAFHdtHYsp9iD/Zruev0onDbYM5T4if2+M9wr979cj5ElLfPplQ8/fCR+EYtXMEU696LmNISJ8iIXA==",
       "requires": {
         "thumbor-lite": "^0.1.8"
       }

--- a/utils/content-elements/package.json
+++ b/utils/content-elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/feeds-content-elements",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Shared arcio content_elements module",
   "main": "dist/feeds-content-elements.cjs.js",
   "module": "dist/feeds-content-elements.esm.js",
@@ -23,8 +23,8 @@
   "author": "Tim Kosmider <timothy.kosmider@washpost.com>",
   "license": "UNLICENSED",
   "dependencies": {
-    "@wpmedia/feeds-find-video-stream": "1.0.3",
-    "@wpmedia/feeds-resizer": "1.0.3",
+    "@wpmedia/feeds-find-video-stream": "1.0.4",
+    "@wpmedia/feeds-resizer": "1.0.4",
     "he": "^1.2.0",
     "jmespath": "^0.15.0",
     "xmlbuilder2": "2.1.2"

--- a/utils/find-video-stream/package-lock.json
+++ b/utils/find-video-stream/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/feeds-find-video-stream",
-  "version": "1.0.2",
+  "version": "1.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/utils/find-video-stream/package.json
+++ b/utils/find-video-stream/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/feeds-find-video-stream",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Utility to search video stream for desired encoding",
   "main": "dist/feeds-find-video-stream.cjs.js",
   "module": "dist/feeds-find-video-stream.esm.js",

--- a/utils/promo-items/package-lock.json
+++ b/utils/promo-items/package-lock.json
@@ -1,21 +1,21 @@
 {
   "name": "@wpmedia/feeds-promo-items",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@wpmedia/feeds-find-video-stream": {
-      "version": "1.0.3",
-      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-find-video-stream/1.0.3/1421c18eef64009dcddf2ca7bf43afd95cd9fce6ddad5e0a08113302a0875a38",
-      "integrity": "sha512-qKbxxQfJEXH9avMI2yb4DhtqemRUE8hYfINCA4TNk0ceYpca3PcYwThS7TUpqFXw8Atze0gAcYmgxJ8irlvIxg==",
+      "version": "1.0.4",
+      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-find-video-stream/1.0.4/b80796c01158c3bb667d3901aa9fe4694e83834c9d069f8c85633692d55c6e0c",
+      "integrity": "sha512-ye4s0pXlRtK16MhP6mn6IneZq/LLUskeE24S9m0po2hEYOa4D+rzXVzoVnz2GTyOzNE1WXrOfWqoTxw8gZ37eg==",
       "requires": {
         "jmespath": "^0.15.0"
       }
     },
     "@wpmedia/feeds-resizer": {
-      "version": "1.0.3",
-      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-resizer/1.0.3/1e40d1939ecc99cf1d16a169c65e89573226a052793e19ba24268ecba871d8f9",
-      "integrity": "sha512-zMOKCGYapel0NURDIJAeVi+k+Yd9OqQKlM7ML2lrAvsVDbOO2pJgQA/jsTcFz4P1TmYJFgqpD+undCEDozrfRg==",
+      "version": "1.0.4",
+      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-resizer/1.0.4/d3b2dcfee851d2b7a148f0b9604d5d2945dd7af10b78a552627a427832f5e5a3",
+      "integrity": "sha512-e1dWHPJ0kAFHdtHYsp9iD/Zruev0onDbYM5T4if2+M9wr979cj5ElLfPplQ8/fCR+EYtXMEU696LmNISJ8iIXA==",
       "requires": {
         "thumbor-lite": "^0.1.8"
       }

--- a/utils/promo-items/package.json
+++ b/utils/promo-items/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/feeds-promo-items",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Shared arcio promo_items module",
   "main": "dist/feeds-promo-items.cjs.js",
   "module": "dist/feeds-promo-items.esm.js",
@@ -23,8 +23,8 @@
   "author": "Tim Kosmider <timothy.kosmider@washpost.com>",
   "license": "UNLICENSED",
   "dependencies": {
-    "@wpmedia/feeds-find-video-stream": "1.0.3",
-    "@wpmedia/feeds-resizer": "1.0.3",
+    "@wpmedia/feeds-find-video-stream": "1.0.4",
+    "@wpmedia/feeds-resizer": "1.0.4",
     "jmespath": "^0.15.0"
   }
 }

--- a/utils/promo-items/src/promoItems.js
+++ b/utils/promo-items/src/promoItems.js
@@ -168,27 +168,38 @@ export function BuildPromoItems() {
     imageTitle,
     imageCaption,
     imageCredits,
-  }) => ({
-    url: buildResizerURL(
-      element.url,
-      resizerKey,
-      resizerURL,
-      resizerWidth,
-      resizerHeight,
-    ),
-    type: `image/${
-      ((match = element.url.match(imageRegex)) &&
-        match &&
-        match[0].replace('.', '').toLowerCase().replace('jpg', 'jpeg')) ||
-      'jpeg'
-    }`,
-    medium: 'image',
-    title: jmespath.search(element, imageTitle),
-    caption: jmespath.search(element, imageCaption),
-    credits: jmespath.search(element, imageCredits),
-    ...(element.height && { height: resizerHeight || element.height }),
-    ...(element.width && { width: resizerWidth || element.width }),
-  })
+  }) => {
+    if (element && element.url) {
+      let title, caption, credits
+      return {
+        url: buildResizerURL(
+          element.url,
+          resizerKey,
+          resizerURL,
+          resizerWidth,
+          resizerHeight,
+        ),
+        type: `image/${
+          ((match = element.url.match(imageRegex)) &&
+            match &&
+            match[0].replace('.', '').toLowerCase().replace('jpg', 'jpeg')) ||
+          'jpeg'
+        }`,
+        medium: 'image',
+        ...(imageTitle &&
+          (title = jmespath.search(element, imageTitle)) &&
+          title && { title: title }),
+        ...(imageCaption &&
+          (caption = jmespath.search(element, imageCaption)) &&
+          caption && { caption: caption }),
+        ...(imageCredits &&
+          (credits = jmespath.search(element, imageCredits)) &&
+          credits && { credits: credits }),
+        ...(element.height && { height: resizerHeight || element.height }),
+        ...(element.width && { width: resizerWidth || element.width }),
+      }
+    }
+  }
 
   this.video = ({
     element,

--- a/utils/promo-items/src/promoItems.test.js
+++ b/utils/promo-items/src/promoItems.test.js
@@ -137,8 +137,8 @@ it('handle empty promo_items', () => {
     ...options,
     ans: {
       promo_items: {
-        basic: { version: '10.0.1' },
-        lead_art: { version: '10.0.1' },
+        basic: { type: 'image', version: '10.0.1' },
+        lead_art: { type: 'image', version: '10.0.1' },
       },
     },
   })
@@ -156,6 +156,22 @@ it('handle basic image promo_items', () => {
         'image:loc':
           'https://www.example.com/resizer/abcdefghijklmnopqrstuvwxyz=/arc-anglerfish-arc2-prod-demo.s3.amazonaws.com/public/FK3A3PGSLNFYXCHLKWQGADE2ZA.jpg',
         'image:title': { $: 'Basic Title' },
+      },
+    },
+  ])
+})
+
+it('handle no title or caption image promo_items', () => {
+  const img = MyPromoItems.imageTag({
+    ...options,
+    imageTitle: '',
+    imageCaption: '',
+  })
+  expect(img).toMatchObject([
+    {
+      'image:image': {
+        'image:loc':
+          'https://www.example.com/resizer/abcdefghijklmnopqrstuvwxyz=/arc-anglerfish-arc2-prod-demo.s3.amazonaws.com/public/FK3A3PGSLNFYXCHLKWQGADE2ZA.jpg',
       },
     },
   ])

--- a/utils/prop-types/package.json
+++ b/utils/prop-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/feeds-prop-types",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Shared fusion prop-type tag info",
   "main": "dist/feeds-prop-types.cjs.js",
   "module": "dist/feeds-prop-types.esm.js",

--- a/utils/resizer/package.json
+++ b/utils/resizer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/feeds-resizer",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Utilities to manage image resizing",
   "main": "dist/feeds-resizer.cjs.js",
   "module": "dist/feeds-resizer.esm.js",


### PR DESCRIPTION
I had a test for promo_items: {version: '0.10.7'} but empty images
look like {'basic': {'type': 'image', 'version': '0.10.7'}
Make sure image has a url otherwise return
Only include image title, caption and credits if they exist