### PR TITLE
Reduce size of response  AIO-720

### DIFF
--- a/.changeset/purple-ways-juggle.md
+++ b/.changeset/purple-ways-juggle.md
@@ -1,0 +1,9 @@
+---
+'@wpmedia/feeds-source-collections-block': patch
+'@wpmedia/feeds-source-content-api-block': patch
+'@wpmedia/feeds-source-content-api-by-day-block': patch
+'@wpmedia/feeds-source-content-api-by-day2-block': patch
+'@wpmedia/feeds-source-content-api-by-day3-block': patch
+---
+
+Remove all websites but calling website

--- a/blocks/feeds-source-collections-block/sources/collections.js
+++ b/blocks/feeds-source-collections-block/sources/collections.js
@@ -1,55 +1,6 @@
 import request from 'request-promise-native'
 import { CONTENT_BASE, ARC_ACCESS_TOKEN } from 'fusion:environment'
 
-const options = {
-  gzip: true,
-  json: true,
-  auth: { bearer: ARC_ACCESS_TOKEN },
-}
-
-const ansFields = [
-  'canonical_url',
-  'canonical_website',
-  'content_elements',
-  'created_date',
-  'credits',
-  'description',
-  'display_date',
-  'duration',
-  'first_publish_date',
-  'headlines',
-  'last_updated_date',
-  'promo_image',
-  'promo_items',
-  'publish_date',
-  'source',
-  'streams',
-  'subheadlines',
-  'subtitles',
-  'subtype',
-  'taxonomy.primary_section',
-  'taxonomy.seo_keywords',
-  'taxonomy.tags',
-  'type',
-  'video_type',
-]
-
-const sortStories = (idsResp, collectionResp, ids, site) => {
-  idsResp.content_elements.forEach((item) => {
-    const storyIndex = ids.indexOf(item._id)
-    // transform websites to sections
-    if (item?.websites?.[site]?.website_section && !item?.taxonomy?.sections) {
-      if (!item.taxonomy) item.taxonomy = {}
-      item.taxonomy.sections = [item.websites[site].website_section]
-    }
-    if (item?.websites?.[site]?.website_url)
-      item.website_url = item.websites[site].website_url
-    item.website = site
-    collectionResp.content_elements.splice(storyIndex, 1, item)
-  })
-  return collectionResp
-}
-
 const fetch = async (key = {}) => {
   const {
     'arc-site': site,
@@ -68,6 +19,58 @@ const fetch = async (key = {}) => {
     published: true,
     ...(id && { _id: id }),
     ...(contentAlias && { content_alias: contentAlias }),
+  }
+
+  const options = {
+    gzip: true,
+    json: true,
+    auth: { bearer: ARC_ACCESS_TOKEN },
+  }
+
+  const ansFields = [
+    'canonical_url',
+    'canonical_website',
+    'content_elements',
+    'created_date',
+    'credits',
+    'description',
+    'display_date',
+    'duration',
+    'first_publish_date',
+    'headlines',
+    'last_updated_date',
+    'promo_image',
+    'promo_items',
+    'publish_date',
+    'source',
+    'streams',
+    'subheadlines',
+    'subtitles',
+    'subtype',
+    'taxonomy.primary_section',
+    'taxonomy.seo_keywords',
+    'taxonomy.tags',
+    'type',
+    'video_type',
+  ]
+
+  const sortStories = (idsResp, collectionResp, ids, site) => {
+    idsResp.content_elements.forEach((item) => {
+      const storyIndex = ids.indexOf(item._id)
+      // transform websites to sections
+      if (
+        item?.websites?.[site]?.website_section &&
+        !item?.taxonomy?.sections
+      ) {
+        if (!item.taxonomy) item.taxonomy = {}
+        item.taxonomy.sections = [item.websites[site].website_section]
+      }
+      if (item?.websites?.[site]?.website_url)
+        item.website_url = item.websites[site].website_url
+      item.website = site
+      collectionResp.content_elements.splice(storyIndex, 1, item)
+    })
+    return collectionResp
   }
 
   // limit C-API response to just this websites sections to reduce size

--- a/blocks/feeds-source-content-api-block/sources/feeds-content-api.test.js
+++ b/blocks/feeds-source-content-api-block/sources/feeds-content-api.test.js
@@ -2,6 +2,48 @@
 import Consumer from 'fusion:consumer'
 const resolver = require('./feeds-content-api')
 
+const globalContent = {
+  content_elements: [
+    {
+      taxonomy: {
+        tags: [],
+      },
+      websites: {
+        demo: {
+          website_url: '/news/test-article-1',
+          website_section: {
+            _id: '/news',
+          },
+        },
+      },
+    },
+    {
+      taxonomy: {
+        tags: [],
+        sections: [{ _id: '/sports' }],
+      },
+      websites: {
+        demo: {
+          website_url: '/news/test-article-2',
+          website_section: {
+            _id: '/news',
+          },
+        },
+      },
+    },
+    {
+      websites: {
+        demo: {
+          website_url: '/news/test-article-3',
+          website_section: {
+            _id: '/news',
+          },
+        },
+      },
+    },
+  ],
+}
+
 it('validate schemaName', () => {
   expect(resolver.default.schemaName).toBe('feeds')
 })
@@ -46,7 +88,7 @@ it('returns query with default values', () => {
     'Source-Include': '',
   })
   expect(query).toBe(
-    'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22range%22:%7B%22last_updated_date%22:%7B%22gte%22:%22now-2d%22,%22lte%22:%22now%22%7D%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&_sourceExclude=related_content&sort=publish_date:desc',
+    'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22range%22:%7B%22last_updated_date%22:%7B%22gte%22:%22now-2d%22,%22lte%22:%22now%22%7D%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&sort=publish_date:desc&_sourceIncludes=canonical_url,canonical_website,content_elements,created_date,credits,description,display_date,duration,first_publish_date,headlines,last_updated_date,promo_image,promo_items,publish_date,streams,subheadlines,subtitles,subtype,taxonomy.primary_section,taxonomy.seo_keywords,taxonomy.tags,type,video_type,websites.demo',
   )
 })
 
@@ -64,16 +106,22 @@ it('returns query with parameter values', () => {
     'Feed-Size': '25',
     'Feed-Offset': '3',
     Sort: 'display_date:asc',
-    'Source-Exclude': 'headlines,description,website_url',
-    'Source-Include': 'related_items,content_elements,taxonomy',
+    'Source-Exclude': 'content_elements,taxonomy',
+    'Source-Include': 'source,owner',
     'Include-Distributor-Name': 'AP',
     'Exclude-Distributor-Name': 'paid',
     'Include-Distributor-Category': 'promotions',
     'Exclude-Distributor-Category': 'wires',
   })
-  expect(query).toBe(
-    'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22range%22:%7B%22last_updated_date%22:%7B%22gte%22:%22now-2d%22,%22lte%22:%22now%22%7D%7D%7D%5D%7D%7D%7D&website=demo&size=25&from=3&_sourceExclude=headlines,description,website_url&sort=display_date:asc&_sourceInclude=related_items,content_elements,taxonomy&include_distributor_name=AP',
-  )
+  expect(query).toContain('&size=25')
+  expect(query).toContain('&from=3')
+  expect(query).toContain('_sourceExcludes=taxonomy&')
+  expect(query).toContain(',source,owner')
+  expect(query).not.toContain('content_elements')
+  expect(query).toContain('&include_distributor_name=AP')
+  expect(query).not.toContain('paid')
+  expect(query).not.toContain('promotions')
+  expect(query).not.toContain('wires')
 })
 
 it('returns query by section', () => {
@@ -93,9 +141,7 @@ it('returns query by section', () => {
     'Source-Exclude': '',
     'Source-Include': '',
   })
-  expect(query).toBe(
-    'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22range%22:%7B%22last_updated_date%22:%7B%22gte%22:%22now-2d%22,%22lte%22:%22now%22%7D%7D%7D,%7B%22nested%22:%7B%22path%22:%22taxonomy.sections%22,%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22taxonomy.sections._website%22:%22demo%22%7D%7D,%7B%22terms%22:%7B%22taxonomy.sections._id%22:%5B%22/sports%22%5D%7D%7D%5D%7D%7D%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&_sourceExclude=related_content&sort=publish_date:desc',
-  )
+  expect(query).toContain('%22taxonomy.sections._id%22:%5B%22/sports%22')
 })
 
 it('returns query by Exclude-Sections', () => {
@@ -116,13 +162,13 @@ it('returns query by Exclude-Sections', () => {
     'Source-Include': '',
   })
   expect(query).toBe(
-    'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22range%22:%7B%22last_updated_date%22:%7B%22gte%22:%22now-2d%22,%22lte%22:%22now%22%7D%7D%7D,%7B%22nested%22:%7B%22path%22:%22taxonomy.sections%22,%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22taxonomy.sections._website%22:%22demo%22%7D%7D%5D%7D%7D%7D%7D%5D,%22must_not%22:%5B%7B%22nested%22:%7B%22path%22:%22taxonomy.sections%22,%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22terms%22:%7B%22taxonomy.sections._id%22:%5B%22/food%22,%22/politics%22%5D%7D%7D%5D%7D%7D%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&_sourceExclude=related_content&sort=publish_date:desc',
+    'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22range%22:%7B%22last_updated_date%22:%7B%22gte%22:%22now-2d%22,%22lte%22:%22now%22%7D%7D%7D,%7B%22nested%22:%7B%22path%22:%22taxonomy.sections%22,%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22taxonomy.sections._website%22:%22demo%22%7D%7D%5D%7D%7D%7D%7D%5D,%22must_not%22:%5B%7B%22nested%22:%7B%22path%22:%22taxonomy.sections%22,%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22terms%22:%7B%22taxonomy.sections._id%22:%5B%22/food%22,%22/politics%22%5D%7D%7D%5D%7D%7D%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&sort=publish_date:desc&_sourceIncludes=canonical_url,canonical_website,content_elements,created_date,credits,description,display_date,duration,first_publish_date,headlines,last_updated_date,promo_image,promo_items,publish_date,streams,subheadlines,subtitles,subtype,taxonomy.primary_section,taxonomy.seo_keywords,taxonomy.tags,type,video_type,websites.demo',
   )
 })
 
 it('returns query by section and Exclude-Sections', () => {
   const query = resolver.default.resolve({
-    Section: '/sports/',
+    Section: '/sports/,/news/',
     Author: '',
     Keywords: '',
     'Tags-Text': '',
@@ -138,29 +184,7 @@ it('returns query by section and Exclude-Sections', () => {
     'Source-Include': '',
   })
   expect(query).toBe(
-    'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22range%22:%7B%22last_updated_date%22:%7B%22gte%22:%22now-2d%22,%22lte%22:%22now%22%7D%7D%7D,%7B%22nested%22:%7B%22path%22:%22taxonomy.sections%22,%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22taxonomy.sections._website%22:%22demo%22%7D%7D,%7B%22terms%22:%7B%22taxonomy.sections._id%22:%5B%22/sports%22%5D%7D%7D%5D%7D%7D%7D%7D%5D,%22must_not%22:%5B%7B%22nested%22:%7B%22path%22:%22taxonomy.sections%22,%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22terms%22:%7B%22taxonomy.sections._id%22:%5B%22/food%22,%22/politics%22%5D%7D%7D%5D%7D%7D%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&_sourceExclude=related_content&sort=publish_date:desc',
-  )
-})
-
-it('returns query by section with leading slash', () => {
-  const query = resolver.default.resolve({
-    Section: 'sports/',
-    Author: '',
-    Keywords: '',
-    'Tags-Text': '',
-    'Tags-Slug': '',
-    'arc-site': 'demo',
-    'Include-Terms': '',
-    'Exclude-Terms': '',
-    'Exclude-Sections': '',
-    'Feed-Size': '',
-    'Feed-Offset': '',
-    Sort: '',
-    'Source-Exclude': '',
-    'Source-Include': '',
-  })
-  expect(query).toBe(
-    'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22range%22:%7B%22last_updated_date%22:%7B%22gte%22:%22now-2d%22,%22lte%22:%22now%22%7D%7D%7D,%7B%22nested%22:%7B%22path%22:%22taxonomy.sections%22,%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22taxonomy.sections._website%22:%22demo%22%7D%7D,%7B%22terms%22:%7B%22taxonomy.sections._id%22:%5B%22/sports%22%5D%7D%7D%5D%7D%7D%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&_sourceExclude=related_content&sort=publish_date:desc',
+    'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22range%22:%7B%22last_updated_date%22:%7B%22gte%22:%22now-2d%22,%22lte%22:%22now%22%7D%7D%7D,%7B%22nested%22:%7B%22path%22:%22taxonomy.sections%22,%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22taxonomy.sections._website%22:%22demo%22%7D%7D,%7B%22terms%22:%7B%22taxonomy.sections._id%22:%5B%22/sports%22,%22/news%22%5D%7D%7D%5D%7D%7D%7D%7D%5D,%22must_not%22:%5B%7B%22nested%22:%7B%22path%22:%22taxonomy.sections%22,%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22terms%22:%7B%22taxonomy.sections._id%22:%5B%22/food%22,%22/politics%22%5D%7D%7D%5D%7D%7D%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&sort=publish_date:desc&_sourceIncludes=canonical_url,canonical_website,content_elements,created_date,credits,description,display_date,duration,first_publish_date,headlines,last_updated_date,promo_image,promo_items,publish_date,streams,subheadlines,subtitles,subtype,taxonomy.primary_section,taxonomy.seo_keywords,taxonomy.tags,type,video_type,websites.demo',
   )
 })
 
@@ -182,7 +206,7 @@ it('returns query by author', () => {
     'Source-Include': '',
   })
   expect(query).toBe(
-    'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22range%22:%7B%22last_updated_date%22:%7B%22gte%22:%22now-2d%22,%22lte%22:%22now%22%7D%7D%7D,%7B%22term%22:%7B%22credits.by._id%22:%22John%20Smith%22%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&_sourceExclude=related_content&sort=publish_date:desc',
+    'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22range%22:%7B%22last_updated_date%22:%7B%22gte%22:%22now-2d%22,%22lte%22:%22now%22%7D%7D%7D,%7B%22term%22:%7B%22credits.by._id%22:%22John%20Smith%22%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&sort=publish_date:desc&_sourceIncludes=canonical_url,canonical_website,content_elements,created_date,credits,description,display_date,duration,first_publish_date,headlines,last_updated_date,promo_image,promo_items,publish_date,streams,subheadlines,subtitles,subtype,taxonomy.primary_section,taxonomy.seo_keywords,taxonomy.tags,type,video_type,websites.demo',
   )
 })
 
@@ -204,7 +228,7 @@ it('returns query by author with slash', () => {
     'Source-Include': '',
   })
   expect(query).toBe(
-    'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22range%22:%7B%22last_updated_date%22:%7B%22gte%22:%22now-2d%22,%22lte%22:%22now%22%7D%7D%7D,%7B%22term%22:%7B%22credits.by._id%22:%22John%20Smith%22%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&_sourceExclude=related_content&sort=publish_date:desc',
+    'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22range%22:%7B%22last_updated_date%22:%7B%22gte%22:%22now-2d%22,%22lte%22:%22now%22%7D%7D%7D,%7B%22term%22:%7B%22credits.by._id%22:%22John%20Smith%22%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&sort=publish_date:desc&_sourceIncludes=canonical_url,canonical_website,content_elements,created_date,credits,description,display_date,duration,first_publish_date,headlines,last_updated_date,promo_image,promo_items,publish_date,streams,subheadlines,subtitles,subtype,taxonomy.primary_section,taxonomy.seo_keywords,taxonomy.tags,type,video_type,websites.demo',
   )
 })
 
@@ -226,7 +250,7 @@ it('returns query by keywords', () => {
     'Source-Include': '',
   })
   expect(query).toBe(
-    'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22range%22:%7B%22last_updated_date%22:%7B%22gte%22:%22now-2d%22,%22lte%22:%22now%22%7D%7D%7D,%7B%22simple_query_string%22:%7B%22query%22:%22%5C%22washington%20football%5C%22%20%7C%20%5C%22sports%5C%22%22,%22fields%22:%5B%22taxonomy.seo_keywords%22%5D%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&_sourceExclude=related_content&sort=publish_date:desc',
+    'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22range%22:%7B%22last_updated_date%22:%7B%22gte%22:%22now-2d%22,%22lte%22:%22now%22%7D%7D%7D,%7B%22simple_query_string%22:%7B%22query%22:%22%5C%22washington%20football%5C%22%20%7C%20%5C%22sports%5C%22%22,%22fields%22:%5B%22taxonomy.seo_keywords%22%5D%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&sort=publish_date:desc&_sourceIncludes=canonical_url,canonical_website,content_elements,created_date,credits,description,display_date,duration,first_publish_date,headlines,last_updated_date,promo_image,promo_items,publish_date,streams,subheadlines,subtitles,subtype,taxonomy.primary_section,taxonomy.seo_keywords,taxonomy.tags,type,video_type,websites.demo',
   )
 })
 
@@ -248,7 +272,7 @@ it('returns query by tags text', () => {
     'Source-Include': '',
   })
   expect(query).toBe(
-    'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22range%22:%7B%22last_updated_date%22:%7B%22gte%22:%22now-2d%22,%22lte%22:%22now%22%7D%7D%7D,%7B%22terms%22:%7B%22taxonomy.tags.text.raw%22:%5B%22football%22,%22sports%22%5D%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&_sourceExclude=related_content&sort=publish_date:desc',
+    'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22range%22:%7B%22last_updated_date%22:%7B%22gte%22:%22now-2d%22,%22lte%22:%22now%22%7D%7D%7D,%7B%22terms%22:%7B%22taxonomy.tags.text.raw%22:%5B%22football%22,%22sports%22%5D%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&sort=publish_date:desc&_sourceIncludes=canonical_url,canonical_website,content_elements,created_date,credits,description,display_date,duration,first_publish_date,headlines,last_updated_date,promo_image,promo_items,publish_date,streams,subheadlines,subtitles,subtype,taxonomy.primary_section,taxonomy.seo_keywords,taxonomy.tags,type,video_type,websites.demo',
   )
 })
 
@@ -270,6 +294,99 @@ it('returns query by tags slug', () => {
     'Source-Include': '',
   })
   expect(query).toBe(
-    'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22range%22:%7B%22last_updated_date%22:%7B%22gte%22:%22now-2d%22,%22lte%22:%22now%22%7D%7D%7D,%7B%22terms%22:%7B%22taxonomy.tags.slug%22:%5B%22football%22,%22sports%22%5D%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&_sourceExclude=related_content&sort=publish_date:desc',
+    'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22range%22:%7B%22last_updated_date%22:%7B%22gte%22:%22now-2d%22,%22lte%22:%22now%22%7D%7D%7D,%7B%22terms%22:%7B%22taxonomy.tags.slug%22:%5B%22football%22,%22sports%22%5D%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&sort=publish_date:desc&_sourceIncludes=canonical_url,canonical_website,content_elements,created_date,credits,description,display_date,duration,first_publish_date,headlines,last_updated_date,promo_image,promo_items,publish_date,streams,subheadlines,subtitles,subtype,taxonomy.primary_section,taxonomy.seo_keywords,taxonomy.tags,type,video_type,websites.demo',
   )
+})
+
+it('returns query by Include-Terms', () => {
+  const query = resolver.default.resolve({
+    Section: '',
+    Author: '',
+    Keywords: '',
+    'Tags-Text': '',
+    'Tags-Slug': '',
+    'arc-site': 'demo',
+    'Include-Terms': '[{"term":{"type":"video"}}]',
+    'Exclude-Terms': '',
+    'Exclude-Sections': '',
+    'Feed-Size': '',
+    'Feed-Offset': '',
+    Sort: '',
+    'Source-Exclude': '',
+    'Source-Include': '',
+  })
+  expect(query).not.toContain('%22term%22:%7B%22type%22:%22story%22')
+  expect(query).toContain('%22term%22:%7B%22type%22:%22video%22')
+})
+
+it('returns query by Exclude-Terms', () => {
+  const query = resolver.default.resolve({
+    Section: '',
+    Author: '',
+    Keywords: '',
+    'Tags-Text': '',
+    'Tags-Slug': '',
+    'arc-site': 'demo',
+    'Include-Terms': '',
+    'Exclude-Terms': '[{"term":{"subtype":"premium"}}]',
+    'Exclude-Sections': '',
+    'Feed-Size': '',
+    'Feed-Offset': '',
+    Sort: '',
+    'Source-Exclude': '',
+    'Source-Include': '',
+  })
+  expect(query).toContain('%22term%22:%7B%22type%22:%22story%22')
+  expect(query).toContain('%22term%22:%7B%22subtype%22:%22premium%22')
+})
+
+it('Test transform with empty data', () => {
+  const transform = resolver.default.transform(undefined, {
+    'arc-site': 'demo',
+  })
+  expect(transform).toBe(undefined)
+})
+
+// Every article should have a website and website_url. Only replace sections if !exist
+it('Test transform', () => {
+  const transform = resolver.default.transform(globalContent, {
+    'arc-site': 'demo',
+  })
+  expect(transform).toEqual({
+    content_elements: [
+      {
+        taxonomy: { sections: [{ _id: '/news' }], tags: [] },
+        website: 'demo',
+        website_url: '/news/test-article-1',
+        websites: {
+          demo: {
+            website_section: { _id: '/news' },
+            website_url: '/news/test-article-1',
+          },
+        },
+      },
+      {
+        taxonomy: { sections: [{ _id: '/sports' }], tags: [] },
+        website: 'demo',
+        website_url: '/news/test-article-2',
+        websites: {
+          demo: {
+            website_section: { _id: '/news' },
+            website_url: '/news/test-article-2',
+          },
+        },
+      },
+      {
+        taxonomy: { sections: [{ _id: '/news' }] },
+        website: 'demo',
+        website_url: '/news/test-article-3',
+        websites: {
+          demo: {
+            website_section: { _id: '/news' },
+            website_url: '/news/test-article-3',
+          },
+        },
+      },
+    ],
+  })
 })

--- a/blocks/feeds-source-content-api-by-day-block/sources/feeds-content-api-by-day.js
+++ b/blocks/feeds-source-content-api-by-day-block/sources/feeds-content-api-by-day.js
@@ -4,6 +4,31 @@ import getProperties from 'fusion:properties'
 import moment from 'moment'
 
 const contentURL = `${CONTENT_BASE}/content/v4/search/published/`
+// Excludes content_elements
+const ansFields = [
+  'canonical_url',
+  'canonical_website',
+  'created_date',
+  'credits',
+  'description',
+  'display_date',
+  'duration',
+  'first_publish_date',
+  'headlines',
+  'last_updated_date',
+  'promo_image',
+  'promo_items',
+  'publish_date',
+  'streams',
+  'subheadlines',
+  'subtitles',
+  'subtype',
+  'taxonomy.primary_section',
+  'taxonomy.seo_keywords',
+  'taxonomy.tags',
+  'type',
+  'video_type',
+]
 
 const options = {
   gzip: true,
@@ -23,12 +48,31 @@ const fetch = async (key = {}) => {
     website: key['arc-site'],
     size: 100,
     sort: key.sort || 'last_updated_date:desc',
-    _sourceExclude:
-      key['Source-Exclude'] ||
-      'address,additional_properties,content_elements,credits,geo,language,label,owner,planning,publishing,related_content,taxonomy,revision,source,subtype,version,workflow',
   }
 
-  if (key['Source-Include']) paramList._sourceInclude = key['Source-Include']
+  // limit C-API response to just this websites sections to reduce size
+  ansFields.push(`websites.${key['arc-site']}`)
+
+  if (key['Source-Exclude']) {
+    const sourceExcludes = []
+    key['Source-Exclude'].split(',').forEach((i) => {
+      if (i && ansFields.indexOf(i) !== -1) {
+        ansFields.splice(ansFields.indexOf(i), 1)
+      } else {
+        i && sourceExcludes.push(i)
+      }
+    })
+    if (sourceExcludes.length)
+      paramList._sourceExcludes = sourceExcludes.join(',')
+  }
+
+  if (key['Source-Include']) {
+    key['Source-Include']
+      .split(',')
+      .forEach((i) => i && !ansFields.includes(i) && ansFields.push(i))
+  }
+  paramList._sourceIncludes = ansFields.join(',')
+
   if (key['Include-Distributor-Name']) {
     paramList.include_distributor_name = key['Include-Distributor-Name']
   } else if (key['Exclude-Distributor-Name']) {
@@ -210,9 +254,29 @@ const fetch = async (key = {}) => {
   return { type: 'resp', content_elements: allContentElements }
 }
 
+const transform = (data, query) => {
+  const source = data || {}
+  const website = query['arc-site']
+  if (source.content_elements && source.content_elements.length) {
+    const transformedContent = source.content_elements.map((i) => {
+      if (i?.websites?.[website]?.website_section && !i?.taxonomy?.sections) {
+        if (!i.taxonomy) i.taxonomy = {}
+        i.taxonomy.sections = [i.websites[website].website_section]
+      }
+      if (i?.websites?.[website]?.website_url)
+        i.website_url = i.websites[website].website_url
+      i.website = website
+      return i
+    })
+    source.content_elements = transformedContent
+    return source
+  }
+}
+
 export default {
   fetch,
   schemaName: 'feeds',
+  transform,
   params: [
     {
       name: 'dateField',
@@ -245,13 +309,13 @@ export default {
       type: 'text',
     },
     {
-      name: 'Source-Exclude',
-      displayName: 'Source Exclude (list of ANS fields comma separated)',
+      name: 'Source-Include',
+      displayName: 'Source Include (list of ANS fields comma separated)',
       type: 'text',
     },
     {
-      name: 'Source-Include',
-      displayName: 'Source Include (list of ANS fields comma separated)',
+      name: 'Source-Exclude',
+      displayName: 'Source Exclude (list of ANS fields comma separated)',
       type: 'text',
     },
     {

--- a/blocks/feeds-source-content-api-by-day2-block/sources/feeds-content-api-by-day2.js
+++ b/blocks/feeds-source-content-api-by-day2-block/sources/feeds-content-api-by-day2.js
@@ -4,6 +4,31 @@ import getProperties from 'fusion:properties'
 import moment from 'moment'
 
 const contentURL = `${CONTENT_BASE}/content/v4/search/published/`
+// Excludes content_elements
+const ansFields = [
+  'canonical_url',
+  'canonical_website',
+  'created_date',
+  'credits',
+  'description',
+  'display_date',
+  'duration',
+  'first_publish_date',
+  'headlines',
+  'last_updated_date',
+  'promo_image',
+  'promo_items',
+  'publish_date',
+  'streams',
+  'subheadlines',
+  'subtitles',
+  'subtype',
+  'taxonomy.primary_section',
+  'taxonomy.seo_keywords',
+  'taxonomy.tags',
+  'type',
+  'video_type',
+]
 
 const options = {
   gzip: true,
@@ -23,12 +48,31 @@ const fetch = async (key = {}) => {
     website: key['arc-site'],
     size: 100,
     sort: key.sort || 'last_updated_date:desc',
-    _sourceExclude:
-      key['Source-Exclude'] ||
-      'address,additional_properties,content_elements,credits,geo,language,label,owner,planning,publishing,related_content,taxonomy,revision,source,subtype,version,workflow',
   }
 
-  if (key['Source-Include']) paramList._sourceInclude = key['Source-Include']
+  // limit C-API response to just this websites sections to reduce size
+  ansFields.push(`websites.${key['arc-site']}`)
+
+  if (key['Source-Exclude']) {
+    const sourceExcludes = []
+    key['Source-Exclude'].split(',').forEach((i) => {
+      if (i && ansFields.indexOf(i) !== -1) {
+        ansFields.splice(ansFields.indexOf(i), 1)
+      } else {
+        i && sourceExcludes.push(i)
+      }
+    })
+    if (sourceExcludes.length)
+      paramList._sourceExcludes = sourceExcludes.join(',')
+  }
+
+  if (key['Source-Include']) {
+    key['Source-Include']
+      .split(',')
+      .forEach((i) => i && !ansFields.includes(i) && ansFields.push(i))
+  }
+  paramList._sourceIncludes = ansFields.join(',')
+
   if (key['Include-Distributor-Name']) {
     paramList.include_distributor_name = key['Include-Distributor-Name']
   } else if (key['Exclude-Distributor-Name']) {
@@ -210,9 +254,29 @@ const fetch = async (key = {}) => {
   return { type: 'resp', content_elements: allContentElements }
 }
 
+const transform = (data, query) => {
+  const source = data || {}
+  const website = query['arc-site']
+  if (source.content_elements && source.content_elements.length) {
+    const transformedContent = source.content_elements.map((i) => {
+      if (i?.websites?.[website]?.website_section && !i?.taxonomy?.sections) {
+        if (!i.taxonomy) i.taxonomy = {}
+        i.taxonomy.sections = [i.websites[website].website_section]
+      }
+      if (i?.websites?.[website]?.website_url)
+        i.website_url = i.websites[website].website_url
+      i.website = website
+      return i
+    })
+    source.content_elements = transformedContent
+    return source
+  }
+}
+
 export default {
   fetch,
   schemaName: 'feeds',
+  transform,
   params: [
     {
       name: 'dateField',
@@ -245,13 +309,13 @@ export default {
       type: 'text',
     },
     {
-      name: 'Source-Exclude',
-      displayName: 'Source Exclude (list of ANS fields comma separated)',
+      name: 'Source-Include',
+      displayName: 'Source Include (list of ANS fields comma separated)',
       type: 'text',
     },
     {
-      name: 'Source-Include',
-      displayName: 'Source Include (list of ANS fields comma separated)',
+      name: 'Source-Exclude',
+      displayName: 'Source Exclude (list of ANS fields comma separated)',
       type: 'text',
     },
     {

--- a/blocks/feeds-source-content-api-by-day3-block/sources/feeds-content-api-by-day3.js
+++ b/blocks/feeds-source-content-api-by-day3-block/sources/feeds-content-api-by-day3.js
@@ -4,6 +4,31 @@ import getProperties from 'fusion:properties'
 import moment from 'moment'
 
 const contentURL = `${CONTENT_BASE}/content/v4/search/published/`
+// Excludes content_elements
+const ansFields = [
+  'canonical_url',
+  'canonical_website',
+  'created_date',
+  'credits',
+  'description',
+  'display_date',
+  'duration',
+  'first_publish_date',
+  'headlines',
+  'last_updated_date',
+  'promo_image',
+  'promo_items',
+  'publish_date',
+  'streams',
+  'subheadlines',
+  'subtitles',
+  'subtype',
+  'taxonomy.primary_section',
+  'taxonomy.seo_keywords',
+  'taxonomy.tags',
+  'type',
+  'video_type',
+]
 
 const options = {
   gzip: true,
@@ -23,12 +48,31 @@ const fetch = async (key = {}) => {
     website: key['arc-site'],
     size: 100,
     sort: key.sort || 'last_updated_date:desc',
-    _sourceExclude:
-      key['Source-Exclude'] ||
-      'address,additional_properties,content_elements,credits,geo,language,label,owner,planning,publishing,related_content,taxonomy,revision,source,subtype,version,workflow',
   }
 
-  if (key['Source-Include']) paramList._sourceInclude = key['Source-Include']
+  // limit C-API response to just this websites sections to reduce size
+  ansFields.push(`websites.${key['arc-site']}`)
+
+  if (key['Source-Exclude']) {
+    const sourceExcludes = []
+    key['Source-Exclude'].split(',').forEach((i) => {
+      if (i && ansFields.indexOf(i) !== -1) {
+        ansFields.splice(ansFields.indexOf(i), 1)
+      } else {
+        i && sourceExcludes.push(i)
+      }
+    })
+    if (sourceExcludes.length)
+      paramList._sourceExcludes = sourceExcludes.join(',')
+  }
+
+  if (key['Source-Include']) {
+    key['Source-Include']
+      .split(',')
+      .forEach((i) => i && !ansFields.includes(i) && ansFields.push(i))
+  }
+  paramList._sourceIncludes = ansFields.join(',')
+
   if (key['Include-Distributor-Name']) {
     paramList.include_distributor_name = key['Include-Distributor-Name']
   } else if (key['Exclude-Distributor-Name']) {
@@ -210,9 +254,29 @@ const fetch = async (key = {}) => {
   return { type: 'resp', content_elements: allContentElements }
 }
 
+const transform = (data, query) => {
+  const source = data || {}
+  const website = query['arc-site']
+  if (source.content_elements && source.content_elements.length) {
+    const transformedContent = source.content_elements.map((i) => {
+      if (i?.websites?.[website]?.website_section && !i?.taxonomy?.sections) {
+        if (!i.taxonomy) i.taxonomy = {}
+        i.taxonomy.sections = [i.websites[website].website_section]
+      }
+      if (i?.websites?.[website]?.website_url)
+        i.website_url = i.websites[website].website_url
+      i.website = website
+      return i
+    })
+    source.content_elements = transformedContent
+    return source
+  }
+}
+
 export default {
   fetch,
   schemaName: 'feeds',
+  transform,
   params: [
     {
       name: 'dateField',
@@ -245,13 +309,13 @@ export default {
       type: 'text',
     },
     {
-      name: 'Source-Exclude',
-      displayName: 'Source Exclude (list of ANS fields comma separated)',
+      name: 'Source-Include',
+      displayName: 'Source Include (list of ANS fields comma separated)',
       type: 'text',
     },
     {
-      name: 'Source-Include',
-      displayName: 'Source Include (list of ANS fields comma separated)',
+      name: 'Source-Exclude',
+      displayName: 'Source Exclude (list of ANS fields comma separated)',
       type: 'text',
     },
     {

--- a/utils/content-source-utils/README.md
+++ b/utils/content-source-utils/README.md
@@ -1,0 +1,26 @@
+# Feeds Content Source Utils
+
+A collection of globals and helper functions shared by content sources
+
+## Globals
+
+- defaultANSFields - Array of ANS fields to use in \_source_includes parameter
+
+  To reduce the Content-API response size, only fields used are included. Multi-site
+  clients can have a lot of data in taxonomy.sections. Multiple records for each website.
+  That is why it's not includes, the section will come from websites.
+
+  - The content source needs to add the calling website into this list `websites.{arc-site}`
+  - content_elements is not included. It needs to be added by the content_source if needed.
+
+- validANSDates - Array of valid ANS date fields
+
+## functions
+
+- formatSections - takes a comma separated string of sections, returns an object to use in the DSL
+- generateDistributor - looks for the 4 distributor params and returns up to one param
+- generateParamList - takes an object of key:values, and returns a string of key=value to use as url parameters
+- transform - put websites data into expected locations
+  move websites.{website}.website_section to taxonomy.sections
+  move websites.{website}.website_url to root
+  create website at root

--- a/utils/content-source-utils/package-lock.json
+++ b/utils/content-source-utils/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "@wpmedia/feeds-content-source-utils",
+  "version": "1.0.7",
+  "lockfileVersion": 1
+}

--- a/utils/content-source-utils/package.json
+++ b/utils/content-source-utils/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@wpmedia/feeds-content-source-utils",
+  "version": "1.0.7",
+  "description": "Shared content source globals and functions",
+  "main": "dist/feeds-content-source-utils.cjs.js",
+  "module": "dist/feeds-content-source-utils.esm.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/WPMedia/feed-components.git",
+    "directory": "utils/content-source-utils"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/",
+    "access": "restricted"
+  },
+  "author": "Tim Kosmider",
+  "license": "CC-BY-NC-ND-4.0",
+  "dependencies": {}
+}

--- a/utils/content-source-utils/src/formatSections.js
+++ b/utils/content-source-utils/src/formatSections.js
@@ -1,0 +1,11 @@
+export const formatSections = (section) => {
+  const sectionArray = section
+    .split(',')
+    .map((item) => item.trim().replace(/\/$/, ''))
+    .map((item) => (item.startsWith('/') ? item : `/${item}`))
+  return {
+    terms: {
+      'taxonomy.sections._id': sectionArray,
+    },
+  }
+}

--- a/utils/content-source-utils/src/formatSections.test.js
+++ b/utils/content-source-utils/src/formatSections.test.js
@@ -1,0 +1,16 @@
+// eslint-disable-next-line no-unused-vars
+import { formatSections } from './'
+
+it('Test with single section data no slash', () => {
+  const sections = formatSections('test')
+  expect(sections).toEqual({ terms: { 'taxonomy.sections._id': ['/test'] } })
+})
+
+it('Test with multiple section and subsection data no slash', () => {
+  const sections = formatSections('world/uk/,/sports/highschool/football/')
+  expect(sections).toEqual({
+    terms: {
+      'taxonomy.sections._id': ['/world/uk', '/sports/highschool/football'],
+    },
+  })
+})

--- a/utils/content-source-utils/src/generateDistributor.js
+++ b/utils/content-source-utils/src/generateDistributor.js
@@ -1,0 +1,12 @@
+export const generateDistributor = (key, paramList) => {
+  if (key['Include-Distributor-Name']) {
+    paramList.include_distributor_name = key['Include-Distributor-Name']
+  } else if (key['Exclude-Distributor-Name']) {
+    paramList.exclude_distributor_name = key['Exclude-Distributor-Name']
+  } else if (key['Include-Distributor-Category']) {
+    paramList.include_distributor_category = key['Include-Distributor-Category']
+  } else if (key['Exclude-Distributor-Category']) {
+    paramList.exclude_distributor_category = key['Exclude-Distributor-Category']
+  }
+  return paramList
+}

--- a/utils/content-source-utils/src/generateDistributor.test.js
+++ b/utils/content-source-utils/src/generateDistributor.test.js
@@ -1,0 +1,79 @@
+// eslint-disable-next-line no-unused-vars
+import { generateDistributor } from './'
+
+const defaultParams = { size: 100, sort: 'display_date:desc' }
+
+it('Test distributor with empty data', () => {
+  const paramList = generateDistributor({}, {})
+  expect(paramList).toEqual({})
+})
+
+it('Test distributor works with existing data', () => {
+  const paramList = generateDistributor({}, defaultParams)
+  expect(paramList).toEqual(defaultParams)
+})
+
+it('Test distributor name', () => {
+  let paramList = defaultParams
+  paramList = generateDistributor(
+    { 'Include-Distributor-Name': 'AP,reuters' },
+    paramList,
+  )
+  expect(paramList).toEqual({
+    ...defaultParams,
+    include_distributor_name: 'AP,reuters',
+  })
+})
+
+it('Test Exclude distributor name', () => {
+  let paramList = defaultParams
+  paramList = generateDistributor(
+    { 'Exclude-Distributor-Name': 'AP,reuters' },
+    paramList,
+  )
+  expect(paramList).toEqual({
+    ...defaultParams,
+    exclude_distributor_name: 'AP,reuters',
+  })
+})
+
+it('Test distributor categoru', () => {
+  let paramList = defaultParams
+  paramList = generateDistributor(
+    { 'Include-Distributor-Category': 'wires' },
+    paramList,
+  )
+  expect(paramList).toEqual({
+    ...defaultParams,
+    include_distributor_category: 'wires',
+  })
+})
+
+it('Test Exclude distributor category', () => {
+  let paramList = defaultParams
+  paramList = generateDistributor(
+    { 'Exclude-Distributor-Category': 'wires' },
+    paramList,
+  )
+  expect(paramList).toEqual({
+    ...defaultParams,
+    include_distributor_category: 'wires',
+  })
+})
+
+it('Test combination of params', () => {
+  let paramList = defaultParams
+  paramList = generateDistributor(
+    {
+      'Include-Distributor-Name': 'AP',
+      'Exclude-Distributor-Name': 'reuters',
+      'Include-Distributor-Category': 'wires',
+      'Exclude-Distributor-Category': 'premium',
+    },
+    paramList,
+  )
+  expect(paramList).toEqual({
+    ...defaultParams,
+    include_distributor_name: 'AP',
+  })
+})

--- a/utils/content-source-utils/src/generateParamList.js
+++ b/utils/content-source-utils/src/generateParamList.js
@@ -1,0 +1,7 @@
+export const genParams = (paramList) => {
+  return Object.keys(paramList)
+    .reduce((acc, key) => {
+      return [...acc, `${key}=${paramList[key]}`]
+    }, [])
+    .join('&')
+}

--- a/utils/content-source-utils/src/generateParamList.test.js
+++ b/utils/content-source-utils/src/generateParamList.test.js
@@ -1,0 +1,14 @@
+// eslint-disable-next-line no-unused-vars
+import { genParams } from './'
+
+const defaultParams = { size: 100, sort: 'display_date:desc' }
+
+it('Test with empty data', () => {
+  const paramList = genParams({})
+  expect(paramList).toEqual('')
+})
+
+it('Test with data', () => {
+  const paramList = genParams(defaultParams)
+  expect(paramList).toEqual('size=100&sort=display_date:desc')
+})

--- a/utils/content-source-utils/src/index.js
+++ b/utils/content-source-utils/src/index.js
@@ -1,0 +1,37 @@
+export * from './formatSections'
+export * from './generateDistributor'
+export * from './generateParamList'
+export * from './transform'
+
+export const defaultANSFields = [
+  'canonical_url',
+  'canonical_website',
+  'created_date',
+  'credits',
+  'description',
+  'display_date',
+  'duration',
+  'first_publish_date',
+  'headlines',
+  'last_updated_date',
+  'promo_image',
+  'promo_items',
+  'publish_date',
+  'streams',
+  'subheadlines',
+  'subtitles',
+  'subtype',
+  'taxonomy.primary_section',
+  'taxonomy.seo_keywords',
+  'taxonomy.tags',
+  'type',
+  'video_type',
+]
+
+export const validANSDates = [
+  'created_date',
+  'last_updated_date',
+  'display_date',
+  'first_publish_date',
+  'publish_date',
+]

--- a/utils/content-source-utils/src/transform.js
+++ b/utils/content-source-utils/src/transform.js
@@ -1,0 +1,18 @@
+export const transform = (data, query) => {
+  const source = data || {}
+  const website = query['arc-site']
+  if (source.content_elements && source.content_elements.length) {
+    const transformedContent = source.content_elements.map((i) => {
+      if (i?.websites?.[website]?.website_section && !i?.taxonomy?.sections) {
+        if (!i.taxonomy) i.taxonomy = {}
+        i.taxonomy.sections = [i.websites[website].website_section]
+      }
+      if (i?.websites?.[website]?.website_url)
+        i.website_url = i.websites[website].website_url
+      i.website = website
+      return i
+    })
+    source.content_elements = transformedContent
+    return source
+  }
+}

--- a/utils/content-source-utils/src/transform.test.js
+++ b/utils/content-source-utils/src/transform.test.js
@@ -1,0 +1,95 @@
+// eslint-disable-next-line no-unused-vars
+import { transform } from './'
+
+const globalContent = {
+  content_elements: [
+    {
+      taxonomy: {
+        tags: [],
+      },
+      websites: {
+        demo: {
+          website_url: '/news/test-article-1',
+          website_section: {
+            _id: '/news',
+          },
+        },
+      },
+    },
+    {
+      taxonomy: {
+        tags: [],
+        sections: [{ _id: '/sports' }],
+      },
+      websites: {
+        demo: {
+          website_url: '/news/test-article-2',
+          website_section: {
+            _id: '/news',
+          },
+        },
+      },
+    },
+    {
+      websites: {
+        demo: {
+          website_url: '/news/test-article-3',
+          website_section: {
+            _id: '/news',
+          },
+        },
+      },
+    },
+  ],
+}
+
+it('Test transform with empty data', () => {
+  const transformedANS = transform(undefined, {
+    'arc-site': 'demo',
+  })
+  expect(transformedANS).toBe(undefined)
+})
+
+// Every article should have a website and website_url. Only replace sections if !exist
+it('Test transform', () => {
+  const transformedANS = transform(globalContent, {
+    'arc-site': 'demo',
+  })
+  expect(transformedANS).toEqual({
+    content_elements: [
+      {
+        taxonomy: { sections: [{ _id: '/news' }], tags: [] },
+        website: 'demo',
+        website_url: '/news/test-article-1',
+        websites: {
+          demo: {
+            website_section: { _id: '/news' },
+            website_url: '/news/test-article-1',
+          },
+        },
+      },
+      {
+        taxonomy: { sections: [{ _id: '/sports' }], tags: [] },
+        website: 'demo',
+        website_url: '/news/test-article-2',
+        websites: {
+          demo: {
+            website_section: { _id: '/news' },
+            website_url: '/news/test-article-2',
+          },
+        },
+      },
+      {
+        taxonomy: { sections: [{ _id: '/news' }] },
+        website: 'demo',
+        website_url: '/news/test-article-3',
+        websites: {
+          demo: {
+            website_section: { _id: '/news' },
+            website_url: '/news/test-article-3',
+          },
+        },
+      },
+    ],
+  })
+})


### PR DESCRIPTION
Use _sourceIncludes and _sourceExcludes to remove all websites but calling one.
Use hardcoded list ansFields = [
    'canonical_url',
    'canonical_website',
    'content_elements',
    'created_date',
    'credits',
    'description',
    'display_date',
    'duration',
    'first_publish_date',
    'headlines',
    'last_updated_date',
    'promo_image',
    'promo_items',
    'publish_date',
    'streams',
    'subheadlines',
    'subtitles',
    'subtype',
    'taxonomy.primary_section',
    'taxonomy.seo_keywords',
    'taxonomy.tags',
    'type',
    'video_type',
  ]
Add website.{arc-site} to only include calling website
remove fields in sourceExcludes from ansFields
Add fields in sourceIncludes from ansFields
use transform to move website.*.website_section to taxonomy.sections
add website_url and website that are missing from use of sourceInclude