### PR TITLE
Aio 720

### DIFF
--- a/.changeset/purple-ways-juggle.md
+++ b/.changeset/purple-ways-juggle.md
@@ -1,0 +1,9 @@
+---
+'@wpmedia/feeds-source-collections-block': patch
+'@wpmedia/feeds-source-content-api-block': patch
+'@wpmedia/feeds-source-content-api-by-day-block': patch
+'@wpmedia/feeds-source-content-api-by-day2-block': patch
+'@wpmedia/feeds-source-content-api-by-day3-block': patch
+---
+
+Remove all websites but calling website

--- a/.changeset/short-jobs-speak.md
+++ b/.changeset/short-jobs-speak.md
@@ -1,0 +1,18 @@
+---
+'@wpmedia/ans-feature-block': patch
+'@wpmedia/mrss-feature-block': patch
+'@wpmedia/rss-alexa-feature-block': patch
+'@wpmedia/rss-fbia-feature-block': patch
+'@wpmedia/rss-feature-block': patch
+'@wpmedia/rss-flipboard-feature-block': patch
+'@wpmedia/rss-google-news-feature-block': patch
+'@wpmedia/rss-msn-feature-block': patch
+'@wpmedia/sitemap-feature-block': patch
+'@wpmedia/sitemap-index-by-day-feature-block': patch
+'@wpmedia/sitemap-index-feature-block': patch
+'@wpmedia/sitemap-news-feature-block': patch
+'@wpmedia/sitemap-section-index-feature-block': patch
+'@wpmedia/sitemap-video-feature-block': patch
+---
+
+Update utils to 1.0.7

--- a/blocks/ans-feature-block/package-lock.json
+++ b/blocks/ans-feature-block/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@wpmedia/feeds-resizer": {
-      "version": "1.0.6",
-      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-resizer/1.0.6/0ce63a556ffef4fe4176e2a48973b1cd63812783bed5ac47220755a83334d702",
-      "integrity": "sha512-V9ShtU87YdAZjdWC2AsWKhR1E8Q7CRcJ747lPy51p7oqwlWCfEX8OqCFfNJSzrAcHqNYTzaa4cBgDso5lQEYFw==",
+      "version": "1.0.7",
+      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-resizer/1.0.7/a46142ce4e537dc88a41f138b3a74d39bc7c819667bc56ebd52b2838a527358e",
+      "integrity": "sha512-R0GiWxkLStpIn1hkiOJHiPZ0nzpz4LrpKTNQGiPbobKXfqEfPSl/GJBKZfZGxa7MBV1TQqWkoHLudPHxpxbngA==",
       "requires": {
         "thumbor-lite": "^0.1.8"
       }

--- a/blocks/ans-feature-block/package.json
+++ b/blocks/ans-feature-block/package.json
@@ -22,6 +22,6 @@
   ],
   "homepage": "https://github.com/WPMedia/feed-components#readme",
   "dependencies": {
-    "@wpmedia/feeds-resizer": "^1.0.6"
+    "@wpmedia/feeds-resizer": "^1.0.7"
   }
 }

--- a/blocks/feeds-source-collections-block/package-lock.json
+++ b/blocks/feeds-source-collections-block/package-lock.json
@@ -4,6 +4,11 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@wpmedia/feeds-content-source-utils": {
+      "version": "1.0.7",
+      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-content-source-utils/1.0.7/336af8202408caecbe3ffebe3c92319ca35756af67decb284c7485ac3f3f6fa1",
+      "integrity": "sha512-p+Q2sHYnKiA2rr/B9cZgXsMPbitxC+nbEHpzXYfSZHh82HzBRx8QeMRn9g0VZr1wdYJUMP9dLX9zctrSK0PCOQ=="
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",

--- a/blocks/feeds-source-collections-block/package.json
+++ b/blocks/feeds-source-collections-block/package.json
@@ -23,7 +23,9 @@
     "Tim Kosmider <timothy.kosmider@washpost.com>"
   ],
   "homepage": "https://github.com/WPMedia/feed-components#readme",
-  "dependencies": {},
+  "dependencies": {
+    "@wpmedia/feeds-content-source-utils": "1.0.1"
+  },
   "devDependencies": {
     "prop-types": "^15.7.2"
   }

--- a/blocks/feeds-source-collections-block/package.json
+++ b/blocks/feeds-source-collections-block/package.json
@@ -24,7 +24,7 @@
   ],
   "homepage": "https://github.com/WPMedia/feed-components#readme",
   "dependencies": {
-    "@wpmedia/feeds-content-source-utils": "1.0.1"
+    "@wpmedia/feeds-content-source-utils": "1.0.7"
   },
   "devDependencies": {
     "prop-types": "^15.7.2"

--- a/blocks/feeds-source-collections-block/sources/collections.js
+++ b/blocks/feeds-source-collections-block/sources/collections.js
@@ -1,55 +1,6 @@
 import request from 'request-promise-native'
 import { CONTENT_BASE, ARC_ACCESS_TOKEN } from 'fusion:environment'
 
-const options = {
-  gzip: true,
-  json: true,
-  auth: { bearer: ARC_ACCESS_TOKEN },
-}
-
-const ansFields = [
-  'canonical_url',
-  'canonical_website',
-  'content_elements',
-  'created_date',
-  'credits',
-  'description',
-  'display_date',
-  'duration',
-  'first_publish_date',
-  'headlines',
-  'last_updated_date',
-  'promo_image',
-  'promo_items',
-  'publish_date',
-  'source',
-  'streams',
-  'subheadlines',
-  'subtitles',
-  'subtype',
-  'taxonomy.primary_section',
-  'taxonomy.seo_keywords',
-  'taxonomy.tags',
-  'type',
-  'video_type',
-]
-
-const sortStories = (idsResp, collectionResp, ids, site) => {
-  idsResp.content_elements.forEach((item) => {
-    const storyIndex = ids.indexOf(item._id)
-    // transform websites to sections
-    if (item?.websites?.[site]?.website_section && !item?.taxonomy?.sections) {
-      if (!item.taxonomy) item.taxonomy = {}
-      item.taxonomy.sections = [item.websites[site].website_section]
-    }
-    if (item?.websites?.[site]?.website_url)
-      item.website_url = item.websites[site].website_url
-    item.website = site
-    collectionResp.content_elements.splice(storyIndex, 1, item)
-  })
-  return collectionResp
-}
-
 const fetch = async (key = {}) => {
   const {
     'arc-site': site,
@@ -68,6 +19,58 @@ const fetch = async (key = {}) => {
     published: true,
     ...(id && { _id: id }),
     ...(contentAlias && { content_alias: contentAlias }),
+  }
+
+  const options = {
+    gzip: true,
+    json: true,
+    auth: { bearer: ARC_ACCESS_TOKEN },
+  }
+
+  const ansFields = [
+    'canonical_url',
+    'canonical_website',
+    'content_elements',
+    'created_date',
+    'credits',
+    'description',
+    'display_date',
+    'duration',
+    'first_publish_date',
+    'headlines',
+    'last_updated_date',
+    'promo_image',
+    'promo_items',
+    'publish_date',
+    'source',
+    'streams',
+    'subheadlines',
+    'subtitles',
+    'subtype',
+    'taxonomy.primary_section',
+    'taxonomy.seo_keywords',
+    'taxonomy.tags',
+    'type',
+    'video_type',
+  ]
+
+  const sortStories = (idsResp, collectionResp, ids, site) => {
+    idsResp.content_elements.forEach((item) => {
+      const storyIndex = ids.indexOf(item._id)
+      // transform websites to sections
+      if (
+        item?.websites?.[site]?.website_section &&
+        !item?.taxonomy?.sections
+      ) {
+        if (!item.taxonomy) item.taxonomy = {}
+        item.taxonomy.sections = [item.websites[site].website_section]
+      }
+      if (item?.websites?.[site]?.website_url)
+        item.website_url = item.websites[site].website_url
+      item.website = site
+      collectionResp.content_elements.splice(storyIndex, 1, item)
+    })
+    return collectionResp
   }
 
   // limit C-API response to just this websites sections to reduce size

--- a/blocks/feeds-source-collections-block/sources/collections.js
+++ b/blocks/feeds-source-collections-block/sources/collections.js
@@ -1,5 +1,6 @@
 import request from 'request-promise-native'
 import { CONTENT_BASE, ARC_ACCESS_TOKEN } from 'fusion:environment'
+import { defaultANSFields } from '@wpmedia/feeds-content-source-utils'
 
 const fetch = async (key = {}) => {
   const {
@@ -27,32 +28,7 @@ const fetch = async (key = {}) => {
     auth: { bearer: ARC_ACCESS_TOKEN },
   }
 
-  const ansFields = [
-    'canonical_url',
-    'canonical_website',
-    'content_elements',
-    'created_date',
-    'credits',
-    'description',
-    'display_date',
-    'duration',
-    'first_publish_date',
-    'headlines',
-    'last_updated_date',
-    'promo_image',
-    'promo_items',
-    'publish_date',
-    'source',
-    'streams',
-    'subheadlines',
-    'subtitles',
-    'subtype',
-    'taxonomy.primary_section',
-    'taxonomy.seo_keywords',
-    'taxonomy.tags',
-    'type',
-    'video_type',
-  ]
+  const ansFields = [...defaultANSFields, 'content_elements']
 
   const sortStories = (idsResp, collectionResp, ids, site) => {
     idsResp.content_elements.forEach((item) => {

--- a/blocks/feeds-source-content-api-block/package-lock.json
+++ b/blocks/feeds-source-content-api-block/package-lock.json
@@ -4,6 +4,11 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@wpmedia/feeds-content-source-utils": {
+      "version": "1.0.7",
+      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-content-source-utils/1.0.7/336af8202408caecbe3ffebe3c92319ca35756af67decb284c7485ac3f3f6fa1",
+      "integrity": "sha512-p+Q2sHYnKiA2rr/B9cZgXsMPbitxC+nbEHpzXYfSZHh82HzBRx8QeMRn9g0VZr1wdYJUMP9dLX9zctrSK0PCOQ=="
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",

--- a/blocks/feeds-source-content-api-block/package.json
+++ b/blocks/feeds-source-content-api-block/package.json
@@ -23,7 +23,7 @@
   ],
   "homepage": "https://github.com/WPMedia/feed-components#readme",
   "dependencies": {
-    "@wpmedia/feeds-content-source-utils": "1.0.1"
+    "@wpmedia/feeds-content-source-utils": "1.0.7"
   },
   "devDependencies": {
     "prop-types": "^15.7.2"

--- a/blocks/feeds-source-content-api-block/package.json
+++ b/blocks/feeds-source-content-api-block/package.json
@@ -22,7 +22,9 @@
     "Tim Kosmider <tim.kosmider@washpost.com>"
   ],
   "homepage": "https://github.com/WPMedia/feed-components#readme",
-  "dependencies": {},
+  "dependencies": {
+    "@wpmedia/feeds-content-source-utils": "1.0.1"
+  },
   "devDependencies": {
     "prop-types": "^15.7.2"
   }

--- a/blocks/feeds-source-content-api-block/sources/feeds-content-api.js
+++ b/blocks/feeds-source-content-api-block/sources/feeds-content-api.js
@@ -4,12 +4,13 @@ import {
   defaultANSFields,
   formatSections,
   generateDistributor,
-  generateParamList,
+  genParams,
   transform,
-} from '@wpmedia/feeds-source-content-api-block'
+} from '@wpmedia/feeds-content-source-utils'
 
 const resolve = function resolve(key) {
   const requestUri = `${CONTENT_BASE}/content/v4/search/published`
+  // const ansFields = [...defaultANSFields, 'content_elements']
   const ansFields = [...defaultANSFields, 'content_elements']
 
   const paramList = {
@@ -18,6 +19,7 @@ const resolve = function resolve(key) {
     from: key['Feed-Offset'] || '0',
     sort: key.Sort || 'publish_date:desc',
   }
+  generateDistributor(key, paramList)
 
   // limit C-API response to just this websites sections to reduce size
   ansFields.push(`websites.${key['arc-site']}`)
@@ -41,8 +43,6 @@ const resolve = function resolve(key) {
       .forEach((i) => i && !ansFields.includes(i) && ansFields.push(i))
   }
   paramList._sourceIncludes = ansFields.join(',')
-
-  generateDistributor(key, paramList)
 
   // basic ES query
   const body = {
@@ -188,7 +188,7 @@ const resolve = function resolve(key) {
   }
 
   const encodedBody = encodeURI(JSON.stringify(body))
-  return `${requestUri}?body=${encodedBody}&${generateParamList(paramList)}`
+  return `${requestUri}?body=${encodedBody}&${genParams(paramList)}`
 }
 
 export default {

--- a/blocks/feeds-source-content-api-block/sources/feeds-content-api.test.js
+++ b/blocks/feeds-source-content-api-block/sources/feeds-content-api.test.js
@@ -2,48 +2,6 @@
 import Consumer from 'fusion:consumer'
 const resolver = require('./feeds-content-api')
 
-const globalContent = {
-  content_elements: [
-    {
-      taxonomy: {
-        tags: [],
-      },
-      websites: {
-        demo: {
-          website_url: '/news/test-article-1',
-          website_section: {
-            _id: '/news',
-          },
-        },
-      },
-    },
-    {
-      taxonomy: {
-        tags: [],
-        sections: [{ _id: '/sports' }],
-      },
-      websites: {
-        demo: {
-          website_url: '/news/test-article-2',
-          website_section: {
-            _id: '/news',
-          },
-        },
-      },
-    },
-    {
-      websites: {
-        demo: {
-          website_url: '/news/test-article-3',
-          website_section: {
-            _id: '/news',
-          },
-        },
-      },
-    },
-  ],
-}
-
 it('validate schemaName', () => {
   expect(resolver.default.schemaName).toBe('feeds')
 })
@@ -338,55 +296,4 @@ it('returns query by Exclude-Terms', () => {
   })
   expect(query).toContain('%22term%22:%7B%22type%22:%22story%22')
   expect(query).toContain('%22term%22:%7B%22subtype%22:%22premium%22')
-})
-
-it('Test transform with empty data', () => {
-  const transform = resolver.default.transform(undefined, {
-    'arc-site': 'demo',
-  })
-  expect(transform).toBe(undefined)
-})
-
-// Every article should have a website and website_url. Only replace sections if !exist
-it('Test transform', () => {
-  const transform = resolver.default.transform(globalContent, {
-    'arc-site': 'demo',
-  })
-  expect(transform).toEqual({
-    content_elements: [
-      {
-        taxonomy: { sections: [{ _id: '/news' }], tags: [] },
-        website: 'demo',
-        website_url: '/news/test-article-1',
-        websites: {
-          demo: {
-            website_section: { _id: '/news' },
-            website_url: '/news/test-article-1',
-          },
-        },
-      },
-      {
-        taxonomy: { sections: [{ _id: '/sports' }], tags: [] },
-        website: 'demo',
-        website_url: '/news/test-article-2',
-        websites: {
-          demo: {
-            website_section: { _id: '/news' },
-            website_url: '/news/test-article-2',
-          },
-        },
-      },
-      {
-        taxonomy: { sections: [{ _id: '/news' }] },
-        website: 'demo',
-        website_url: '/news/test-article-3',
-        websites: {
-          demo: {
-            website_section: { _id: '/news' },
-            website_url: '/news/test-article-3',
-          },
-        },
-      },
-    ],
-  })
 })

--- a/blocks/feeds-source-content-api-block/sources/feeds-content-api.test.js
+++ b/blocks/feeds-source-content-api-block/sources/feeds-content-api.test.js
@@ -2,6 +2,48 @@
 import Consumer from 'fusion:consumer'
 const resolver = require('./feeds-content-api')
 
+const globalContent = {
+  content_elements: [
+    {
+      taxonomy: {
+        tags: [],
+      },
+      websites: {
+        demo: {
+          website_url: '/news/test-article-1',
+          website_section: {
+            _id: '/news',
+          },
+        },
+      },
+    },
+    {
+      taxonomy: {
+        tags: [],
+        sections: [{ _id: '/sports' }],
+      },
+      websites: {
+        demo: {
+          website_url: '/news/test-article-2',
+          website_section: {
+            _id: '/news',
+          },
+        },
+      },
+    },
+    {
+      websites: {
+        demo: {
+          website_url: '/news/test-article-3',
+          website_section: {
+            _id: '/news',
+          },
+        },
+      },
+    },
+  ],
+}
+
 it('validate schemaName', () => {
   expect(resolver.default.schemaName).toBe('feeds')
 })
@@ -46,7 +88,7 @@ it('returns query with default values', () => {
     'Source-Include': '',
   })
   expect(query).toBe(
-    'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22range%22:%7B%22last_updated_date%22:%7B%22gte%22:%22now-2d%22,%22lte%22:%22now%22%7D%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&_sourceExclude=related_content&sort=publish_date:desc',
+    'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22range%22:%7B%22last_updated_date%22:%7B%22gte%22:%22now-2d%22,%22lte%22:%22now%22%7D%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&sort=publish_date:desc&_sourceIncludes=canonical_url,canonical_website,content_elements,created_date,credits,description,display_date,duration,first_publish_date,headlines,last_updated_date,promo_image,promo_items,publish_date,streams,subheadlines,subtitles,subtype,taxonomy.primary_section,taxonomy.seo_keywords,taxonomy.tags,type,video_type,websites.demo',
   )
 })
 
@@ -64,16 +106,22 @@ it('returns query with parameter values', () => {
     'Feed-Size': '25',
     'Feed-Offset': '3',
     Sort: 'display_date:asc',
-    'Source-Exclude': 'headlines,description,website_url',
-    'Source-Include': 'related_items,content_elements,taxonomy',
+    'Source-Exclude': 'content_elements,taxonomy',
+    'Source-Include': 'source,owner',
     'Include-Distributor-Name': 'AP',
     'Exclude-Distributor-Name': 'paid',
     'Include-Distributor-Category': 'promotions',
     'Exclude-Distributor-Category': 'wires',
   })
-  expect(query).toBe(
-    'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22range%22:%7B%22last_updated_date%22:%7B%22gte%22:%22now-2d%22,%22lte%22:%22now%22%7D%7D%7D%5D%7D%7D%7D&website=demo&size=25&from=3&_sourceExclude=headlines,description,website_url&sort=display_date:asc&_sourceInclude=related_items,content_elements,taxonomy&include_distributor_name=AP',
-  )
+  expect(query).toContain('&size=25')
+  expect(query).toContain('&from=3')
+  expect(query).toContain('_sourceExcludes=taxonomy&')
+  expect(query).toContain(',source,owner')
+  expect(query).not.toContain('content_elements')
+  expect(query).toContain('&include_distributor_name=AP')
+  expect(query).not.toContain('paid')
+  expect(query).not.toContain('promotions')
+  expect(query).not.toContain('wires')
 })
 
 it('returns query by section', () => {
@@ -93,9 +141,7 @@ it('returns query by section', () => {
     'Source-Exclude': '',
     'Source-Include': '',
   })
-  expect(query).toBe(
-    'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22range%22:%7B%22last_updated_date%22:%7B%22gte%22:%22now-2d%22,%22lte%22:%22now%22%7D%7D%7D,%7B%22nested%22:%7B%22path%22:%22taxonomy.sections%22,%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22taxonomy.sections._website%22:%22demo%22%7D%7D,%7B%22terms%22:%7B%22taxonomy.sections._id%22:%5B%22/sports%22%5D%7D%7D%5D%7D%7D%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&_sourceExclude=related_content&sort=publish_date:desc',
-  )
+  expect(query).toContain('%22taxonomy.sections._id%22:%5B%22/sports%22')
 })
 
 it('returns query by Exclude-Sections', () => {
@@ -116,13 +162,13 @@ it('returns query by Exclude-Sections', () => {
     'Source-Include': '',
   })
   expect(query).toBe(
-    'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22range%22:%7B%22last_updated_date%22:%7B%22gte%22:%22now-2d%22,%22lte%22:%22now%22%7D%7D%7D,%7B%22nested%22:%7B%22path%22:%22taxonomy.sections%22,%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22taxonomy.sections._website%22:%22demo%22%7D%7D%5D%7D%7D%7D%7D%5D,%22must_not%22:%5B%7B%22nested%22:%7B%22path%22:%22taxonomy.sections%22,%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22terms%22:%7B%22taxonomy.sections._id%22:%5B%22/food%22,%22/politics%22%5D%7D%7D%5D%7D%7D%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&_sourceExclude=related_content&sort=publish_date:desc',
+    'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22range%22:%7B%22last_updated_date%22:%7B%22gte%22:%22now-2d%22,%22lte%22:%22now%22%7D%7D%7D,%7B%22nested%22:%7B%22path%22:%22taxonomy.sections%22,%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22taxonomy.sections._website%22:%22demo%22%7D%7D%5D%7D%7D%7D%7D%5D,%22must_not%22:%5B%7B%22nested%22:%7B%22path%22:%22taxonomy.sections%22,%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22terms%22:%7B%22taxonomy.sections._id%22:%5B%22/food%22,%22/politics%22%5D%7D%7D%5D%7D%7D%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&sort=publish_date:desc&_sourceIncludes=canonical_url,canonical_website,content_elements,created_date,credits,description,display_date,duration,first_publish_date,headlines,last_updated_date,promo_image,promo_items,publish_date,streams,subheadlines,subtitles,subtype,taxonomy.primary_section,taxonomy.seo_keywords,taxonomy.tags,type,video_type,websites.demo',
   )
 })
 
 it('returns query by section and Exclude-Sections', () => {
   const query = resolver.default.resolve({
-    Section: '/sports/',
+    Section: '/sports/,/news/',
     Author: '',
     Keywords: '',
     'Tags-Text': '',
@@ -138,29 +184,7 @@ it('returns query by section and Exclude-Sections', () => {
     'Source-Include': '',
   })
   expect(query).toBe(
-    'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22range%22:%7B%22last_updated_date%22:%7B%22gte%22:%22now-2d%22,%22lte%22:%22now%22%7D%7D%7D,%7B%22nested%22:%7B%22path%22:%22taxonomy.sections%22,%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22taxonomy.sections._website%22:%22demo%22%7D%7D,%7B%22terms%22:%7B%22taxonomy.sections._id%22:%5B%22/sports%22%5D%7D%7D%5D%7D%7D%7D%7D%5D,%22must_not%22:%5B%7B%22nested%22:%7B%22path%22:%22taxonomy.sections%22,%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22terms%22:%7B%22taxonomy.sections._id%22:%5B%22/food%22,%22/politics%22%5D%7D%7D%5D%7D%7D%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&_sourceExclude=related_content&sort=publish_date:desc',
-  )
-})
-
-it('returns query by section with leading slash', () => {
-  const query = resolver.default.resolve({
-    Section: 'sports/',
-    Author: '',
-    Keywords: '',
-    'Tags-Text': '',
-    'Tags-Slug': '',
-    'arc-site': 'demo',
-    'Include-Terms': '',
-    'Exclude-Terms': '',
-    'Exclude-Sections': '',
-    'Feed-Size': '',
-    'Feed-Offset': '',
-    Sort: '',
-    'Source-Exclude': '',
-    'Source-Include': '',
-  })
-  expect(query).toBe(
-    'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22range%22:%7B%22last_updated_date%22:%7B%22gte%22:%22now-2d%22,%22lte%22:%22now%22%7D%7D%7D,%7B%22nested%22:%7B%22path%22:%22taxonomy.sections%22,%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22taxonomy.sections._website%22:%22demo%22%7D%7D,%7B%22terms%22:%7B%22taxonomy.sections._id%22:%5B%22/sports%22%5D%7D%7D%5D%7D%7D%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&_sourceExclude=related_content&sort=publish_date:desc',
+    'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22range%22:%7B%22last_updated_date%22:%7B%22gte%22:%22now-2d%22,%22lte%22:%22now%22%7D%7D%7D,%7B%22nested%22:%7B%22path%22:%22taxonomy.sections%22,%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22taxonomy.sections._website%22:%22demo%22%7D%7D,%7B%22terms%22:%7B%22taxonomy.sections._id%22:%5B%22/sports%22,%22/news%22%5D%7D%7D%5D%7D%7D%7D%7D%5D,%22must_not%22:%5B%7B%22nested%22:%7B%22path%22:%22taxonomy.sections%22,%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22terms%22:%7B%22taxonomy.sections._id%22:%5B%22/food%22,%22/politics%22%5D%7D%7D%5D%7D%7D%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&sort=publish_date:desc&_sourceIncludes=canonical_url,canonical_website,content_elements,created_date,credits,description,display_date,duration,first_publish_date,headlines,last_updated_date,promo_image,promo_items,publish_date,streams,subheadlines,subtitles,subtype,taxonomy.primary_section,taxonomy.seo_keywords,taxonomy.tags,type,video_type,websites.demo',
   )
 })
 
@@ -182,7 +206,7 @@ it('returns query by author', () => {
     'Source-Include': '',
   })
   expect(query).toBe(
-    'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22range%22:%7B%22last_updated_date%22:%7B%22gte%22:%22now-2d%22,%22lte%22:%22now%22%7D%7D%7D,%7B%22term%22:%7B%22credits.by._id%22:%22John%20Smith%22%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&_sourceExclude=related_content&sort=publish_date:desc',
+    'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22range%22:%7B%22last_updated_date%22:%7B%22gte%22:%22now-2d%22,%22lte%22:%22now%22%7D%7D%7D,%7B%22term%22:%7B%22credits.by._id%22:%22John%20Smith%22%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&sort=publish_date:desc&_sourceIncludes=canonical_url,canonical_website,content_elements,created_date,credits,description,display_date,duration,first_publish_date,headlines,last_updated_date,promo_image,promo_items,publish_date,streams,subheadlines,subtitles,subtype,taxonomy.primary_section,taxonomy.seo_keywords,taxonomy.tags,type,video_type,websites.demo',
   )
 })
 
@@ -204,7 +228,7 @@ it('returns query by author with slash', () => {
     'Source-Include': '',
   })
   expect(query).toBe(
-    'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22range%22:%7B%22last_updated_date%22:%7B%22gte%22:%22now-2d%22,%22lte%22:%22now%22%7D%7D%7D,%7B%22term%22:%7B%22credits.by._id%22:%22John%20Smith%22%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&_sourceExclude=related_content&sort=publish_date:desc',
+    'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22range%22:%7B%22last_updated_date%22:%7B%22gte%22:%22now-2d%22,%22lte%22:%22now%22%7D%7D%7D,%7B%22term%22:%7B%22credits.by._id%22:%22John%20Smith%22%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&sort=publish_date:desc&_sourceIncludes=canonical_url,canonical_website,content_elements,created_date,credits,description,display_date,duration,first_publish_date,headlines,last_updated_date,promo_image,promo_items,publish_date,streams,subheadlines,subtitles,subtype,taxonomy.primary_section,taxonomy.seo_keywords,taxonomy.tags,type,video_type,websites.demo',
   )
 })
 
@@ -226,7 +250,7 @@ it('returns query by keywords', () => {
     'Source-Include': '',
   })
   expect(query).toBe(
-    'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22range%22:%7B%22last_updated_date%22:%7B%22gte%22:%22now-2d%22,%22lte%22:%22now%22%7D%7D%7D,%7B%22simple_query_string%22:%7B%22query%22:%22%5C%22washington%20football%5C%22%20%7C%20%5C%22sports%5C%22%22,%22fields%22:%5B%22taxonomy.seo_keywords%22%5D%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&_sourceExclude=related_content&sort=publish_date:desc',
+    'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22range%22:%7B%22last_updated_date%22:%7B%22gte%22:%22now-2d%22,%22lte%22:%22now%22%7D%7D%7D,%7B%22simple_query_string%22:%7B%22query%22:%22%5C%22washington%20football%5C%22%20%7C%20%5C%22sports%5C%22%22,%22fields%22:%5B%22taxonomy.seo_keywords%22%5D%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&sort=publish_date:desc&_sourceIncludes=canonical_url,canonical_website,content_elements,created_date,credits,description,display_date,duration,first_publish_date,headlines,last_updated_date,promo_image,promo_items,publish_date,streams,subheadlines,subtitles,subtype,taxonomy.primary_section,taxonomy.seo_keywords,taxonomy.tags,type,video_type,websites.demo',
   )
 })
 
@@ -248,7 +272,7 @@ it('returns query by tags text', () => {
     'Source-Include': '',
   })
   expect(query).toBe(
-    'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22range%22:%7B%22last_updated_date%22:%7B%22gte%22:%22now-2d%22,%22lte%22:%22now%22%7D%7D%7D,%7B%22terms%22:%7B%22taxonomy.tags.text.raw%22:%5B%22football%22,%22sports%22%5D%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&_sourceExclude=related_content&sort=publish_date:desc',
+    'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22range%22:%7B%22last_updated_date%22:%7B%22gte%22:%22now-2d%22,%22lte%22:%22now%22%7D%7D%7D,%7B%22terms%22:%7B%22taxonomy.tags.text.raw%22:%5B%22football%22,%22sports%22%5D%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&sort=publish_date:desc&_sourceIncludes=canonical_url,canonical_website,content_elements,created_date,credits,description,display_date,duration,first_publish_date,headlines,last_updated_date,promo_image,promo_items,publish_date,streams,subheadlines,subtitles,subtype,taxonomy.primary_section,taxonomy.seo_keywords,taxonomy.tags,type,video_type,websites.demo',
   )
 })
 
@@ -270,6 +294,99 @@ it('returns query by tags slug', () => {
     'Source-Include': '',
   })
   expect(query).toBe(
-    'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22range%22:%7B%22last_updated_date%22:%7B%22gte%22:%22now-2d%22,%22lte%22:%22now%22%7D%7D%7D,%7B%22terms%22:%7B%22taxonomy.tags.slug%22:%5B%22football%22,%22sports%22%5D%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&_sourceExclude=related_content&sort=publish_date:desc',
+    'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22range%22:%7B%22last_updated_date%22:%7B%22gte%22:%22now-2d%22,%22lte%22:%22now%22%7D%7D%7D,%7B%22terms%22:%7B%22taxonomy.tags.slug%22:%5B%22football%22,%22sports%22%5D%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&sort=publish_date:desc&_sourceIncludes=canonical_url,canonical_website,content_elements,created_date,credits,description,display_date,duration,first_publish_date,headlines,last_updated_date,promo_image,promo_items,publish_date,streams,subheadlines,subtitles,subtype,taxonomy.primary_section,taxonomy.seo_keywords,taxonomy.tags,type,video_type,websites.demo',
   )
+})
+
+it('returns query by Include-Terms', () => {
+  const query = resolver.default.resolve({
+    Section: '',
+    Author: '',
+    Keywords: '',
+    'Tags-Text': '',
+    'Tags-Slug': '',
+    'arc-site': 'demo',
+    'Include-Terms': '[{"term":{"type":"video"}}]',
+    'Exclude-Terms': '',
+    'Exclude-Sections': '',
+    'Feed-Size': '',
+    'Feed-Offset': '',
+    Sort: '',
+    'Source-Exclude': '',
+    'Source-Include': '',
+  })
+  expect(query).not.toContain('%22term%22:%7B%22type%22:%22story%22')
+  expect(query).toContain('%22term%22:%7B%22type%22:%22video%22')
+})
+
+it('returns query by Exclude-Terms', () => {
+  const query = resolver.default.resolve({
+    Section: '',
+    Author: '',
+    Keywords: '',
+    'Tags-Text': '',
+    'Tags-Slug': '',
+    'arc-site': 'demo',
+    'Include-Terms': '',
+    'Exclude-Terms': '[{"term":{"subtype":"premium"}}]',
+    'Exclude-Sections': '',
+    'Feed-Size': '',
+    'Feed-Offset': '',
+    Sort: '',
+    'Source-Exclude': '',
+    'Source-Include': '',
+  })
+  expect(query).toContain('%22term%22:%7B%22type%22:%22story%22')
+  expect(query).toContain('%22term%22:%7B%22subtype%22:%22premium%22')
+})
+
+it('Test transform with empty data', () => {
+  const transform = resolver.default.transform(undefined, {
+    'arc-site': 'demo',
+  })
+  expect(transform).toBe(undefined)
+})
+
+// Every article should have a website and website_url. Only replace sections if !exist
+it('Test transform', () => {
+  const transform = resolver.default.transform(globalContent, {
+    'arc-site': 'demo',
+  })
+  expect(transform).toEqual({
+    content_elements: [
+      {
+        taxonomy: { sections: [{ _id: '/news' }], tags: [] },
+        website: 'demo',
+        website_url: '/news/test-article-1',
+        websites: {
+          demo: {
+            website_section: { _id: '/news' },
+            website_url: '/news/test-article-1',
+          },
+        },
+      },
+      {
+        taxonomy: { sections: [{ _id: '/sports' }], tags: [] },
+        website: 'demo',
+        website_url: '/news/test-article-2',
+        websites: {
+          demo: {
+            website_section: { _id: '/news' },
+            website_url: '/news/test-article-2',
+          },
+        },
+      },
+      {
+        taxonomy: { sections: [{ _id: '/news' }] },
+        website: 'demo',
+        website_url: '/news/test-article-3',
+        websites: {
+          demo: {
+            website_section: { _id: '/news' },
+            website_url: '/news/test-article-3',
+          },
+        },
+      },
+    ],
+  })
 })

--- a/blocks/feeds-source-content-api-block/sources/feeds-content-api.test.js
+++ b/blocks/feeds-source-content-api-block/sources/feeds-content-api.test.js
@@ -46,7 +46,7 @@ it('returns query with default values', () => {
     'Source-Include': '',
   })
   expect(query).toBe(
-    'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22range%22:%7B%22last_updated_date%22:%7B%22gte%22:%22now-2d%22,%22lte%22:%22now%22%7D%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&sort=publish_date:desc&_sourceIncludes=canonical_url,canonical_website,content_elements,created_date,credits,description,display_date,duration,first_publish_date,headlines,last_updated_date,promo_image,promo_items,publish_date,streams,subheadlines,subtitles,subtype,taxonomy.primary_section,taxonomy.seo_keywords,taxonomy.tags,type,video_type,websites.demo',
+    'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22range%22:%7B%22last_updated_date%22:%7B%22gte%22:%22now-2d%22,%22lte%22:%22now%22%7D%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&sort=publish_date:desc&_sourceIncludes=canonical_url,canonical_website,created_date,credits,description,display_date,duration,first_publish_date,headlines,last_updated_date,promo_image,promo_items,publish_date,streams,subheadlines,subtitles,subtype,taxonomy.primary_section,taxonomy.seo_keywords,taxonomy.tags,type,video_type,content_elements,websites.demo',
   )
 })
 
@@ -120,7 +120,7 @@ it('returns query by Exclude-Sections', () => {
     'Source-Include': '',
   })
   expect(query).toBe(
-    'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22range%22:%7B%22last_updated_date%22:%7B%22gte%22:%22now-2d%22,%22lte%22:%22now%22%7D%7D%7D,%7B%22nested%22:%7B%22path%22:%22taxonomy.sections%22,%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22taxonomy.sections._website%22:%22demo%22%7D%7D%5D%7D%7D%7D%7D%5D,%22must_not%22:%5B%7B%22nested%22:%7B%22path%22:%22taxonomy.sections%22,%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22terms%22:%7B%22taxonomy.sections._id%22:%5B%22/food%22,%22/politics%22%5D%7D%7D%5D%7D%7D%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&sort=publish_date:desc&_sourceIncludes=canonical_url,canonical_website,content_elements,created_date,credits,description,display_date,duration,first_publish_date,headlines,last_updated_date,promo_image,promo_items,publish_date,streams,subheadlines,subtitles,subtype,taxonomy.primary_section,taxonomy.seo_keywords,taxonomy.tags,type,video_type,websites.demo',
+    'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22range%22:%7B%22last_updated_date%22:%7B%22gte%22:%22now-2d%22,%22lte%22:%22now%22%7D%7D%7D,%7B%22nested%22:%7B%22path%22:%22taxonomy.sections%22,%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22taxonomy.sections._website%22:%22demo%22%7D%7D%5D%7D%7D%7D%7D%5D,%22must_not%22:%5B%7B%22nested%22:%7B%22path%22:%22taxonomy.sections%22,%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22terms%22:%7B%22taxonomy.sections._id%22:%5B%22/food%22,%22/politics%22%5D%7D%7D%5D%7D%7D%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&sort=publish_date:desc&_sourceIncludes=canonical_url,canonical_website,created_date,credits,description,display_date,duration,first_publish_date,headlines,last_updated_date,promo_image,promo_items,publish_date,streams,subheadlines,subtitles,subtype,taxonomy.primary_section,taxonomy.seo_keywords,taxonomy.tags,type,video_type,content_elements,websites.demo',
   )
 })
 
@@ -142,7 +142,7 @@ it('returns query by section and Exclude-Sections', () => {
     'Source-Include': '',
   })
   expect(query).toBe(
-    'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22range%22:%7B%22last_updated_date%22:%7B%22gte%22:%22now-2d%22,%22lte%22:%22now%22%7D%7D%7D,%7B%22nested%22:%7B%22path%22:%22taxonomy.sections%22,%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22taxonomy.sections._website%22:%22demo%22%7D%7D,%7B%22terms%22:%7B%22taxonomy.sections._id%22:%5B%22/sports%22,%22/news%22%5D%7D%7D%5D%7D%7D%7D%7D%5D,%22must_not%22:%5B%7B%22nested%22:%7B%22path%22:%22taxonomy.sections%22,%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22terms%22:%7B%22taxonomy.sections._id%22:%5B%22/food%22,%22/politics%22%5D%7D%7D%5D%7D%7D%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&sort=publish_date:desc&_sourceIncludes=canonical_url,canonical_website,content_elements,created_date,credits,description,display_date,duration,first_publish_date,headlines,last_updated_date,promo_image,promo_items,publish_date,streams,subheadlines,subtitles,subtype,taxonomy.primary_section,taxonomy.seo_keywords,taxonomy.tags,type,video_type,websites.demo',
+    'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22range%22:%7B%22last_updated_date%22:%7B%22gte%22:%22now-2d%22,%22lte%22:%22now%22%7D%7D%7D,%7B%22nested%22:%7B%22path%22:%22taxonomy.sections%22,%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22taxonomy.sections._website%22:%22demo%22%7D%7D,%7B%22terms%22:%7B%22taxonomy.sections._id%22:%5B%22/sports%22,%22/news%22%5D%7D%7D%5D%7D%7D%7D%7D%5D,%22must_not%22:%5B%7B%22nested%22:%7B%22path%22:%22taxonomy.sections%22,%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22terms%22:%7B%22taxonomy.sections._id%22:%5B%22/food%22,%22/politics%22%5D%7D%7D%5D%7D%7D%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&sort=publish_date:desc&_sourceIncludes=canonical_url,canonical_website,created_date,credits,description,display_date,duration,first_publish_date,headlines,last_updated_date,promo_image,promo_items,publish_date,streams,subheadlines,subtitles,subtype,taxonomy.primary_section,taxonomy.seo_keywords,taxonomy.tags,type,video_type,content_elements,websites.demo',
   )
 })
 
@@ -164,7 +164,7 @@ it('returns query by author', () => {
     'Source-Include': '',
   })
   expect(query).toBe(
-    'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22range%22:%7B%22last_updated_date%22:%7B%22gte%22:%22now-2d%22,%22lte%22:%22now%22%7D%7D%7D,%7B%22term%22:%7B%22credits.by._id%22:%22John%20Smith%22%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&sort=publish_date:desc&_sourceIncludes=canonical_url,canonical_website,content_elements,created_date,credits,description,display_date,duration,first_publish_date,headlines,last_updated_date,promo_image,promo_items,publish_date,streams,subheadlines,subtitles,subtype,taxonomy.primary_section,taxonomy.seo_keywords,taxonomy.tags,type,video_type,websites.demo',
+    'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22range%22:%7B%22last_updated_date%22:%7B%22gte%22:%22now-2d%22,%22lte%22:%22now%22%7D%7D%7D,%7B%22term%22:%7B%22credits.by._id%22:%22John%20Smith%22%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&sort=publish_date:desc&_sourceIncludes=canonical_url,canonical_website,created_date,credits,description,display_date,duration,first_publish_date,headlines,last_updated_date,promo_image,promo_items,publish_date,streams,subheadlines,subtitles,subtype,taxonomy.primary_section,taxonomy.seo_keywords,taxonomy.tags,type,video_type,content_elements,websites.demo',
   )
 })
 
@@ -186,7 +186,7 @@ it('returns query by author with slash', () => {
     'Source-Include': '',
   })
   expect(query).toBe(
-    'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22range%22:%7B%22last_updated_date%22:%7B%22gte%22:%22now-2d%22,%22lte%22:%22now%22%7D%7D%7D,%7B%22term%22:%7B%22credits.by._id%22:%22John%20Smith%22%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&sort=publish_date:desc&_sourceIncludes=canonical_url,canonical_website,content_elements,created_date,credits,description,display_date,duration,first_publish_date,headlines,last_updated_date,promo_image,promo_items,publish_date,streams,subheadlines,subtitles,subtype,taxonomy.primary_section,taxonomy.seo_keywords,taxonomy.tags,type,video_type,websites.demo',
+    'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22range%22:%7B%22last_updated_date%22:%7B%22gte%22:%22now-2d%22,%22lte%22:%22now%22%7D%7D%7D,%7B%22term%22:%7B%22credits.by._id%22:%22John%20Smith%22%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&sort=publish_date:desc&_sourceIncludes=canonical_url,canonical_website,created_date,credits,description,display_date,duration,first_publish_date,headlines,last_updated_date,promo_image,promo_items,publish_date,streams,subheadlines,subtitles,subtype,taxonomy.primary_section,taxonomy.seo_keywords,taxonomy.tags,type,video_type,content_elements,websites.demo',
   )
 })
 
@@ -208,7 +208,7 @@ it('returns query by keywords', () => {
     'Source-Include': '',
   })
   expect(query).toBe(
-    'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22range%22:%7B%22last_updated_date%22:%7B%22gte%22:%22now-2d%22,%22lte%22:%22now%22%7D%7D%7D,%7B%22simple_query_string%22:%7B%22query%22:%22%5C%22washington%20football%5C%22%20%7C%20%5C%22sports%5C%22%22,%22fields%22:%5B%22taxonomy.seo_keywords%22%5D%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&sort=publish_date:desc&_sourceIncludes=canonical_url,canonical_website,content_elements,created_date,credits,description,display_date,duration,first_publish_date,headlines,last_updated_date,promo_image,promo_items,publish_date,streams,subheadlines,subtitles,subtype,taxonomy.primary_section,taxonomy.seo_keywords,taxonomy.tags,type,video_type,websites.demo',
+    'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22range%22:%7B%22last_updated_date%22:%7B%22gte%22:%22now-2d%22,%22lte%22:%22now%22%7D%7D%7D,%7B%22simple_query_string%22:%7B%22query%22:%22%5C%22washington%20football%5C%22%20%7C%20%5C%22sports%5C%22%22,%22fields%22:%5B%22taxonomy.seo_keywords%22%5D%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&sort=publish_date:desc&_sourceIncludes=canonical_url,canonical_website,created_date,credits,description,display_date,duration,first_publish_date,headlines,last_updated_date,promo_image,promo_items,publish_date,streams,subheadlines,subtitles,subtype,taxonomy.primary_section,taxonomy.seo_keywords,taxonomy.tags,type,video_type,content_elements,websites.demo',
   )
 })
 
@@ -230,7 +230,7 @@ it('returns query by tags text', () => {
     'Source-Include': '',
   })
   expect(query).toBe(
-    'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22range%22:%7B%22last_updated_date%22:%7B%22gte%22:%22now-2d%22,%22lte%22:%22now%22%7D%7D%7D,%7B%22terms%22:%7B%22taxonomy.tags.text.raw%22:%5B%22football%22,%22sports%22%5D%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&sort=publish_date:desc&_sourceIncludes=canonical_url,canonical_website,content_elements,created_date,credits,description,display_date,duration,first_publish_date,headlines,last_updated_date,promo_image,promo_items,publish_date,streams,subheadlines,subtitles,subtype,taxonomy.primary_section,taxonomy.seo_keywords,taxonomy.tags,type,video_type,websites.demo',
+    'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22range%22:%7B%22last_updated_date%22:%7B%22gte%22:%22now-2d%22,%22lte%22:%22now%22%7D%7D%7D,%7B%22terms%22:%7B%22taxonomy.tags.text.raw%22:%5B%22football%22,%22sports%22%5D%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&sort=publish_date:desc&_sourceIncludes=canonical_url,canonical_website,created_date,credits,description,display_date,duration,first_publish_date,headlines,last_updated_date,promo_image,promo_items,publish_date,streams,subheadlines,subtitles,subtype,taxonomy.primary_section,taxonomy.seo_keywords,taxonomy.tags,type,video_type,content_elements,websites.demo',
   )
 })
 
@@ -252,7 +252,7 @@ it('returns query by tags slug', () => {
     'Source-Include': '',
   })
   expect(query).toBe(
-    'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22range%22:%7B%22last_updated_date%22:%7B%22gte%22:%22now-2d%22,%22lte%22:%22now%22%7D%7D%7D,%7B%22terms%22:%7B%22taxonomy.tags.slug%22:%5B%22football%22,%22sports%22%5D%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&sort=publish_date:desc&_sourceIncludes=canonical_url,canonical_website,content_elements,created_date,credits,description,display_date,duration,first_publish_date,headlines,last_updated_date,promo_image,promo_items,publish_date,streams,subheadlines,subtitles,subtype,taxonomy.primary_section,taxonomy.seo_keywords,taxonomy.tags,type,video_type,websites.demo',
+    'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22range%22:%7B%22last_updated_date%22:%7B%22gte%22:%22now-2d%22,%22lte%22:%22now%22%7D%7D%7D,%7B%22terms%22:%7B%22taxonomy.tags.slug%22:%5B%22football%22,%22sports%22%5D%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&sort=publish_date:desc&_sourceIncludes=canonical_url,canonical_website,created_date,credits,description,display_date,duration,first_publish_date,headlines,last_updated_date,promo_image,promo_items,publish_date,streams,subheadlines,subtitles,subtype,taxonomy.primary_section,taxonomy.seo_keywords,taxonomy.tags,type,video_type,content_elements,websites.demo',
   )
 })
 
@@ -296,4 +296,26 @@ it('returns query by Exclude-Terms', () => {
   })
   expect(query).toContain('%22term%22:%7B%22type%22:%22story%22')
   expect(query).toContain('%22term%22:%7B%22subtype%22:%22premium%22')
+})
+
+it('returns query by Exclude-Terms', () => {
+  const query = resolver.default.resolve({
+    Section: '',
+    Author: '',
+    Keywords: '',
+    'Tags-Text': '',
+    'Tags-Slug': '',
+    'arc-site': 'demo',
+    'Include-Terms': '',
+    'Exclude-Terms': '',
+    'Exclude-Sections': '',
+    'Feed-Size': '',
+    'Feed-Offset': '',
+    Sort: '',
+    'Source-Exclude': '',
+    'Source-Include': '',
+    'Include-Distributor-Name': 'AP',
+  })
+  expect(query).toContain('include_distributor_name=AP')
+  expect(query).not.toContain('exclude_distributor_name=AP')
 })

--- a/blocks/feeds-source-content-api-by-day-block/package-lock.json
+++ b/blocks/feeds-source-content-api-by-day-block/package-lock.json
@@ -4,6 +4,11 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@wpmedia/feeds-content-source-utils": {
+      "version": "1.0.7",
+      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-content-source-utils/1.0.7/336af8202408caecbe3ffebe3c92319ca35756af67decb284c7485ac3f3f6fa1",
+      "integrity": "sha512-p+Q2sHYnKiA2rr/B9cZgXsMPbitxC+nbEHpzXYfSZHh82HzBRx8QeMRn9g0VZr1wdYJUMP9dLX9zctrSK0PCOQ=="
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",

--- a/blocks/feeds-source-content-api-by-day-block/package.json
+++ b/blocks/feeds-source-content-api-by-day-block/package.json
@@ -19,7 +19,7 @@
   "author": "Tim Kosmider <tim.kosmider@washpost.com>",
   "homepage": "https://github.com/WPMedia/feed-components#readme",
   "dependencies": {
-    "@wpmedia/feeds-content-source-utils": "1.0.1",
+    "@wpmedia/feeds-content-source-utils": "1.0.7",
     "moment": "^2.29.1"
   },
   "devDependencies": {

--- a/blocks/feeds-source-content-api-by-day-block/package.json
+++ b/blocks/feeds-source-content-api-by-day-block/package.json
@@ -19,6 +19,7 @@
   "author": "Tim Kosmider <tim.kosmider@washpost.com>",
   "homepage": "https://github.com/WPMedia/feed-components#readme",
   "dependencies": {
+    "@wpmedia/feeds-content-source-utils": "1.0.1",
     "moment": "^2.29.1"
   },
   "devDependencies": {

--- a/blocks/feeds-source-content-api-by-day-block/sources/feeds-content-api-by-day.js
+++ b/blocks/feeds-source-content-api-by-day-block/sources/feeds-content-api-by-day.js
@@ -8,7 +8,7 @@ import {
   generateDistributor,
   transform,
   validANSDates,
-} from '@wpmedia/feeds-source-content-api-block'
+} from '@wpmedia/feeds-content-source-utils'
 
 const contentURL = `${CONTENT_BASE}/content/v4/search/published/`
 // Excludes content_elements
@@ -26,6 +26,7 @@ const fetch = async (key = {}) => {
     size: 100,
     sort: key.sort || `${key.dateField}:desc`,
   }
+  generateDistributor(key, paramList)
 
   // limit C-API response to just this websites sections to reduce size
   ansFields.push(`websites.${key['arc-site']}`)
@@ -49,8 +50,6 @@ const fetch = async (key = {}) => {
       .forEach((i) => i && !ansFields.includes(i) && ansFields.push(i))
   }
   paramList._sourceIncludes = ansFields.join(',')
-
-  generateDistributor(key, paramList)
 
   // basic ES query
   const body = {

--- a/blocks/feeds-source-content-api-by-day-block/sources/feeds-content-api-by-day.js
+++ b/blocks/feeds-source-content-api-by-day-block/sources/feeds-content-api-by-day.js
@@ -4,6 +4,31 @@ import getProperties from 'fusion:properties'
 import moment from 'moment'
 
 const contentURL = `${CONTENT_BASE}/content/v4/search/published/`
+// Excludes content_elements
+const ansFields = [
+  'canonical_url',
+  'canonical_website',
+  'created_date',
+  'credits',
+  'description',
+  'display_date',
+  'duration',
+  'first_publish_date',
+  'headlines',
+  'last_updated_date',
+  'promo_image',
+  'promo_items',
+  'publish_date',
+  'streams',
+  'subheadlines',
+  'subtitles',
+  'subtype',
+  'taxonomy.primary_section',
+  'taxonomy.seo_keywords',
+  'taxonomy.tags',
+  'type',
+  'video_type',
+]
 
 const options = {
   gzip: true,
@@ -23,12 +48,31 @@ const fetch = async (key = {}) => {
     website: key['arc-site'],
     size: 100,
     sort: key.sort || 'last_updated_date:desc',
-    _sourceExclude:
-      key['Source-Exclude'] ||
-      'address,additional_properties,content_elements,credits,geo,language,label,owner,planning,publishing,related_content,taxonomy,revision,source,subtype,version,workflow',
   }
 
-  if (key['Source-Include']) paramList._sourceInclude = key['Source-Include']
+  // limit C-API response to just this websites sections to reduce size
+  ansFields.push(`websites.${key['arc-site']}`)
+
+  if (key['Source-Exclude']) {
+    const sourceExcludes = []
+    key['Source-Exclude'].split(',').forEach((i) => {
+      if (i && ansFields.indexOf(i) !== -1) {
+        ansFields.splice(ansFields.indexOf(i), 1)
+      } else {
+        i && sourceExcludes.push(i)
+      }
+    })
+    if (sourceExcludes.length)
+      paramList._sourceExcludes = sourceExcludes.join(',')
+  }
+
+  if (key['Source-Include']) {
+    key['Source-Include']
+      .split(',')
+      .forEach((i) => i && !ansFields.includes(i) && ansFields.push(i))
+  }
+  paramList._sourceIncludes = ansFields.join(',')
+
   if (key['Include-Distributor-Name']) {
     paramList.include_distributor_name = key['Include-Distributor-Name']
   } else if (key['Exclude-Distributor-Name']) {
@@ -210,9 +254,29 @@ const fetch = async (key = {}) => {
   return { type: 'resp', content_elements: allContentElements }
 }
 
+const transform = (data, query) => {
+  const source = data || {}
+  const website = query['arc-site']
+  if (source.content_elements && source.content_elements.length) {
+    const transformedContent = source.content_elements.map((i) => {
+      if (i?.websites?.[website]?.website_section && !i?.taxonomy?.sections) {
+        if (!i.taxonomy) i.taxonomy = {}
+        i.taxonomy.sections = [i.websites[website].website_section]
+      }
+      if (i?.websites?.[website]?.website_url)
+        i.website_url = i.websites[website].website_url
+      i.website = website
+      return i
+    })
+    source.content_elements = transformedContent
+    return source
+  }
+}
+
 export default {
   fetch,
   schemaName: 'feeds',
+  transform,
   params: [
     {
       name: 'dateField',
@@ -245,13 +309,13 @@ export default {
       type: 'text',
     },
     {
-      name: 'Source-Exclude',
-      displayName: 'Source Exclude (list of ANS fields comma separated)',
+      name: 'Source-Include',
+      displayName: 'Source Include (list of ANS fields comma separated)',
       type: 'text',
     },
     {
-      name: 'Source-Include',
-      displayName: 'Source Include (list of ANS fields comma separated)',
+      name: 'Source-Exclude',
+      displayName: 'Source Exclude (list of ANS fields comma separated)',
       type: 'text',
     },
     {

--- a/blocks/feeds-source-content-api-by-day2-block/package-lock.json
+++ b/blocks/feeds-source-content-api-by-day2-block/package-lock.json
@@ -4,6 +4,11 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@wpmedia/feeds-content-source-utils": {
+      "version": "1.0.7",
+      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-content-source-utils/1.0.7/336af8202408caecbe3ffebe3c92319ca35756af67decb284c7485ac3f3f6fa1",
+      "integrity": "sha512-p+Q2sHYnKiA2rr/B9cZgXsMPbitxC+nbEHpzXYfSZHh82HzBRx8QeMRn9g0VZr1wdYJUMP9dLX9zctrSK0PCOQ=="
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",

--- a/blocks/feeds-source-content-api-by-day2-block/package.json
+++ b/blocks/feeds-source-content-api-by-day2-block/package.json
@@ -19,7 +19,7 @@
   "author": "Tim Kosmider <tim.kosmider@washpost.com>",
   "homepage": "https://github.com/WPMedia/feed-components#readme",
   "dependencies": {
-    "@wpmedia/feeds-content-source-utils": "1.0.1",
+    "@wpmedia/feeds-content-source-utils": "1.0.7",
     "moment": "^2.29.1"
   },
   "devDependencies": {

--- a/blocks/feeds-source-content-api-by-day2-block/package.json
+++ b/blocks/feeds-source-content-api-by-day2-block/package.json
@@ -19,6 +19,7 @@
   "author": "Tim Kosmider <tim.kosmider@washpost.com>",
   "homepage": "https://github.com/WPMedia/feed-components#readme",
   "dependencies": {
+    "@wpmedia/feeds-content-source-utils": "1.0.1",
     "moment": "^2.29.1"
   },
   "devDependencies": {

--- a/blocks/feeds-source-content-api-by-day2-block/sources/feeds-content-api-by-day2.js
+++ b/blocks/feeds-source-content-api-by-day2-block/sources/feeds-content-api-by-day2.js
@@ -8,7 +8,7 @@ import {
   generateDistributor,
   transform,
   validANSDates,
-} from '@wpmedia/feeds-source-content-api-block'
+} from '@wpmedia/feeds-content-source-utils'
 
 const contentURL = `${CONTENT_BASE}/content/v4/search/published/`
 // Excludes content_elements
@@ -26,6 +26,7 @@ const fetch = async (key = {}) => {
     size: 100,
     sort: key.sort || `${key.dateField}:desc`,
   }
+  generateDistributor(key, paramList)
 
   // limit C-API response to just this websites sections to reduce size
   ansFields.push(`websites.${key['arc-site']}`)
@@ -49,8 +50,6 @@ const fetch = async (key = {}) => {
       .forEach((i) => i && !ansFields.includes(i) && ansFields.push(i))
   }
   paramList._sourceIncludes = ansFields.join(',')
-
-  generateDistributor(key, paramList)
 
   // basic ES query
   const body = {

--- a/blocks/feeds-source-content-api-by-day2-block/sources/feeds-content-api-by-day2.js
+++ b/blocks/feeds-source-content-api-by-day2-block/sources/feeds-content-api-by-day2.js
@@ -4,6 +4,31 @@ import getProperties from 'fusion:properties'
 import moment from 'moment'
 
 const contentURL = `${CONTENT_BASE}/content/v4/search/published/`
+// Excludes content_elements
+const ansFields = [
+  'canonical_url',
+  'canonical_website',
+  'created_date',
+  'credits',
+  'description',
+  'display_date',
+  'duration',
+  'first_publish_date',
+  'headlines',
+  'last_updated_date',
+  'promo_image',
+  'promo_items',
+  'publish_date',
+  'streams',
+  'subheadlines',
+  'subtitles',
+  'subtype',
+  'taxonomy.primary_section',
+  'taxonomy.seo_keywords',
+  'taxonomy.tags',
+  'type',
+  'video_type',
+]
 
 const options = {
   gzip: true,
@@ -23,12 +48,31 @@ const fetch = async (key = {}) => {
     website: key['arc-site'],
     size: 100,
     sort: key.sort || 'last_updated_date:desc',
-    _sourceExclude:
-      key['Source-Exclude'] ||
-      'address,additional_properties,content_elements,credits,geo,language,label,owner,planning,publishing,related_content,taxonomy,revision,source,subtype,version,workflow',
   }
 
-  if (key['Source-Include']) paramList._sourceInclude = key['Source-Include']
+  // limit C-API response to just this websites sections to reduce size
+  ansFields.push(`websites.${key['arc-site']}`)
+
+  if (key['Source-Exclude']) {
+    const sourceExcludes = []
+    key['Source-Exclude'].split(',').forEach((i) => {
+      if (i && ansFields.indexOf(i) !== -1) {
+        ansFields.splice(ansFields.indexOf(i), 1)
+      } else {
+        i && sourceExcludes.push(i)
+      }
+    })
+    if (sourceExcludes.length)
+      paramList._sourceExcludes = sourceExcludes.join(',')
+  }
+
+  if (key['Source-Include']) {
+    key['Source-Include']
+      .split(',')
+      .forEach((i) => i && !ansFields.includes(i) && ansFields.push(i))
+  }
+  paramList._sourceIncludes = ansFields.join(',')
+
   if (key['Include-Distributor-Name']) {
     paramList.include_distributor_name = key['Include-Distributor-Name']
   } else if (key['Exclude-Distributor-Name']) {
@@ -210,9 +254,29 @@ const fetch = async (key = {}) => {
   return { type: 'resp', content_elements: allContentElements }
 }
 
+const transform = (data, query) => {
+  const source = data || {}
+  const website = query['arc-site']
+  if (source.content_elements && source.content_elements.length) {
+    const transformedContent = source.content_elements.map((i) => {
+      if (i?.websites?.[website]?.website_section && !i?.taxonomy?.sections) {
+        if (!i.taxonomy) i.taxonomy = {}
+        i.taxonomy.sections = [i.websites[website].website_section]
+      }
+      if (i?.websites?.[website]?.website_url)
+        i.website_url = i.websites[website].website_url
+      i.website = website
+      return i
+    })
+    source.content_elements = transformedContent
+    return source
+  }
+}
+
 export default {
   fetch,
   schemaName: 'feeds',
+  transform,
   params: [
     {
       name: 'dateField',
@@ -245,13 +309,13 @@ export default {
       type: 'text',
     },
     {
-      name: 'Source-Exclude',
-      displayName: 'Source Exclude (list of ANS fields comma separated)',
+      name: 'Source-Include',
+      displayName: 'Source Include (list of ANS fields comma separated)',
       type: 'text',
     },
     {
-      name: 'Source-Include',
-      displayName: 'Source Include (list of ANS fields comma separated)',
+      name: 'Source-Exclude',
+      displayName: 'Source Exclude (list of ANS fields comma separated)',
       type: 'text',
     },
     {

--- a/blocks/feeds-source-content-api-by-day3-block/package-lock.json
+++ b/blocks/feeds-source-content-api-by-day3-block/package-lock.json
@@ -4,6 +4,11 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@wpmedia/feeds-content-source-utils": {
+      "version": "1.0.7",
+      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-content-source-utils/1.0.7/336af8202408caecbe3ffebe3c92319ca35756af67decb284c7485ac3f3f6fa1",
+      "integrity": "sha512-p+Q2sHYnKiA2rr/B9cZgXsMPbitxC+nbEHpzXYfSZHh82HzBRx8QeMRn9g0VZr1wdYJUMP9dLX9zctrSK0PCOQ=="
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",

--- a/blocks/feeds-source-content-api-by-day3-block/package.json
+++ b/blocks/feeds-source-content-api-by-day3-block/package.json
@@ -19,7 +19,7 @@
   "author": "Tim Kosmider <tim.kosmider@washpost.com>",
   "homepage": "https://github.com/WPMedia/feed-components#readme",
   "dependencies": {
-    "@wpmedia/feeds-content-source-utils": "1.0.1",
+    "@wpmedia/feeds-content-source-utils": "1.0.7",
     "moment": "^2.29.1"
   },
   "devDependencies": {

--- a/blocks/feeds-source-content-api-by-day3-block/package.json
+++ b/blocks/feeds-source-content-api-by-day3-block/package.json
@@ -19,6 +19,7 @@
   "author": "Tim Kosmider <tim.kosmider@washpost.com>",
   "homepage": "https://github.com/WPMedia/feed-components#readme",
   "dependencies": {
+    "@wpmedia/feeds-content-source-utils": "1.0.1",
     "moment": "^2.29.1"
   },
   "devDependencies": {

--- a/blocks/feeds-source-content-api-by-day3-block/sources/feeds-content-api-by-day3.js
+++ b/blocks/feeds-source-content-api-by-day3-block/sources/feeds-content-api-by-day3.js
@@ -8,7 +8,7 @@ import {
   generateDistributor,
   transform,
   validANSDates,
-} from '@wpmedia/feeds-source-content-api-block'
+} from '@wpmedia/feeds-content-source-utils'
 
 const contentURL = `${CONTENT_BASE}/content/v4/search/published/`
 // Excludes content_elements
@@ -26,6 +26,7 @@ const fetch = async (key = {}) => {
     size: 100,
     sort: key.sort || `${key.dateField}:desc`,
   }
+  generateDistributor(key, paramList)
 
   // limit C-API response to just this websites sections to reduce size
   ansFields.push(`websites.${key['arc-site']}`)
@@ -49,8 +50,6 @@ const fetch = async (key = {}) => {
       .forEach((i) => i && !ansFields.includes(i) && ansFields.push(i))
   }
   paramList._sourceIncludes = ansFields.join(',')
-
-  generateDistributor(key, paramList)
 
   // basic ES query
   const body = {

--- a/blocks/feeds-source-content-api-by-day3-block/sources/feeds-content-api-by-day3.js
+++ b/blocks/feeds-source-content-api-by-day3-block/sources/feeds-content-api-by-day3.js
@@ -4,6 +4,31 @@ import getProperties from 'fusion:properties'
 import moment from 'moment'
 
 const contentURL = `${CONTENT_BASE}/content/v4/search/published/`
+// Excludes content_elements
+const ansFields = [
+  'canonical_url',
+  'canonical_website',
+  'created_date',
+  'credits',
+  'description',
+  'display_date',
+  'duration',
+  'first_publish_date',
+  'headlines',
+  'last_updated_date',
+  'promo_image',
+  'promo_items',
+  'publish_date',
+  'streams',
+  'subheadlines',
+  'subtitles',
+  'subtype',
+  'taxonomy.primary_section',
+  'taxonomy.seo_keywords',
+  'taxonomy.tags',
+  'type',
+  'video_type',
+]
 
 const options = {
   gzip: true,
@@ -23,12 +48,31 @@ const fetch = async (key = {}) => {
     website: key['arc-site'],
     size: 100,
     sort: key.sort || 'last_updated_date:desc',
-    _sourceExclude:
-      key['Source-Exclude'] ||
-      'address,additional_properties,content_elements,credits,geo,language,label,owner,planning,publishing,related_content,taxonomy,revision,source,subtype,version,workflow',
   }
 
-  if (key['Source-Include']) paramList._sourceInclude = key['Source-Include']
+  // limit C-API response to just this websites sections to reduce size
+  ansFields.push(`websites.${key['arc-site']}`)
+
+  if (key['Source-Exclude']) {
+    const sourceExcludes = []
+    key['Source-Exclude'].split(',').forEach((i) => {
+      if (i && ansFields.indexOf(i) !== -1) {
+        ansFields.splice(ansFields.indexOf(i), 1)
+      } else {
+        i && sourceExcludes.push(i)
+      }
+    })
+    if (sourceExcludes.length)
+      paramList._sourceExcludes = sourceExcludes.join(',')
+  }
+
+  if (key['Source-Include']) {
+    key['Source-Include']
+      .split(',')
+      .forEach((i) => i && !ansFields.includes(i) && ansFields.push(i))
+  }
+  paramList._sourceIncludes = ansFields.join(',')
+
   if (key['Include-Distributor-Name']) {
     paramList.include_distributor_name = key['Include-Distributor-Name']
   } else if (key['Exclude-Distributor-Name']) {
@@ -210,9 +254,29 @@ const fetch = async (key = {}) => {
   return { type: 'resp', content_elements: allContentElements }
 }
 
+const transform = (data, query) => {
+  const source = data || {}
+  const website = query['arc-site']
+  if (source.content_elements && source.content_elements.length) {
+    const transformedContent = source.content_elements.map((i) => {
+      if (i?.websites?.[website]?.website_section && !i?.taxonomy?.sections) {
+        if (!i.taxonomy) i.taxonomy = {}
+        i.taxonomy.sections = [i.websites[website].website_section]
+      }
+      if (i?.websites?.[website]?.website_url)
+        i.website_url = i.websites[website].website_url
+      i.website = website
+      return i
+    })
+    source.content_elements = transformedContent
+    return source
+  }
+}
+
 export default {
   fetch,
   schemaName: 'feeds',
+  transform,
   params: [
     {
       name: 'dateField',
@@ -245,13 +309,13 @@ export default {
       type: 'text',
     },
     {
-      name: 'Source-Exclude',
-      displayName: 'Source Exclude (list of ANS fields comma separated)',
+      name: 'Source-Include',
+      displayName: 'Source Include (list of ANS fields comma separated)',
       type: 'text',
     },
     {
-      name: 'Source-Include',
-      displayName: 'Source Include (list of ANS fields comma separated)',
+      name: 'Source-Exclude',
+      displayName: 'Source Exclude (list of ANS fields comma separated)',
       type: 'text',
     },
     {

--- a/blocks/mrss-feature-block/package-lock.json
+++ b/blocks/mrss-feature-block/package-lock.json
@@ -73,65 +73,47 @@
       "integrity": "sha512-Ufpab7G5PfnEhQyy5kDg9C8ltWJjsVT1P/IYqacjstaqydG4Q21HAT2HUZQYBrC/a1ZLKCz87pfydlDvv8y97w=="
     },
     "@wpmedia/feeds-content-elements": {
-      "version": "1.0.6",
-      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-content-elements/1.0.6/876919f45373c1e555886df6c5fe21d80bd440831a1d6a2f6ee0ff03f1ea49b6",
-      "integrity": "sha512-l5ZHtic8FQxHay5o0S6SEitRGTRQpMaQmHp+tXABP8TSqduLOmsnorkWqLNcGt28XmXdKaG37bHWA0RBEXfa7Q==",
+      "version": "1.0.7",
+      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-content-elements/1.0.7/0fe5b6c6e84c14bbc088c7f5f36e45da8a87bccf0b98370a941f8c0d6e2ece8d",
+      "integrity": "sha512-QebfMsKkYcA3SPbL6og0G6sXGQ1AMe5hJ8fUqztwcG7XBbKq7FXPMB3FRFjWUM6SVfb6Z3VYmeqWwpwqBM8JCg==",
       "requires": {
-        "@wpmedia/feeds-find-video-stream": "1.0.6",
-        "@wpmedia/feeds-resizer": "1.0.6",
+        "@wpmedia/feeds-find-video-stream": "1.0.7",
+        "@wpmedia/feeds-resizer": "1.0.7",
         "he": "^1.2.0",
         "jmespath": "^0.15.0",
         "xmlbuilder2": "2.1.2"
-      },
-      "dependencies": {
-        "@wpmedia/feeds-find-video-stream": {
-          "version": "1.0.6",
-          "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-find-video-stream/1.0.6/257ad4f8ca5e3973cac0a1dc099725e75f14dc57723e50d8549bc3bac17042b0",
-          "integrity": "sha512-JXmTMavkzWbWMjvipPDsLc/rwYu0bx5X2mTvb+ap+FqWoBBkJh3nebGFq/DMfSS5ewLtukC16cwRfdgxqsl0Jw==",
-          "requires": {
-            "jmespath": "^0.15.0"
-          }
-        },
-        "@wpmedia/feeds-resizer": {
-          "version": "1.0.6",
-          "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-resizer/1.0.6/0ce63a556ffef4fe4176e2a48973b1cd63812783bed5ac47220755a83334d702",
-          "integrity": "sha512-V9ShtU87YdAZjdWC2AsWKhR1E8Q7CRcJ747lPy51p7oqwlWCfEX8OqCFfNJSzrAcHqNYTzaa4cBgDso5lQEYFw==",
-          "requires": {
-            "thumbor-lite": "^0.1.8"
-          }
-        }
       }
     },
     "@wpmedia/feeds-find-video-stream": {
-      "version": "1.0.6",
-      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-find-video-stream/1.0.6/257ad4f8ca5e3973cac0a1dc099725e75f14dc57723e50d8549bc3bac17042b0",
-      "integrity": "sha512-JXmTMavkzWbWMjvipPDsLc/rwYu0bx5X2mTvb+ap+FqWoBBkJh3nebGFq/DMfSS5ewLtukC16cwRfdgxqsl0Jw==",
+      "version": "1.0.7",
+      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-find-video-stream/1.0.7/84256b5e5e561670869c668293ccf9a783c6a3fe629bf74f63364cb021f25f0d",
+      "integrity": "sha512-g57SPA3WM35k8mL0fK+gT9XUz5XtdFOGQHpmuk0vwmYj6AV4xrXIVL2qiwXzrBARyt3eJHgib+bZd1TUdE4zMA==",
       "requires": {
         "jmespath": "^0.15.0"
       }
     },
     "@wpmedia/feeds-promo-items": {
-      "version": "1.0.6",
-      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-promo-items/1.0.6/58fb23405fe24290f546d289c7d5816cd4aa84c0760744dd396ab08932ed4fb9",
-      "integrity": "sha512-MzsGyGZ/rGNAAqlmAyKrO0MWrQyQgWCDYcnlptcwHYUVcyf81TGbAnS9ce2LwRoaeuOgVpHClJz5u5tTq0HZcA==",
+      "version": "1.0.7",
+      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-promo-items/1.0.7/f10d8da401a66012dc91a48cd543455b3fc7b73572311e66522c4fc5515d2e0e",
+      "integrity": "sha512-e6XR6cb4IGUmcL8hR1y79IabyoUMPrVT0etQ07UffxNij2XW2SF/ilmnlXvzl57ukLUlUknjQHNkhLUp0tAOtA==",
       "requires": {
-        "@wpmedia/feeds-find-video-stream": "1.0.6",
-        "@wpmedia/feeds-resizer": "1.0.6",
+        "@wpmedia/feeds-find-video-stream": "1.0.7",
+        "@wpmedia/feeds-resizer": "1.0.7",
         "jmespath": "^0.15.0"
       }
     },
     "@wpmedia/feeds-prop-types": {
-      "version": "1.0.6",
-      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-prop-types/1.0.6/c9381195fd94a475eca7a6820b9a72bb06f0a53a3b7796294ea32ac23bcd8302",
-      "integrity": "sha512-spfC4q2n2Lts+oEvA6e0PcNoV9QwisMNzf9MWf1C0/CIkoe6P8HXzfTa3rewNxWo26Am9rS4LQ7EgYZ5hM1F8Q==",
+      "version": "1.0.7",
+      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-prop-types/1.0.7/66391267d37397f1005fd3c0ab2cfb221a4be4cfceff3df1044f318ff796bed4",
+      "integrity": "sha512-/LU1yrkxjTj1hZ5aWEjzTg4yJFx845DBv10Wc4vUw83R1tDYO7GfdcNq5WJLdxs/nB5jU7nSBcy+l9JpOvNoEA==",
       "requires": {
         "prop-types": "^15.7.2"
       }
     },
     "@wpmedia/feeds-resizer": {
-      "version": "1.0.6",
-      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-resizer/1.0.6/0ce63a556ffef4fe4176e2a48973b1cd63812783bed5ac47220755a83334d702",
-      "integrity": "sha512-V9ShtU87YdAZjdWC2AsWKhR1E8Q7CRcJ747lPy51p7oqwlWCfEX8OqCFfNJSzrAcHqNYTzaa4cBgDso5lQEYFw==",
+      "version": "1.0.7",
+      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-resizer/1.0.7/a46142ce4e537dc88a41f138b3a74d39bc7c819667bc56ebd52b2838a527358e",
+      "integrity": "sha512-R0GiWxkLStpIn1hkiOJHiPZ0nzpz4LrpKTNQGiPbobKXfqEfPSl/GJBKZfZGxa7MBV1TQqWkoHLudPHxpxbngA==",
       "requires": {
         "thumbor-lite": "^0.1.8"
       }

--- a/blocks/mrss-feature-block/package.json
+++ b/blocks/mrss-feature-block/package.json
@@ -22,10 +22,10 @@
   ],
   "homepage": "https://github.com/WPMedia/feed-components#readme",
   "dependencies": {
-    "@wpmedia/feeds-content-elements": "^1.0.6",
-    "@wpmedia/feeds-promo-items": "1.0.6",
-    "@wpmedia/feeds-prop-types": "1.0.6",
-    "@wpmedia/feeds-resizer": "^1.0.6",
+    "@wpmedia/feeds-content-elements": "^1.0.7",
+    "@wpmedia/feeds-promo-items": "1.0.7",
+    "@wpmedia/feeds-prop-types": "1.0.7",
+    "@wpmedia/feeds-resizer": "^1.0.7",
     "jmespath": "^0.15.0",
     "moment": "^2.24.0"
   }

--- a/blocks/rss-alexa-feature-block/package-lock.json
+++ b/blocks/rss-alexa-feature-block/package-lock.json
@@ -73,37 +73,37 @@
       "integrity": "sha512-Ufpab7G5PfnEhQyy5kDg9C8ltWJjsVT1P/IYqacjstaqydG4Q21HAT2HUZQYBrC/a1ZLKCz87pfydlDvv8y97w=="
     },
     "@wpmedia/feeds-content-elements": {
-      "version": "1.0.6",
-      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-content-elements/1.0.6/876919f45373c1e555886df6c5fe21d80bd440831a1d6a2f6ee0ff03f1ea49b6",
-      "integrity": "sha512-l5ZHtic8FQxHay5o0S6SEitRGTRQpMaQmHp+tXABP8TSqduLOmsnorkWqLNcGt28XmXdKaG37bHWA0RBEXfa7Q==",
+      "version": "1.0.7",
+      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-content-elements/1.0.7/0fe5b6c6e84c14bbc088c7f5f36e45da8a87bccf0b98370a941f8c0d6e2ece8d",
+      "integrity": "sha512-QebfMsKkYcA3SPbL6og0G6sXGQ1AMe5hJ8fUqztwcG7XBbKq7FXPMB3FRFjWUM6SVfb6Z3VYmeqWwpwqBM8JCg==",
       "requires": {
-        "@wpmedia/feeds-find-video-stream": "1.0.6",
-        "@wpmedia/feeds-resizer": "1.0.6",
+        "@wpmedia/feeds-find-video-stream": "1.0.7",
+        "@wpmedia/feeds-resizer": "1.0.7",
         "he": "^1.2.0",
         "jmespath": "^0.15.0",
         "xmlbuilder2": "2.1.2"
       }
     },
     "@wpmedia/feeds-find-video-stream": {
-      "version": "1.0.6",
-      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-find-video-stream/1.0.6/257ad4f8ca5e3973cac0a1dc099725e75f14dc57723e50d8549bc3bac17042b0",
-      "integrity": "sha512-JXmTMavkzWbWMjvipPDsLc/rwYu0bx5X2mTvb+ap+FqWoBBkJh3nebGFq/DMfSS5ewLtukC16cwRfdgxqsl0Jw==",
+      "version": "1.0.7",
+      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-find-video-stream/1.0.7/84256b5e5e561670869c668293ccf9a783c6a3fe629bf74f63364cb021f25f0d",
+      "integrity": "sha512-g57SPA3WM35k8mL0fK+gT9XUz5XtdFOGQHpmuk0vwmYj6AV4xrXIVL2qiwXzrBARyt3eJHgib+bZd1TUdE4zMA==",
       "requires": {
         "jmespath": "^0.15.0"
       }
     },
     "@wpmedia/feeds-prop-types": {
-      "version": "1.0.6",
-      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-prop-types/1.0.6/c9381195fd94a475eca7a6820b9a72bb06f0a53a3b7796294ea32ac23bcd8302",
-      "integrity": "sha512-spfC4q2n2Lts+oEvA6e0PcNoV9QwisMNzf9MWf1C0/CIkoe6P8HXzfTa3rewNxWo26Am9rS4LQ7EgYZ5hM1F8Q==",
+      "version": "1.0.7",
+      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-prop-types/1.0.7/66391267d37397f1005fd3c0ab2cfb221a4be4cfceff3df1044f318ff796bed4",
+      "integrity": "sha512-/LU1yrkxjTj1hZ5aWEjzTg4yJFx845DBv10Wc4vUw83R1tDYO7GfdcNq5WJLdxs/nB5jU7nSBcy+l9JpOvNoEA==",
       "requires": {
         "prop-types": "^15.7.2"
       }
     },
     "@wpmedia/feeds-resizer": {
-      "version": "1.0.6",
-      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-resizer/1.0.6/0ce63a556ffef4fe4176e2a48973b1cd63812783bed5ac47220755a83334d702",
-      "integrity": "sha512-V9ShtU87YdAZjdWC2AsWKhR1E8Q7CRcJ747lPy51p7oqwlWCfEX8OqCFfNJSzrAcHqNYTzaa4cBgDso5lQEYFw==",
+      "version": "1.0.7",
+      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-resizer/1.0.7/a46142ce4e537dc88a41f138b3a74d39bc7c819667bc56ebd52b2838a527358e",
+      "integrity": "sha512-R0GiWxkLStpIn1hkiOJHiPZ0nzpz4LrpKTNQGiPbobKXfqEfPSl/GJBKZfZGxa7MBV1TQqWkoHLudPHxpxbngA==",
       "requires": {
         "thumbor-lite": "^0.1.8"
       }

--- a/blocks/rss-alexa-feature-block/package.json
+++ b/blocks/rss-alexa-feature-block/package.json
@@ -23,9 +23,9 @@
   ],
   "homepage": "https://github.com/WPMedia/feed-components#readme",
   "dependencies": {
-    "@wpmedia/feeds-content-elements": "^1.0.6",
-    "@wpmedia/feeds-prop-types": "^1.0.6",
-    "@wpmedia/feeds-resizer": "^1.0.6",
+    "@wpmedia/feeds-content-elements": "^1.0.7",
+    "@wpmedia/feeds-prop-types": "^1.0.7",
+    "@wpmedia/feeds-resizer": "^1.0.7",
     "cheerio": "^1.0.0-rc.10",
     "jmespath": "^0.15.0",
     "moment": "^2.24.0"

--- a/blocks/rss-fbia-feature-block/package-lock.json
+++ b/blocks/rss-fbia-feature-block/package-lock.json
@@ -73,33 +73,17 @@
       "integrity": "sha512-Ufpab7G5PfnEhQyy5kDg9C8ltWJjsVT1P/IYqacjstaqydG4Q21HAT2HUZQYBrC/a1ZLKCz87pfydlDvv8y97w=="
     },
     "@wpmedia/feeds-content-elements": {
-      "version": "1.0.6",
-      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-content-elements/1.0.6/876919f45373c1e555886df6c5fe21d80bd440831a1d6a2f6ee0ff03f1ea49b6",
-      "integrity": "sha512-l5ZHtic8FQxHay5o0S6SEitRGTRQpMaQmHp+tXABP8TSqduLOmsnorkWqLNcGt28XmXdKaG37bHWA0RBEXfa7Q==",
+      "version": "1.0.7",
+      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-content-elements/1.0.7/0fe5b6c6e84c14bbc088c7f5f36e45da8a87bccf0b98370a941f8c0d6e2ece8d",
+      "integrity": "sha512-QebfMsKkYcA3SPbL6og0G6sXGQ1AMe5hJ8fUqztwcG7XBbKq7FXPMB3FRFjWUM6SVfb6Z3VYmeqWwpwqBM8JCg==",
       "requires": {
-        "@wpmedia/feeds-find-video-stream": "1.0.6",
-        "@wpmedia/feeds-resizer": "1.0.6",
+        "@wpmedia/feeds-find-video-stream": "1.0.7",
+        "@wpmedia/feeds-resizer": "1.0.7",
         "he": "^1.2.0",
         "jmespath": "^0.15.0",
         "xmlbuilder2": "2.1.2"
       },
       "dependencies": {
-        "@wpmedia/feeds-find-video-stream": {
-          "version": "1.0.6",
-          "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-find-video-stream/1.0.6/257ad4f8ca5e3973cac0a1dc099725e75f14dc57723e50d8549bc3bac17042b0",
-          "integrity": "sha512-JXmTMavkzWbWMjvipPDsLc/rwYu0bx5X2mTvb+ap+FqWoBBkJh3nebGFq/DMfSS5ewLtukC16cwRfdgxqsl0Jw==",
-          "requires": {
-            "jmespath": "^0.15.0"
-          }
-        },
-        "@wpmedia/feeds-resizer": {
-          "version": "1.0.6",
-          "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-resizer/1.0.6/0ce63a556ffef4fe4176e2a48973b1cd63812783bed5ac47220755a83334d702",
-          "integrity": "sha512-V9ShtU87YdAZjdWC2AsWKhR1E8Q7CRcJ747lPy51p7oqwlWCfEX8OqCFfNJSzrAcHqNYTzaa4cBgDso5lQEYFw==",
-          "requires": {
-            "thumbor-lite": "^0.1.8"
-          }
-        },
         "xmlbuilder2": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/xmlbuilder2/-/xmlbuilder2-2.1.2.tgz",
@@ -113,35 +97,35 @@
       }
     },
     "@wpmedia/feeds-find-video-stream": {
-      "version": "1.0.6",
-      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-find-video-stream/1.0.6/257ad4f8ca5e3973cac0a1dc099725e75f14dc57723e50d8549bc3bac17042b0",
-      "integrity": "sha512-JXmTMavkzWbWMjvipPDsLc/rwYu0bx5X2mTvb+ap+FqWoBBkJh3nebGFq/DMfSS5ewLtukC16cwRfdgxqsl0Jw==",
+      "version": "1.0.7",
+      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-find-video-stream/1.0.7/84256b5e5e561670869c668293ccf9a783c6a3fe629bf74f63364cb021f25f0d",
+      "integrity": "sha512-g57SPA3WM35k8mL0fK+gT9XUz5XtdFOGQHpmuk0vwmYj6AV4xrXIVL2qiwXzrBARyt3eJHgib+bZd1TUdE4zMA==",
       "requires": {
         "jmespath": "^0.15.0"
       }
     },
     "@wpmedia/feeds-promo-items": {
-      "version": "1.0.6",
-      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-promo-items/1.0.6/58fb23405fe24290f546d289c7d5816cd4aa84c0760744dd396ab08932ed4fb9",
-      "integrity": "sha512-MzsGyGZ/rGNAAqlmAyKrO0MWrQyQgWCDYcnlptcwHYUVcyf81TGbAnS9ce2LwRoaeuOgVpHClJz5u5tTq0HZcA==",
+      "version": "1.0.7",
+      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-promo-items/1.0.7/f10d8da401a66012dc91a48cd543455b3fc7b73572311e66522c4fc5515d2e0e",
+      "integrity": "sha512-e6XR6cb4IGUmcL8hR1y79IabyoUMPrVT0etQ07UffxNij2XW2SF/ilmnlXvzl57ukLUlUknjQHNkhLUp0tAOtA==",
       "requires": {
-        "@wpmedia/feeds-find-video-stream": "1.0.6",
-        "@wpmedia/feeds-resizer": "1.0.6",
+        "@wpmedia/feeds-find-video-stream": "1.0.7",
+        "@wpmedia/feeds-resizer": "1.0.7",
         "jmespath": "^0.15.0"
       }
     },
     "@wpmedia/feeds-prop-types": {
-      "version": "1.0.6",
-      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-prop-types/1.0.6/c9381195fd94a475eca7a6820b9a72bb06f0a53a3b7796294ea32ac23bcd8302",
-      "integrity": "sha512-spfC4q2n2Lts+oEvA6e0PcNoV9QwisMNzf9MWf1C0/CIkoe6P8HXzfTa3rewNxWo26Am9rS4LQ7EgYZ5hM1F8Q==",
+      "version": "1.0.7",
+      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-prop-types/1.0.7/66391267d37397f1005fd3c0ab2cfb221a4be4cfceff3df1044f318ff796bed4",
+      "integrity": "sha512-/LU1yrkxjTj1hZ5aWEjzTg4yJFx845DBv10Wc4vUw83R1tDYO7GfdcNq5WJLdxs/nB5jU7nSBcy+l9JpOvNoEA==",
       "requires": {
         "prop-types": "^15.7.2"
       }
     },
     "@wpmedia/feeds-resizer": {
-      "version": "1.0.6",
-      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-resizer/1.0.6/0ce63a556ffef4fe4176e2a48973b1cd63812783bed5ac47220755a83334d702",
-      "integrity": "sha512-V9ShtU87YdAZjdWC2AsWKhR1E8Q7CRcJ747lPy51p7oqwlWCfEX8OqCFfNJSzrAcHqNYTzaa4cBgDso5lQEYFw==",
+      "version": "1.0.7",
+      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-resizer/1.0.7/a46142ce4e537dc88a41f138b3a74d39bc7c819667bc56ebd52b2838a527358e",
+      "integrity": "sha512-R0GiWxkLStpIn1hkiOJHiPZ0nzpz4LrpKTNQGiPbobKXfqEfPSl/GJBKZfZGxa7MBV1TQqWkoHLudPHxpxbngA==",
       "requires": {
         "thumbor-lite": "^0.1.8"
       }

--- a/blocks/rss-fbia-feature-block/package.json
+++ b/blocks/rss-fbia-feature-block/package.json
@@ -24,10 +24,10 @@
   ],
   "homepage": "https://github.com/WPMedia/feed-components#readme",
   "dependencies": {
-    "@wpmedia/feeds-content-elements": "^1.0.6",
-    "@wpmedia/feeds-promo-items": "1.0.6",
-    "@wpmedia/feeds-prop-types": "1.0.6",
-    "@wpmedia/feeds-resizer": "^1.0.6",
+    "@wpmedia/feeds-content-elements": "^1.0.7",
+    "@wpmedia/feeds-promo-items": "1.0.7",
+    "@wpmedia/feeds-prop-types": "1.0.7",
+    "@wpmedia/feeds-resizer": "^1.0.7",
     "jmespath": "^0.15.0",
     "moment": "^2.24.0",
     "xmlbuilder2": "2.1.7"

--- a/blocks/rss-feature-block/package-lock.json
+++ b/blocks/rss-feature-block/package-lock.json
@@ -73,65 +73,47 @@
       "integrity": "sha512-Ufpab7G5PfnEhQyy5kDg9C8ltWJjsVT1P/IYqacjstaqydG4Q21HAT2HUZQYBrC/a1ZLKCz87pfydlDvv8y97w=="
     },
     "@wpmedia/feeds-content-elements": {
-      "version": "1.0.6",
-      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-content-elements/1.0.6/876919f45373c1e555886df6c5fe21d80bd440831a1d6a2f6ee0ff03f1ea49b6",
-      "integrity": "sha512-l5ZHtic8FQxHay5o0S6SEitRGTRQpMaQmHp+tXABP8TSqduLOmsnorkWqLNcGt28XmXdKaG37bHWA0RBEXfa7Q==",
+      "version": "1.0.7",
+      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-content-elements/1.0.7/0fe5b6c6e84c14bbc088c7f5f36e45da8a87bccf0b98370a941f8c0d6e2ece8d",
+      "integrity": "sha512-QebfMsKkYcA3SPbL6og0G6sXGQ1AMe5hJ8fUqztwcG7XBbKq7FXPMB3FRFjWUM6SVfb6Z3VYmeqWwpwqBM8JCg==",
       "requires": {
-        "@wpmedia/feeds-find-video-stream": "1.0.6",
-        "@wpmedia/feeds-resizer": "1.0.6",
+        "@wpmedia/feeds-find-video-stream": "1.0.7",
+        "@wpmedia/feeds-resizer": "1.0.7",
         "he": "^1.2.0",
         "jmespath": "^0.15.0",
         "xmlbuilder2": "2.1.2"
-      },
-      "dependencies": {
-        "@wpmedia/feeds-find-video-stream": {
-          "version": "1.0.6",
-          "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-find-video-stream/1.0.6/257ad4f8ca5e3973cac0a1dc099725e75f14dc57723e50d8549bc3bac17042b0",
-          "integrity": "sha512-JXmTMavkzWbWMjvipPDsLc/rwYu0bx5X2mTvb+ap+FqWoBBkJh3nebGFq/DMfSS5ewLtukC16cwRfdgxqsl0Jw==",
-          "requires": {
-            "jmespath": "^0.15.0"
-          }
-        },
-        "@wpmedia/feeds-resizer": {
-          "version": "1.0.6",
-          "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-resizer/1.0.6/0ce63a556ffef4fe4176e2a48973b1cd63812783bed5ac47220755a83334d702",
-          "integrity": "sha512-V9ShtU87YdAZjdWC2AsWKhR1E8Q7CRcJ747lPy51p7oqwlWCfEX8OqCFfNJSzrAcHqNYTzaa4cBgDso5lQEYFw==",
-          "requires": {
-            "thumbor-lite": "^0.1.8"
-          }
-        }
       }
     },
     "@wpmedia/feeds-find-video-stream": {
-      "version": "1.0.6",
-      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-find-video-stream/1.0.6/257ad4f8ca5e3973cac0a1dc099725e75f14dc57723e50d8549bc3bac17042b0",
-      "integrity": "sha512-JXmTMavkzWbWMjvipPDsLc/rwYu0bx5X2mTvb+ap+FqWoBBkJh3nebGFq/DMfSS5ewLtukC16cwRfdgxqsl0Jw==",
+      "version": "1.0.7",
+      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-find-video-stream/1.0.7/84256b5e5e561670869c668293ccf9a783c6a3fe629bf74f63364cb021f25f0d",
+      "integrity": "sha512-g57SPA3WM35k8mL0fK+gT9XUz5XtdFOGQHpmuk0vwmYj6AV4xrXIVL2qiwXzrBARyt3eJHgib+bZd1TUdE4zMA==",
       "requires": {
         "jmespath": "^0.15.0"
       }
     },
     "@wpmedia/feeds-promo-items": {
-      "version": "1.0.6",
-      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-promo-items/1.0.6/58fb23405fe24290f546d289c7d5816cd4aa84c0760744dd396ab08932ed4fb9",
-      "integrity": "sha512-MzsGyGZ/rGNAAqlmAyKrO0MWrQyQgWCDYcnlptcwHYUVcyf81TGbAnS9ce2LwRoaeuOgVpHClJz5u5tTq0HZcA==",
+      "version": "1.0.7",
+      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-promo-items/1.0.7/f10d8da401a66012dc91a48cd543455b3fc7b73572311e66522c4fc5515d2e0e",
+      "integrity": "sha512-e6XR6cb4IGUmcL8hR1y79IabyoUMPrVT0etQ07UffxNij2XW2SF/ilmnlXvzl57ukLUlUknjQHNkhLUp0tAOtA==",
       "requires": {
-        "@wpmedia/feeds-find-video-stream": "1.0.6",
-        "@wpmedia/feeds-resizer": "1.0.6",
+        "@wpmedia/feeds-find-video-stream": "1.0.7",
+        "@wpmedia/feeds-resizer": "1.0.7",
         "jmespath": "^0.15.0"
       }
     },
     "@wpmedia/feeds-prop-types": {
-      "version": "1.0.6",
-      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-prop-types/1.0.6/c9381195fd94a475eca7a6820b9a72bb06f0a53a3b7796294ea32ac23bcd8302",
-      "integrity": "sha512-spfC4q2n2Lts+oEvA6e0PcNoV9QwisMNzf9MWf1C0/CIkoe6P8HXzfTa3rewNxWo26Am9rS4LQ7EgYZ5hM1F8Q==",
+      "version": "1.0.7",
+      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-prop-types/1.0.7/66391267d37397f1005fd3c0ab2cfb221a4be4cfceff3df1044f318ff796bed4",
+      "integrity": "sha512-/LU1yrkxjTj1hZ5aWEjzTg4yJFx845DBv10Wc4vUw83R1tDYO7GfdcNq5WJLdxs/nB5jU7nSBcy+l9JpOvNoEA==",
       "requires": {
         "prop-types": "^15.7.2"
       }
     },
     "@wpmedia/feeds-resizer": {
-      "version": "1.0.6",
-      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-resizer/1.0.6/0ce63a556ffef4fe4176e2a48973b1cd63812783bed5ac47220755a83334d702",
-      "integrity": "sha512-V9ShtU87YdAZjdWC2AsWKhR1E8Q7CRcJ747lPy51p7oqwlWCfEX8OqCFfNJSzrAcHqNYTzaa4cBgDso5lQEYFw==",
+      "version": "1.0.7",
+      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-resizer/1.0.7/a46142ce4e537dc88a41f138b3a74d39bc7c819667bc56ebd52b2838a527358e",
+      "integrity": "sha512-R0GiWxkLStpIn1hkiOJHiPZ0nzpz4LrpKTNQGiPbobKXfqEfPSl/GJBKZfZGxa7MBV1TQqWkoHLudPHxpxbngA==",
       "requires": {
         "thumbor-lite": "^0.1.8"
       }

--- a/blocks/rss-feature-block/package.json
+++ b/blocks/rss-feature-block/package.json
@@ -23,10 +23,10 @@
   ],
   "homepage": "https://github.com/WPMedia/feed-components#readme",
   "dependencies": {
-    "@wpmedia/feeds-content-elements": "^1.0.6",
-    "@wpmedia/feeds-promo-items": "1.0.6",
-    "@wpmedia/feeds-prop-types": "1.0.6",
-    "@wpmedia/feeds-resizer": "^1.0.6",
+    "@wpmedia/feeds-content-elements": "^1.0.7",
+    "@wpmedia/feeds-promo-items": "1.0.7",
+    "@wpmedia/feeds-prop-types": "1.0.7",
+    "@wpmedia/feeds-resizer": "^1.0.7",
     "jmespath": "^0.15.0",
     "moment": "^2.24.0"
   }

--- a/blocks/rss-flipboard-feature-block/package-lock.json
+++ b/blocks/rss-flipboard-feature-block/package-lock.json
@@ -73,65 +73,47 @@
       "integrity": "sha512-Ufpab7G5PfnEhQyy5kDg9C8ltWJjsVT1P/IYqacjstaqydG4Q21HAT2HUZQYBrC/a1ZLKCz87pfydlDvv8y97w=="
     },
     "@wpmedia/feeds-content-elements": {
-      "version": "1.0.6",
-      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-content-elements/1.0.6/876919f45373c1e555886df6c5fe21d80bd440831a1d6a2f6ee0ff03f1ea49b6",
-      "integrity": "sha512-l5ZHtic8FQxHay5o0S6SEitRGTRQpMaQmHp+tXABP8TSqduLOmsnorkWqLNcGt28XmXdKaG37bHWA0RBEXfa7Q==",
+      "version": "1.0.7",
+      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-content-elements/1.0.7/0fe5b6c6e84c14bbc088c7f5f36e45da8a87bccf0b98370a941f8c0d6e2ece8d",
+      "integrity": "sha512-QebfMsKkYcA3SPbL6og0G6sXGQ1AMe5hJ8fUqztwcG7XBbKq7FXPMB3FRFjWUM6SVfb6Z3VYmeqWwpwqBM8JCg==",
       "requires": {
-        "@wpmedia/feeds-find-video-stream": "1.0.6",
-        "@wpmedia/feeds-resizer": "1.0.6",
+        "@wpmedia/feeds-find-video-stream": "1.0.7",
+        "@wpmedia/feeds-resizer": "1.0.7",
         "he": "^1.2.0",
         "jmespath": "^0.15.0",
         "xmlbuilder2": "2.1.2"
-      },
-      "dependencies": {
-        "@wpmedia/feeds-find-video-stream": {
-          "version": "1.0.6",
-          "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-find-video-stream/1.0.6/257ad4f8ca5e3973cac0a1dc099725e75f14dc57723e50d8549bc3bac17042b0",
-          "integrity": "sha512-JXmTMavkzWbWMjvipPDsLc/rwYu0bx5X2mTvb+ap+FqWoBBkJh3nebGFq/DMfSS5ewLtukC16cwRfdgxqsl0Jw==",
-          "requires": {
-            "jmespath": "^0.15.0"
-          }
-        },
-        "@wpmedia/feeds-resizer": {
-          "version": "1.0.6",
-          "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-resizer/1.0.6/0ce63a556ffef4fe4176e2a48973b1cd63812783bed5ac47220755a83334d702",
-          "integrity": "sha512-V9ShtU87YdAZjdWC2AsWKhR1E8Q7CRcJ747lPy51p7oqwlWCfEX8OqCFfNJSzrAcHqNYTzaa4cBgDso5lQEYFw==",
-          "requires": {
-            "thumbor-lite": "^0.1.8"
-          }
-        }
       }
     },
     "@wpmedia/feeds-find-video-stream": {
-      "version": "1.0.6",
-      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-find-video-stream/1.0.6/257ad4f8ca5e3973cac0a1dc099725e75f14dc57723e50d8549bc3bac17042b0",
-      "integrity": "sha512-JXmTMavkzWbWMjvipPDsLc/rwYu0bx5X2mTvb+ap+FqWoBBkJh3nebGFq/DMfSS5ewLtukC16cwRfdgxqsl0Jw==",
+      "version": "1.0.7",
+      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-find-video-stream/1.0.7/84256b5e5e561670869c668293ccf9a783c6a3fe629bf74f63364cb021f25f0d",
+      "integrity": "sha512-g57SPA3WM35k8mL0fK+gT9XUz5XtdFOGQHpmuk0vwmYj6AV4xrXIVL2qiwXzrBARyt3eJHgib+bZd1TUdE4zMA==",
       "requires": {
         "jmespath": "^0.15.0"
       }
     },
     "@wpmedia/feeds-promo-items": {
-      "version": "1.0.6",
-      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-promo-items/1.0.6/58fb23405fe24290f546d289c7d5816cd4aa84c0760744dd396ab08932ed4fb9",
-      "integrity": "sha512-MzsGyGZ/rGNAAqlmAyKrO0MWrQyQgWCDYcnlptcwHYUVcyf81TGbAnS9ce2LwRoaeuOgVpHClJz5u5tTq0HZcA==",
+      "version": "1.0.7",
+      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-promo-items/1.0.7/f10d8da401a66012dc91a48cd543455b3fc7b73572311e66522c4fc5515d2e0e",
+      "integrity": "sha512-e6XR6cb4IGUmcL8hR1y79IabyoUMPrVT0etQ07UffxNij2XW2SF/ilmnlXvzl57ukLUlUknjQHNkhLUp0tAOtA==",
       "requires": {
-        "@wpmedia/feeds-find-video-stream": "1.0.6",
-        "@wpmedia/feeds-resizer": "1.0.6",
+        "@wpmedia/feeds-find-video-stream": "1.0.7",
+        "@wpmedia/feeds-resizer": "1.0.7",
         "jmespath": "^0.15.0"
       }
     },
     "@wpmedia/feeds-prop-types": {
-      "version": "1.0.6",
-      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-prop-types/1.0.6/c9381195fd94a475eca7a6820b9a72bb06f0a53a3b7796294ea32ac23bcd8302",
-      "integrity": "sha512-spfC4q2n2Lts+oEvA6e0PcNoV9QwisMNzf9MWf1C0/CIkoe6P8HXzfTa3rewNxWo26Am9rS4LQ7EgYZ5hM1F8Q==",
+      "version": "1.0.7",
+      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-prop-types/1.0.7/66391267d37397f1005fd3c0ab2cfb221a4be4cfceff3df1044f318ff796bed4",
+      "integrity": "sha512-/LU1yrkxjTj1hZ5aWEjzTg4yJFx845DBv10Wc4vUw83R1tDYO7GfdcNq5WJLdxs/nB5jU7nSBcy+l9JpOvNoEA==",
       "requires": {
         "prop-types": "^15.7.2"
       }
     },
     "@wpmedia/feeds-resizer": {
-      "version": "1.0.6",
-      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-resizer/1.0.6/0ce63a556ffef4fe4176e2a48973b1cd63812783bed5ac47220755a83334d702",
-      "integrity": "sha512-V9ShtU87YdAZjdWC2AsWKhR1E8Q7CRcJ747lPy51p7oqwlWCfEX8OqCFfNJSzrAcHqNYTzaa4cBgDso5lQEYFw==",
+      "version": "1.0.7",
+      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-resizer/1.0.7/a46142ce4e537dc88a41f138b3a74d39bc7c819667bc56ebd52b2838a527358e",
+      "integrity": "sha512-R0GiWxkLStpIn1hkiOJHiPZ0nzpz4LrpKTNQGiPbobKXfqEfPSl/GJBKZfZGxa7MBV1TQqWkoHLudPHxpxbngA==",
       "requires": {
         "thumbor-lite": "^0.1.8"
       }

--- a/blocks/rss-flipboard-feature-block/package.json
+++ b/blocks/rss-flipboard-feature-block/package.json
@@ -22,10 +22,10 @@
   ],
   "homepage": "https://github.com/WPMedia/feed-components#readme",
   "dependencies": {
-    "@wpmedia/feeds-content-elements": "^1.0.6",
-    "@wpmedia/feeds-promo-items": "1.0.6",
-    "@wpmedia/feeds-prop-types": "1.0.6",
-    "@wpmedia/feeds-resizer": "^1.0.6",
+    "@wpmedia/feeds-content-elements": "^1.0.7",
+    "@wpmedia/feeds-promo-items": "1.0.7",
+    "@wpmedia/feeds-prop-types": "1.0.7",
+    "@wpmedia/feeds-resizer": "^1.0.7",
     "jmespath": "^0.15.0",
     "moment": "^2.24.0"
   }

--- a/blocks/rss-google-news-feature-block/package-lock.json
+++ b/blocks/rss-google-news-feature-block/package-lock.json
@@ -73,65 +73,47 @@
       "integrity": "sha512-Ufpab7G5PfnEhQyy5kDg9C8ltWJjsVT1P/IYqacjstaqydG4Q21HAT2HUZQYBrC/a1ZLKCz87pfydlDvv8y97w=="
     },
     "@wpmedia/feeds-content-elements": {
-      "version": "1.0.6",
-      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-content-elements/1.0.6/876919f45373c1e555886df6c5fe21d80bd440831a1d6a2f6ee0ff03f1ea49b6",
-      "integrity": "sha512-l5ZHtic8FQxHay5o0S6SEitRGTRQpMaQmHp+tXABP8TSqduLOmsnorkWqLNcGt28XmXdKaG37bHWA0RBEXfa7Q==",
+      "version": "1.0.7",
+      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-content-elements/1.0.7/0fe5b6c6e84c14bbc088c7f5f36e45da8a87bccf0b98370a941f8c0d6e2ece8d",
+      "integrity": "sha512-QebfMsKkYcA3SPbL6og0G6sXGQ1AMe5hJ8fUqztwcG7XBbKq7FXPMB3FRFjWUM6SVfb6Z3VYmeqWwpwqBM8JCg==",
       "requires": {
-        "@wpmedia/feeds-find-video-stream": "1.0.6",
-        "@wpmedia/feeds-resizer": "1.0.6",
+        "@wpmedia/feeds-find-video-stream": "1.0.7",
+        "@wpmedia/feeds-resizer": "1.0.7",
         "he": "^1.2.0",
         "jmespath": "^0.15.0",
         "xmlbuilder2": "2.1.2"
-      },
-      "dependencies": {
-        "@wpmedia/feeds-find-video-stream": {
-          "version": "1.0.6",
-          "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-find-video-stream/1.0.6/257ad4f8ca5e3973cac0a1dc099725e75f14dc57723e50d8549bc3bac17042b0",
-          "integrity": "sha512-JXmTMavkzWbWMjvipPDsLc/rwYu0bx5X2mTvb+ap+FqWoBBkJh3nebGFq/DMfSS5ewLtukC16cwRfdgxqsl0Jw==",
-          "requires": {
-            "jmespath": "^0.15.0"
-          }
-        },
-        "@wpmedia/feeds-resizer": {
-          "version": "1.0.6",
-          "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-resizer/1.0.6/0ce63a556ffef4fe4176e2a48973b1cd63812783bed5ac47220755a83334d702",
-          "integrity": "sha512-V9ShtU87YdAZjdWC2AsWKhR1E8Q7CRcJ747lPy51p7oqwlWCfEX8OqCFfNJSzrAcHqNYTzaa4cBgDso5lQEYFw==",
-          "requires": {
-            "thumbor-lite": "^0.1.8"
-          }
-        }
       }
     },
     "@wpmedia/feeds-find-video-stream": {
-      "version": "1.0.6",
-      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-find-video-stream/1.0.6/257ad4f8ca5e3973cac0a1dc099725e75f14dc57723e50d8549bc3bac17042b0",
-      "integrity": "sha512-JXmTMavkzWbWMjvipPDsLc/rwYu0bx5X2mTvb+ap+FqWoBBkJh3nebGFq/DMfSS5ewLtukC16cwRfdgxqsl0Jw==",
+      "version": "1.0.7",
+      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-find-video-stream/1.0.7/84256b5e5e561670869c668293ccf9a783c6a3fe629bf74f63364cb021f25f0d",
+      "integrity": "sha512-g57SPA3WM35k8mL0fK+gT9XUz5XtdFOGQHpmuk0vwmYj6AV4xrXIVL2qiwXzrBARyt3eJHgib+bZd1TUdE4zMA==",
       "requires": {
         "jmespath": "^0.15.0"
       }
     },
     "@wpmedia/feeds-promo-items": {
-      "version": "1.0.6",
-      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-promo-items/1.0.6/58fb23405fe24290f546d289c7d5816cd4aa84c0760744dd396ab08932ed4fb9",
-      "integrity": "sha512-MzsGyGZ/rGNAAqlmAyKrO0MWrQyQgWCDYcnlptcwHYUVcyf81TGbAnS9ce2LwRoaeuOgVpHClJz5u5tTq0HZcA==",
+      "version": "1.0.7",
+      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-promo-items/1.0.7/f10d8da401a66012dc91a48cd543455b3fc7b73572311e66522c4fc5515d2e0e",
+      "integrity": "sha512-e6XR6cb4IGUmcL8hR1y79IabyoUMPrVT0etQ07UffxNij2XW2SF/ilmnlXvzl57ukLUlUknjQHNkhLUp0tAOtA==",
       "requires": {
-        "@wpmedia/feeds-find-video-stream": "1.0.6",
-        "@wpmedia/feeds-resizer": "1.0.6",
+        "@wpmedia/feeds-find-video-stream": "1.0.7",
+        "@wpmedia/feeds-resizer": "1.0.7",
         "jmespath": "^0.15.0"
       }
     },
     "@wpmedia/feeds-prop-types": {
-      "version": "1.0.6",
-      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-prop-types/1.0.6/c9381195fd94a475eca7a6820b9a72bb06f0a53a3b7796294ea32ac23bcd8302",
-      "integrity": "sha512-spfC4q2n2Lts+oEvA6e0PcNoV9QwisMNzf9MWf1C0/CIkoe6P8HXzfTa3rewNxWo26Am9rS4LQ7EgYZ5hM1F8Q==",
+      "version": "1.0.7",
+      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-prop-types/1.0.7/66391267d37397f1005fd3c0ab2cfb221a4be4cfceff3df1044f318ff796bed4",
+      "integrity": "sha512-/LU1yrkxjTj1hZ5aWEjzTg4yJFx845DBv10Wc4vUw83R1tDYO7GfdcNq5WJLdxs/nB5jU7nSBcy+l9JpOvNoEA==",
       "requires": {
         "prop-types": "^15.7.2"
       }
     },
     "@wpmedia/feeds-resizer": {
-      "version": "1.0.6",
-      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-resizer/1.0.6/0ce63a556ffef4fe4176e2a48973b1cd63812783bed5ac47220755a83334d702",
-      "integrity": "sha512-V9ShtU87YdAZjdWC2AsWKhR1E8Q7CRcJ747lPy51p7oqwlWCfEX8OqCFfNJSzrAcHqNYTzaa4cBgDso5lQEYFw==",
+      "version": "1.0.7",
+      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-resizer/1.0.7/a46142ce4e537dc88a41f138b3a74d39bc7c819667bc56ebd52b2838a527358e",
+      "integrity": "sha512-R0GiWxkLStpIn1hkiOJHiPZ0nzpz4LrpKTNQGiPbobKXfqEfPSl/GJBKZfZGxa7MBV1TQqWkoHLudPHxpxbngA==",
       "requires": {
         "thumbor-lite": "^0.1.8"
       }

--- a/blocks/rss-google-news-feature-block/package.json
+++ b/blocks/rss-google-news-feature-block/package.json
@@ -23,10 +23,10 @@
   ],
   "homepage": "https://github.com/WPMedia/feed-components#readme",
   "dependencies": {
-    "@wpmedia/feeds-content-elements": "^1.0.6",
-    "@wpmedia/feeds-promo-items": "1.0.6",
-    "@wpmedia/feeds-prop-types": "1.0.6",
-    "@wpmedia/feeds-resizer": "^1.0.6",
+    "@wpmedia/feeds-content-elements": "^1.0.7",
+    "@wpmedia/feeds-promo-items": "1.0.7",
+    "@wpmedia/feeds-prop-types": "1.0.7",
+    "@wpmedia/feeds-resizer": "^1.0.7",
     "jmespath": "^0.15.0",
     "moment": "^2.24.0"
   }

--- a/blocks/rss-msn-feature-block/package-lock.json
+++ b/blocks/rss-msn-feature-block/package-lock.json
@@ -73,65 +73,47 @@
       "integrity": "sha512-Ufpab7G5PfnEhQyy5kDg9C8ltWJjsVT1P/IYqacjstaqydG4Q21HAT2HUZQYBrC/a1ZLKCz87pfydlDvv8y97w=="
     },
     "@wpmedia/feeds-content-elements": {
-      "version": "1.0.6",
-      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-content-elements/1.0.6/876919f45373c1e555886df6c5fe21d80bd440831a1d6a2f6ee0ff03f1ea49b6",
-      "integrity": "sha512-l5ZHtic8FQxHay5o0S6SEitRGTRQpMaQmHp+tXABP8TSqduLOmsnorkWqLNcGt28XmXdKaG37bHWA0RBEXfa7Q==",
+      "version": "1.0.7",
+      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-content-elements/1.0.7/0fe5b6c6e84c14bbc088c7f5f36e45da8a87bccf0b98370a941f8c0d6e2ece8d",
+      "integrity": "sha512-QebfMsKkYcA3SPbL6og0G6sXGQ1AMe5hJ8fUqztwcG7XBbKq7FXPMB3FRFjWUM6SVfb6Z3VYmeqWwpwqBM8JCg==",
       "requires": {
-        "@wpmedia/feeds-find-video-stream": "1.0.6",
-        "@wpmedia/feeds-resizer": "1.0.6",
+        "@wpmedia/feeds-find-video-stream": "1.0.7",
+        "@wpmedia/feeds-resizer": "1.0.7",
         "he": "^1.2.0",
         "jmespath": "^0.15.0",
         "xmlbuilder2": "2.1.2"
-      },
-      "dependencies": {
-        "@wpmedia/feeds-find-video-stream": {
-          "version": "1.0.6",
-          "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-find-video-stream/1.0.6/257ad4f8ca5e3973cac0a1dc099725e75f14dc57723e50d8549bc3bac17042b0",
-          "integrity": "sha512-JXmTMavkzWbWMjvipPDsLc/rwYu0bx5X2mTvb+ap+FqWoBBkJh3nebGFq/DMfSS5ewLtukC16cwRfdgxqsl0Jw==",
-          "requires": {
-            "jmespath": "^0.15.0"
-          }
-        },
-        "@wpmedia/feeds-resizer": {
-          "version": "1.0.6",
-          "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-resizer/1.0.6/0ce63a556ffef4fe4176e2a48973b1cd63812783bed5ac47220755a83334d702",
-          "integrity": "sha512-V9ShtU87YdAZjdWC2AsWKhR1E8Q7CRcJ747lPy51p7oqwlWCfEX8OqCFfNJSzrAcHqNYTzaa4cBgDso5lQEYFw==",
-          "requires": {
-            "thumbor-lite": "^0.1.8"
-          }
-        }
       }
     },
     "@wpmedia/feeds-find-video-stream": {
-      "version": "1.0.6",
-      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-find-video-stream/1.0.6/257ad4f8ca5e3973cac0a1dc099725e75f14dc57723e50d8549bc3bac17042b0",
-      "integrity": "sha512-JXmTMavkzWbWMjvipPDsLc/rwYu0bx5X2mTvb+ap+FqWoBBkJh3nebGFq/DMfSS5ewLtukC16cwRfdgxqsl0Jw==",
+      "version": "1.0.7",
+      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-find-video-stream/1.0.7/84256b5e5e561670869c668293ccf9a783c6a3fe629bf74f63364cb021f25f0d",
+      "integrity": "sha512-g57SPA3WM35k8mL0fK+gT9XUz5XtdFOGQHpmuk0vwmYj6AV4xrXIVL2qiwXzrBARyt3eJHgib+bZd1TUdE4zMA==",
       "requires": {
         "jmespath": "^0.15.0"
       }
     },
     "@wpmedia/feeds-promo-items": {
-      "version": "1.0.6",
-      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-promo-items/1.0.6/58fb23405fe24290f546d289c7d5816cd4aa84c0760744dd396ab08932ed4fb9",
-      "integrity": "sha512-MzsGyGZ/rGNAAqlmAyKrO0MWrQyQgWCDYcnlptcwHYUVcyf81TGbAnS9ce2LwRoaeuOgVpHClJz5u5tTq0HZcA==",
+      "version": "1.0.7",
+      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-promo-items/1.0.7/f10d8da401a66012dc91a48cd543455b3fc7b73572311e66522c4fc5515d2e0e",
+      "integrity": "sha512-e6XR6cb4IGUmcL8hR1y79IabyoUMPrVT0etQ07UffxNij2XW2SF/ilmnlXvzl57ukLUlUknjQHNkhLUp0tAOtA==",
       "requires": {
-        "@wpmedia/feeds-find-video-stream": "1.0.6",
-        "@wpmedia/feeds-resizer": "1.0.6",
+        "@wpmedia/feeds-find-video-stream": "1.0.7",
+        "@wpmedia/feeds-resizer": "1.0.7",
         "jmespath": "^0.15.0"
       }
     },
     "@wpmedia/feeds-prop-types": {
-      "version": "1.0.6",
-      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-prop-types/1.0.6/c9381195fd94a475eca7a6820b9a72bb06f0a53a3b7796294ea32ac23bcd8302",
-      "integrity": "sha512-spfC4q2n2Lts+oEvA6e0PcNoV9QwisMNzf9MWf1C0/CIkoe6P8HXzfTa3rewNxWo26Am9rS4LQ7EgYZ5hM1F8Q==",
+      "version": "1.0.7",
+      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-prop-types/1.0.7/66391267d37397f1005fd3c0ab2cfb221a4be4cfceff3df1044f318ff796bed4",
+      "integrity": "sha512-/LU1yrkxjTj1hZ5aWEjzTg4yJFx845DBv10Wc4vUw83R1tDYO7GfdcNq5WJLdxs/nB5jU7nSBcy+l9JpOvNoEA==",
       "requires": {
         "prop-types": "^15.7.2"
       }
     },
     "@wpmedia/feeds-resizer": {
-      "version": "1.0.6",
-      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-resizer/1.0.6/0ce63a556ffef4fe4176e2a48973b1cd63812783bed5ac47220755a83334d702",
-      "integrity": "sha512-V9ShtU87YdAZjdWC2AsWKhR1E8Q7CRcJ747lPy51p7oqwlWCfEX8OqCFfNJSzrAcHqNYTzaa4cBgDso5lQEYFw==",
+      "version": "1.0.7",
+      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-resizer/1.0.7/a46142ce4e537dc88a41f138b3a74d39bc7c819667bc56ebd52b2838a527358e",
+      "integrity": "sha512-R0GiWxkLStpIn1hkiOJHiPZ0nzpz4LrpKTNQGiPbobKXfqEfPSl/GJBKZfZGxa7MBV1TQqWkoHLudPHxpxbngA==",
       "requires": {
         "thumbor-lite": "^0.1.8"
       }

--- a/blocks/rss-msn-feature-block/package.json
+++ b/blocks/rss-msn-feature-block/package.json
@@ -23,10 +23,10 @@
   ],
   "homepage": "https://github.com/WPMedia/feed-components#readme",
   "dependencies": {
-    "@wpmedia/feeds-content-elements": "^1.0.6",
-    "@wpmedia/feeds-promo-items": "1.0.6",
-    "@wpmedia/feeds-prop-types": "1.0.6",
-    "@wpmedia/feeds-resizer": "^1.0.6",
+    "@wpmedia/feeds-content-elements": "^1.0.7",
+    "@wpmedia/feeds-promo-items": "1.0.7",
+    "@wpmedia/feeds-prop-types": "1.0.7",
+    "@wpmedia/feeds-resizer": "^1.0.7",
     "jmespath": "^0.15.0",
     "moment": "^2.24.0"
   }

--- a/blocks/sitemap-feature-block/package-lock.json
+++ b/blocks/sitemap-feature-block/package-lock.json
@@ -5,35 +5,35 @@
   "requires": true,
   "dependencies": {
     "@wpmedia/feeds-find-video-stream": {
-      "version": "1.0.6",
-      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-find-video-stream/1.0.6/257ad4f8ca5e3973cac0a1dc099725e75f14dc57723e50d8549bc3bac17042b0",
-      "integrity": "sha512-JXmTMavkzWbWMjvipPDsLc/rwYu0bx5X2mTvb+ap+FqWoBBkJh3nebGFq/DMfSS5ewLtukC16cwRfdgxqsl0Jw==",
+      "version": "1.0.7",
+      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-find-video-stream/1.0.7/84256b5e5e561670869c668293ccf9a783c6a3fe629bf74f63364cb021f25f0d",
+      "integrity": "sha512-g57SPA3WM35k8mL0fK+gT9XUz5XtdFOGQHpmuk0vwmYj6AV4xrXIVL2qiwXzrBARyt3eJHgib+bZd1TUdE4zMA==",
       "requires": {
         "jmespath": "^0.15.0"
       }
     },
     "@wpmedia/feeds-promo-items": {
-      "version": "1.0.6",
-      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-promo-items/1.0.6/58fb23405fe24290f546d289c7d5816cd4aa84c0760744dd396ab08932ed4fb9",
-      "integrity": "sha512-MzsGyGZ/rGNAAqlmAyKrO0MWrQyQgWCDYcnlptcwHYUVcyf81TGbAnS9ce2LwRoaeuOgVpHClJz5u5tTq0HZcA==",
+      "version": "1.0.7",
+      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-promo-items/1.0.7/f10d8da401a66012dc91a48cd543455b3fc7b73572311e66522c4fc5515d2e0e",
+      "integrity": "sha512-e6XR6cb4IGUmcL8hR1y79IabyoUMPrVT0etQ07UffxNij2XW2SF/ilmnlXvzl57ukLUlUknjQHNkhLUp0tAOtA==",
       "requires": {
-        "@wpmedia/feeds-find-video-stream": "1.0.6",
-        "@wpmedia/feeds-resizer": "1.0.6",
+        "@wpmedia/feeds-find-video-stream": "1.0.7",
+        "@wpmedia/feeds-resizer": "1.0.7",
         "jmespath": "^0.15.0"
       }
     },
     "@wpmedia/feeds-prop-types": {
-      "version": "1.0.6",
-      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-prop-types/1.0.6/c9381195fd94a475eca7a6820b9a72bb06f0a53a3b7796294ea32ac23bcd8302",
-      "integrity": "sha512-spfC4q2n2Lts+oEvA6e0PcNoV9QwisMNzf9MWf1C0/CIkoe6P8HXzfTa3rewNxWo26Am9rS4LQ7EgYZ5hM1F8Q==",
+      "version": "1.0.7",
+      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-prop-types/1.0.7/66391267d37397f1005fd3c0ab2cfb221a4be4cfceff3df1044f318ff796bed4",
+      "integrity": "sha512-/LU1yrkxjTj1hZ5aWEjzTg4yJFx845DBv10Wc4vUw83R1tDYO7GfdcNq5WJLdxs/nB5jU7nSBcy+l9JpOvNoEA==",
       "requires": {
         "prop-types": "^15.7.2"
       }
     },
     "@wpmedia/feeds-resizer": {
-      "version": "1.0.6",
-      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-resizer/1.0.6/0ce63a556ffef4fe4176e2a48973b1cd63812783bed5ac47220755a83334d702",
-      "integrity": "sha512-V9ShtU87YdAZjdWC2AsWKhR1E8Q7CRcJ747lPy51p7oqwlWCfEX8OqCFfNJSzrAcHqNYTzaa4cBgDso5lQEYFw==",
+      "version": "1.0.7",
+      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-resizer/1.0.7/a46142ce4e537dc88a41f138b3a74d39bc7c819667bc56ebd52b2838a527358e",
+      "integrity": "sha512-R0GiWxkLStpIn1hkiOJHiPZ0nzpz4LrpKTNQGiPbobKXfqEfPSl/GJBKZfZGxa7MBV1TQqWkoHLudPHxpxbngA==",
       "requires": {
         "thumbor-lite": "^0.1.8"
       }

--- a/blocks/sitemap-feature-block/package.json
+++ b/blocks/sitemap-feature-block/package.json
@@ -22,7 +22,7 @@
   ],
   "homepage": "https://github.com/WPMedia/feed-components#readme",
   "dependencies": {
-    "@wpmedia/feeds-promo-items": "1.0.6",
-    "@wpmedia/feeds-prop-types": "1.0.6"
+    "@wpmedia/feeds-promo-items": "1.0.7",
+    "@wpmedia/feeds-prop-types": "1.0.7"
   }
 }

--- a/blocks/sitemap-news-feature-block/package-lock.json
+++ b/blocks/sitemap-news-feature-block/package-lock.json
@@ -5,35 +5,35 @@
   "requires": true,
   "dependencies": {
     "@wpmedia/feeds-find-video-stream": {
-      "version": "1.0.6",
-      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-find-video-stream/1.0.6/257ad4f8ca5e3973cac0a1dc099725e75f14dc57723e50d8549bc3bac17042b0",
-      "integrity": "sha512-JXmTMavkzWbWMjvipPDsLc/rwYu0bx5X2mTvb+ap+FqWoBBkJh3nebGFq/DMfSS5ewLtukC16cwRfdgxqsl0Jw==",
+      "version": "1.0.7",
+      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-find-video-stream/1.0.7/84256b5e5e561670869c668293ccf9a783c6a3fe629bf74f63364cb021f25f0d",
+      "integrity": "sha512-g57SPA3WM35k8mL0fK+gT9XUz5XtdFOGQHpmuk0vwmYj6AV4xrXIVL2qiwXzrBARyt3eJHgib+bZd1TUdE4zMA==",
       "requires": {
         "jmespath": "^0.15.0"
       }
     },
     "@wpmedia/feeds-promo-items": {
-      "version": "1.0.6",
-      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-promo-items/1.0.6/58fb23405fe24290f546d289c7d5816cd4aa84c0760744dd396ab08932ed4fb9",
-      "integrity": "sha512-MzsGyGZ/rGNAAqlmAyKrO0MWrQyQgWCDYcnlptcwHYUVcyf81TGbAnS9ce2LwRoaeuOgVpHClJz5u5tTq0HZcA==",
+      "version": "1.0.7",
+      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-promo-items/1.0.7/f10d8da401a66012dc91a48cd543455b3fc7b73572311e66522c4fc5515d2e0e",
+      "integrity": "sha512-e6XR6cb4IGUmcL8hR1y79IabyoUMPrVT0etQ07UffxNij2XW2SF/ilmnlXvzl57ukLUlUknjQHNkhLUp0tAOtA==",
       "requires": {
-        "@wpmedia/feeds-find-video-stream": "1.0.6",
-        "@wpmedia/feeds-resizer": "1.0.6",
+        "@wpmedia/feeds-find-video-stream": "1.0.7",
+        "@wpmedia/feeds-resizer": "1.0.7",
         "jmespath": "^0.15.0"
       }
     },
     "@wpmedia/feeds-prop-types": {
-      "version": "1.0.6",
-      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-prop-types/1.0.6/c9381195fd94a475eca7a6820b9a72bb06f0a53a3b7796294ea32ac23bcd8302",
-      "integrity": "sha512-spfC4q2n2Lts+oEvA6e0PcNoV9QwisMNzf9MWf1C0/CIkoe6P8HXzfTa3rewNxWo26Am9rS4LQ7EgYZ5hM1F8Q==",
+      "version": "1.0.7",
+      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-prop-types/1.0.7/66391267d37397f1005fd3c0ab2cfb221a4be4cfceff3df1044f318ff796bed4",
+      "integrity": "sha512-/LU1yrkxjTj1hZ5aWEjzTg4yJFx845DBv10Wc4vUw83R1tDYO7GfdcNq5WJLdxs/nB5jU7nSBcy+l9JpOvNoEA==",
       "requires": {
         "prop-types": "^15.7.2"
       }
     },
     "@wpmedia/feeds-resizer": {
-      "version": "1.0.6",
-      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-resizer/1.0.6/0ce63a556ffef4fe4176e2a48973b1cd63812783bed5ac47220755a83334d702",
-      "integrity": "sha512-V9ShtU87YdAZjdWC2AsWKhR1E8Q7CRcJ747lPy51p7oqwlWCfEX8OqCFfNJSzrAcHqNYTzaa4cBgDso5lQEYFw==",
+      "version": "1.0.7",
+      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-resizer/1.0.7/a46142ce4e537dc88a41f138b3a74d39bc7c819667bc56ebd52b2838a527358e",
+      "integrity": "sha512-R0GiWxkLStpIn1hkiOJHiPZ0nzpz4LrpKTNQGiPbobKXfqEfPSl/GJBKZfZGxa7MBV1TQqWkoHLudPHxpxbngA==",
       "requires": {
         "thumbor-lite": "^0.1.8"
       }

--- a/blocks/sitemap-news-feature-block/package.json
+++ b/blocks/sitemap-news-feature-block/package.json
@@ -23,8 +23,8 @@
   ],
   "homepage": "https://github.com/WPMedia/feed-components#readme",
   "dependencies": {
-    "@wpmedia/feeds-promo-items": "1.0.6",
-    "@wpmedia/feeds-prop-types": "1.0.6",
+    "@wpmedia/feeds-promo-items": "1.0.7",
+    "@wpmedia/feeds-prop-types": "1.0.7",
     "jmespath": "^0.15.0"
   }
 }

--- a/blocks/sitemap-video-feature-block/package-lock.json
+++ b/blocks/sitemap-video-feature-block/package-lock.json
@@ -5,35 +5,35 @@
   "requires": true,
   "dependencies": {
     "@wpmedia/feeds-find-video-stream": {
-      "version": "1.0.6",
-      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-find-video-stream/1.0.6/257ad4f8ca5e3973cac0a1dc099725e75f14dc57723e50d8549bc3bac17042b0",
-      "integrity": "sha512-JXmTMavkzWbWMjvipPDsLc/rwYu0bx5X2mTvb+ap+FqWoBBkJh3nebGFq/DMfSS5ewLtukC16cwRfdgxqsl0Jw==",
+      "version": "1.0.7",
+      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-find-video-stream/1.0.7/84256b5e5e561670869c668293ccf9a783c6a3fe629bf74f63364cb021f25f0d",
+      "integrity": "sha512-g57SPA3WM35k8mL0fK+gT9XUz5XtdFOGQHpmuk0vwmYj6AV4xrXIVL2qiwXzrBARyt3eJHgib+bZd1TUdE4zMA==",
       "requires": {
         "jmespath": "^0.15.0"
       }
     },
     "@wpmedia/feeds-promo-items": {
-      "version": "1.0.6",
-      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-promo-items/1.0.6/58fb23405fe24290f546d289c7d5816cd4aa84c0760744dd396ab08932ed4fb9",
-      "integrity": "sha512-MzsGyGZ/rGNAAqlmAyKrO0MWrQyQgWCDYcnlptcwHYUVcyf81TGbAnS9ce2LwRoaeuOgVpHClJz5u5tTq0HZcA==",
+      "version": "1.0.7",
+      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-promo-items/1.0.7/f10d8da401a66012dc91a48cd543455b3fc7b73572311e66522c4fc5515d2e0e",
+      "integrity": "sha512-e6XR6cb4IGUmcL8hR1y79IabyoUMPrVT0etQ07UffxNij2XW2SF/ilmnlXvzl57ukLUlUknjQHNkhLUp0tAOtA==",
       "requires": {
-        "@wpmedia/feeds-find-video-stream": "1.0.6",
-        "@wpmedia/feeds-resizer": "1.0.6",
+        "@wpmedia/feeds-find-video-stream": "1.0.7",
+        "@wpmedia/feeds-resizer": "1.0.7",
         "jmespath": "^0.15.0"
       }
     },
     "@wpmedia/feeds-prop-types": {
-      "version": "1.0.6",
-      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-prop-types/1.0.6/c9381195fd94a475eca7a6820b9a72bb06f0a53a3b7796294ea32ac23bcd8302",
-      "integrity": "sha512-spfC4q2n2Lts+oEvA6e0PcNoV9QwisMNzf9MWf1C0/CIkoe6P8HXzfTa3rewNxWo26Am9rS4LQ7EgYZ5hM1F8Q==",
+      "version": "1.0.7",
+      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-prop-types/1.0.7/66391267d37397f1005fd3c0ab2cfb221a4be4cfceff3df1044f318ff796bed4",
+      "integrity": "sha512-/LU1yrkxjTj1hZ5aWEjzTg4yJFx845DBv10Wc4vUw83R1tDYO7GfdcNq5WJLdxs/nB5jU7nSBcy+l9JpOvNoEA==",
       "requires": {
         "prop-types": "^15.7.2"
       }
     },
     "@wpmedia/feeds-resizer": {
-      "version": "1.0.6",
-      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-resizer/1.0.6/0ce63a556ffef4fe4176e2a48973b1cd63812783bed5ac47220755a83334d702",
-      "integrity": "sha512-V9ShtU87YdAZjdWC2AsWKhR1E8Q7CRcJ747lPy51p7oqwlWCfEX8OqCFfNJSzrAcHqNYTzaa4cBgDso5lQEYFw==",
+      "version": "1.0.7",
+      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-resizer/1.0.7/a46142ce4e537dc88a41f138b3a74d39bc7c819667bc56ebd52b2838a527358e",
+      "integrity": "sha512-R0GiWxkLStpIn1hkiOJHiPZ0nzpz4LrpKTNQGiPbobKXfqEfPSl/GJBKZfZGxa7MBV1TQqWkoHLudPHxpxbngA==",
       "requires": {
         "thumbor-lite": "^0.1.8"
       }

--- a/blocks/sitemap-video-feature-block/package.json
+++ b/blocks/sitemap-video-feature-block/package.json
@@ -25,9 +25,9 @@
   "homepage": "https://github.com/WPMedia/feed-components#readme",
   "dependencies": {
     "jmespath": "^0.15.0",
-    "@wpmedia/feeds-find-video-stream": "1.0.6",
-    "@wpmedia/feeds-promo-items": "1.0.6",
-    "@wpmedia/feeds-prop-types": "1.0.6",
-    "@wpmedia/feeds-resizer": "1.0.6"
+    "@wpmedia/feeds-find-video-stream": "1.0.7",
+    "@wpmedia/feeds-promo-items": "1.0.7",
+    "@wpmedia/feeds-prop-types": "1.0.7",
+    "@wpmedia/feeds-resizer": "1.0.7"
   }
 }

--- a/utils/content-elements/package-lock.json
+++ b/utils/content-elements/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/feeds-content-elements",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -73,17 +73,17 @@
       "integrity": "sha512-Ufpab7G5PfnEhQyy5kDg9C8ltWJjsVT1P/IYqacjstaqydG4Q21HAT2HUZQYBrC/a1ZLKCz87pfydlDvv8y97w=="
     },
     "@wpmedia/feeds-find-video-stream": {
-      "version": "1.0.6",
-      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-find-video-stream/1.0.6/257ad4f8ca5e3973cac0a1dc099725e75f14dc57723e50d8549bc3bac17042b0",
-      "integrity": "sha512-JXmTMavkzWbWMjvipPDsLc/rwYu0bx5X2mTvb+ap+FqWoBBkJh3nebGFq/DMfSS5ewLtukC16cwRfdgxqsl0Jw==",
+      "version": "1.0.7",
+      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-find-video-stream/1.0.7/84256b5e5e561670869c668293ccf9a783c6a3fe629bf74f63364cb021f25f0d",
+      "integrity": "sha512-g57SPA3WM35k8mL0fK+gT9XUz5XtdFOGQHpmuk0vwmYj6AV4xrXIVL2qiwXzrBARyt3eJHgib+bZd1TUdE4zMA==",
       "requires": {
         "jmespath": "^0.15.0"
       }
     },
     "@wpmedia/feeds-resizer": {
-      "version": "1.0.6",
-      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-resizer/1.0.6/0ce63a556ffef4fe4176e2a48973b1cd63812783bed5ac47220755a83334d702",
-      "integrity": "sha512-V9ShtU87YdAZjdWC2AsWKhR1E8Q7CRcJ747lPy51p7oqwlWCfEX8OqCFfNJSzrAcHqNYTzaa4cBgDso5lQEYFw==",
+      "version": "1.0.7",
+      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-resizer/1.0.7/a46142ce4e537dc88a41f138b3a74d39bc7c819667bc56ebd52b2838a527358e",
+      "integrity": "sha512-R0GiWxkLStpIn1hkiOJHiPZ0nzpz4LrpKTNQGiPbobKXfqEfPSl/GJBKZfZGxa7MBV1TQqWkoHLudPHxpxbngA==",
       "requires": {
         "thumbor-lite": "^0.1.8"
       }

--- a/utils/content-elements/package.json
+++ b/utils/content-elements/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/feeds-content-elements",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Shared arcio content_elements module",
   "main": "dist/feeds-content-elements.cjs.js",
   "module": "dist/feeds-content-elements.esm.js",
@@ -21,10 +21,10 @@
     "access": "restricted"
   },
   "author": "Tim Kosmider <timothy.kosmider@washpost.com>",
-  "license": "UNLICENSED",
+  "license": "CC-BY-NC-ND-4.0",
   "dependencies": {
-    "@wpmedia/feeds-find-video-stream": "1.0.6",
-    "@wpmedia/feeds-resizer": "1.0.6",
+    "@wpmedia/feeds-find-video-stream": "1.0.7",
+    "@wpmedia/feeds-resizer": "1.0.7",
     "he": "^1.2.0",
     "jmespath": "^0.15.0",
     "xmlbuilder2": "2.1.2"

--- a/utils/content-source-utils/README.md
+++ b/utils/content-source-utils/README.md
@@ -1,0 +1,26 @@
+# Feeds Content Source Utils
+
+A collection of globals and helper functions shared by content sources
+
+## Globals
+
+- defaultANSFields - Array of ANS fields to use in \_source_includes parameter
+
+  To reduce the Content-API response size, only fields used are included. Multi-site
+  clients can have a lot of data in taxonomy.sections. Multiple records for each website.
+  That is why it's not includes, the section will come from websites.
+
+  - The content source needs to add the calling website into this list `websites.{arc-site}`
+  - content_elements is not included. It needs to be added by the content_source if needed.
+
+- validANSDates - Array of valid ANS date fields
+
+## functions
+
+- formatSections - takes a comma separated string of sections, returns an object to use in the DSL
+- generateDistributor - looks for the 4 distributor params and returns up to one param
+- generateParamList - takes an object of key:values, and returns a string of key=value to use as url parameters
+- transform - put websites data into expected locations
+  move websites.{website}.website_section to taxonomy.sections
+  move websites.{website}.website_url to root
+  create website at root

--- a/utils/content-source-utils/package-lock.json
+++ b/utils/content-source-utils/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "@wpmedia/feeds-content-source-utils",
+  "version": "1.0.7",
+  "lockfileVersion": 1
+}

--- a/utils/content-source-utils/package.json
+++ b/utils/content-source-utils/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@wpmedia/feeds-content-source-utils",
+  "version": "1.0.7",
+  "description": "Shared content source globals and functions",
+  "main": "dist/feeds-content-source-utils.cjs.js",
+  "module": "dist/feeds-content-source-utils.esm.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/WPMedia/feed-components.git",
+    "directory": "utils/content-source-utils"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/",
+    "access": "restricted"
+  },
+  "author": "Tim Kosmider",
+  "license": "CC-BY-NC-ND-4.0",
+  "dependencies": {}
+}

--- a/utils/content-source-utils/src/formatSections.js
+++ b/utils/content-source-utils/src/formatSections.js
@@ -1,0 +1,11 @@
+export const formatSections = (section) => {
+  const sectionArray = section
+    .split(',')
+    .map((item) => item.trim().replace(/\/$/, ''))
+    .map((item) => (item.startsWith('/') ? item : `/${item}`))
+  return {
+    terms: {
+      'taxonomy.sections._id': sectionArray,
+    },
+  }
+}

--- a/utils/content-source-utils/src/formatSections.test.js
+++ b/utils/content-source-utils/src/formatSections.test.js
@@ -1,0 +1,16 @@
+// eslint-disable-next-line no-unused-vars
+import { formatSections } from './'
+
+it('Test with single section data no slash', () => {
+  const sections = formatSections('test')
+  expect(sections).toEqual({ terms: { 'taxonomy.sections._id': ['/test'] } })
+})
+
+it('Test with multiple section and subsection data no slash', () => {
+  const sections = formatSections('world/uk/,/sports/highschool/football/')
+  expect(sections).toEqual({
+    terms: {
+      'taxonomy.sections._id': ['/world/uk', '/sports/highschool/football'],
+    },
+  })
+})

--- a/utils/content-source-utils/src/generateDistributor.js
+++ b/utils/content-source-utils/src/generateDistributor.js
@@ -1,0 +1,12 @@
+export const generateDistributor = (key, paramList) => {
+  if (key['Include-Distributor-Name']) {
+    paramList.include_distributor_name = key['Include-Distributor-Name']
+  } else if (key['Exclude-Distributor-Name']) {
+    paramList.exclude_distributor_name = key['Exclude-Distributor-Name']
+  } else if (key['Include-Distributor-Category']) {
+    paramList.include_distributor_category = key['Include-Distributor-Category']
+  } else if (key['Exclude-Distributor-Category']) {
+    paramList.exclude_distributor_category = key['Exclude-Distributor-Category']
+  }
+  return paramList
+}

--- a/utils/content-source-utils/src/generateDistributor.test.js
+++ b/utils/content-source-utils/src/generateDistributor.test.js
@@ -1,0 +1,79 @@
+// eslint-disable-next-line no-unused-vars
+import { generateDistributor } from './'
+
+const defaultParams = { size: 100, sort: 'display_date:desc' }
+
+it('Test distributor with empty data', () => {
+  const paramList = generateDistributor({}, {})
+  expect(paramList).toEqual({})
+})
+
+it('Test distributor works with existing data', () => {
+  const paramList = generateDistributor({}, defaultParams)
+  expect(paramList).toEqual(defaultParams)
+})
+
+it('Test distributor name', () => {
+  let paramList = defaultParams
+  paramList = generateDistributor(
+    { 'Include-Distributor-Name': 'AP,reuters' },
+    paramList,
+  )
+  expect(paramList).toEqual({
+    ...defaultParams,
+    include_distributor_name: 'AP,reuters',
+  })
+})
+
+it('Test Exclude distributor name', () => {
+  let paramList = defaultParams
+  paramList = generateDistributor(
+    { 'Exclude-Distributor-Name': 'AP,reuters' },
+    paramList,
+  )
+  expect(paramList).toEqual({
+    ...defaultParams,
+    exclude_distributor_name: 'AP,reuters',
+  })
+})
+
+it('Test distributor categoru', () => {
+  let paramList = defaultParams
+  paramList = generateDistributor(
+    { 'Include-Distributor-Category': 'wires' },
+    paramList,
+  )
+  expect(paramList).toEqual({
+    ...defaultParams,
+    include_distributor_category: 'wires',
+  })
+})
+
+it('Test Exclude distributor category', () => {
+  let paramList = defaultParams
+  paramList = generateDistributor(
+    { 'Exclude-Distributor-Category': 'wires' },
+    paramList,
+  )
+  expect(paramList).toEqual({
+    ...defaultParams,
+    include_distributor_category: 'wires',
+  })
+})
+
+it('Test combination of params', () => {
+  let paramList = defaultParams
+  paramList = generateDistributor(
+    {
+      'Include-Distributor-Name': 'AP',
+      'Exclude-Distributor-Name': 'reuters',
+      'Include-Distributor-Category': 'wires',
+      'Exclude-Distributor-Category': 'premium',
+    },
+    paramList,
+  )
+  expect(paramList).toEqual({
+    ...defaultParams,
+    include_distributor_name: 'AP',
+  })
+})

--- a/utils/content-source-utils/src/generateParamList.js
+++ b/utils/content-source-utils/src/generateParamList.js
@@ -1,0 +1,7 @@
+export const genParams = (paramList) => {
+  return Object.keys(paramList)
+    .reduce((acc, key) => {
+      return [...acc, `${key}=${paramList[key]}`]
+    }, [])
+    .join('&')
+}

--- a/utils/content-source-utils/src/generateParamList.test.js
+++ b/utils/content-source-utils/src/generateParamList.test.js
@@ -1,0 +1,14 @@
+// eslint-disable-next-line no-unused-vars
+import { genParams } from './'
+
+const defaultParams = { size: 100, sort: 'display_date:desc' }
+
+it('Test with empty data', () => {
+  const paramList = genParams({})
+  expect(paramList).toEqual('')
+})
+
+it('Test with data', () => {
+  const paramList = genParams(defaultParams)
+  expect(paramList).toEqual('size=100&sort=display_date:desc')
+})

--- a/utils/content-source-utils/src/index.js
+++ b/utils/content-source-utils/src/index.js
@@ -1,0 +1,37 @@
+export * from './formatSections'
+export * from './generateDistributor'
+export * from './generateParamList'
+export * from './transform'
+
+export const defaultANSFields = [
+  'canonical_url',
+  'canonical_website',
+  'created_date',
+  'credits',
+  'description',
+  'display_date',
+  'duration',
+  'first_publish_date',
+  'headlines',
+  'last_updated_date',
+  'promo_image',
+  'promo_items',
+  'publish_date',
+  'streams',
+  'subheadlines',
+  'subtitles',
+  'subtype',
+  'taxonomy.primary_section',
+  'taxonomy.seo_keywords',
+  'taxonomy.tags',
+  'type',
+  'video_type',
+]
+
+export const validANSDates = [
+  'created_date',
+  'last_updated_date',
+  'display_date',
+  'first_publish_date',
+  'publish_date',
+]

--- a/utils/content-source-utils/src/transform.js
+++ b/utils/content-source-utils/src/transform.js
@@ -1,0 +1,18 @@
+export const transform = (data, query) => {
+  const source = data || {}
+  const website = query['arc-site']
+  if (source.content_elements && source.content_elements.length) {
+    const transformedContent = source.content_elements.map((i) => {
+      if (i?.websites?.[website]?.website_section && !i?.taxonomy?.sections) {
+        if (!i.taxonomy) i.taxonomy = {}
+        i.taxonomy.sections = [i.websites[website].website_section]
+      }
+      if (i?.websites?.[website]?.website_url)
+        i.website_url = i.websites[website].website_url
+      i.website = website
+      return i
+    })
+    source.content_elements = transformedContent
+    return source
+  }
+}

--- a/utils/content-source-utils/src/transform.test.js
+++ b/utils/content-source-utils/src/transform.test.js
@@ -1,0 +1,95 @@
+// eslint-disable-next-line no-unused-vars
+import { transform } from './'
+
+const globalContent = {
+  content_elements: [
+    {
+      taxonomy: {
+        tags: [],
+      },
+      websites: {
+        demo: {
+          website_url: '/news/test-article-1',
+          website_section: {
+            _id: '/news',
+          },
+        },
+      },
+    },
+    {
+      taxonomy: {
+        tags: [],
+        sections: [{ _id: '/sports' }],
+      },
+      websites: {
+        demo: {
+          website_url: '/news/test-article-2',
+          website_section: {
+            _id: '/news',
+          },
+        },
+      },
+    },
+    {
+      websites: {
+        demo: {
+          website_url: '/news/test-article-3',
+          website_section: {
+            _id: '/news',
+          },
+        },
+      },
+    },
+  ],
+}
+
+it('Test transform with empty data', () => {
+  const transformedANS = transform(undefined, {
+    'arc-site': 'demo',
+  })
+  expect(transformedANS).toBe(undefined)
+})
+
+// Every article should have a website and website_url. Only replace sections if !exist
+it('Test transform', () => {
+  const transformedANS = transform(globalContent, {
+    'arc-site': 'demo',
+  })
+  expect(transformedANS).toEqual({
+    content_elements: [
+      {
+        taxonomy: { sections: [{ _id: '/news' }], tags: [] },
+        website: 'demo',
+        website_url: '/news/test-article-1',
+        websites: {
+          demo: {
+            website_section: { _id: '/news' },
+            website_url: '/news/test-article-1',
+          },
+        },
+      },
+      {
+        taxonomy: { sections: [{ _id: '/sports' }], tags: [] },
+        website: 'demo',
+        website_url: '/news/test-article-2',
+        websites: {
+          demo: {
+            website_section: { _id: '/news' },
+            website_url: '/news/test-article-2',
+          },
+        },
+      },
+      {
+        taxonomy: { sections: [{ _id: '/news' }] },
+        website: 'demo',
+        website_url: '/news/test-article-3',
+        websites: {
+          demo: {
+            website_section: { _id: '/news' },
+            website_url: '/news/test-article-3',
+          },
+        },
+      },
+    ],
+  })
+})

--- a/utils/find-video-stream/package-lock.json
+++ b/utils/find-video-stream/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/feeds-find-video-stream",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/utils/find-video-stream/package.json
+++ b/utils/find-video-stream/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/feeds-find-video-stream",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Utility to search video stream for desired encoding",
   "main": "dist/feeds-find-video-stream.cjs.js",
   "module": "dist/feeds-find-video-stream.esm.js",
@@ -21,7 +21,7 @@
     "access": "restricted"
   },
   "author": "Tim Kosmider <timothy.kosmider@washpost.com>",
-  "license": "UNLICENSED",
+  "license": "CC-BY-NC-ND-4.0",
   "dependencies": {
     "jmespath": "^0.15.0"
   }

--- a/utils/promo-items/package-lock.json
+++ b/utils/promo-items/package-lock.json
@@ -1,13 +1,58 @@
 {
   "name": "@wpmedia/feeds-promo-items",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@wpmedia/feeds-find-video-stream": {
+      "version": "1.0.7",
+      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-find-video-stream/1.0.7/84256b5e5e561670869c668293ccf9a783c6a3fe629bf74f63364cb021f25f0d",
+      "integrity": "sha512-g57SPA3WM35k8mL0fK+gT9XUz5XtdFOGQHpmuk0vwmYj6AV4xrXIVL2qiwXzrBARyt3eJHgib+bZd1TUdE4zMA==",
+      "requires": {
+        "jmespath": "^0.15.0"
+      }
+    },
+    "@wpmedia/feeds-resizer": {
+      "version": "1.0.7",
+      "resolved": "https://npm.pkg.github.com/download/@wpmedia/feeds-resizer/1.0.7/a46142ce4e537dc88a41f138b3a74d39bc7c819667bc56ebd52b2838a527358e",
+      "integrity": "sha512-R0GiWxkLStpIn1hkiOJHiPZ0nzpz4LrpKTNQGiPbobKXfqEfPSl/GJBKZfZGxa7MBV1TQqWkoHLudPHxpxbngA==",
+      "requires": {
+        "thumbor-lite": "^0.1.8"
+      }
+    },
+    "cipher-base": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+      "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+      "requires": {
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
     "jmespath": {
       "version": "0.15.0",
       "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
       "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
+    },
+    "safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+    },
+    "thumbor-lite": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/thumbor-lite/-/thumbor-lite-0.1.8.tgz",
+      "integrity": "sha512-8C0Ohi2vi0/JVdhRVzNEhtF3MptFp3r9Br0nU3rjor3m5zhGL6QtGJZPV42NJ/e8qyVisZtr0d/Ew4mBz5w4OQ==",
+      "requires": {
+        "cipher-base": "^1.0.4",
+        "inherits": "^2.0.4",
+        "safe-buffer": "^5.2.0"
+      }
     }
   }
 }

--- a/utils/promo-items/package.json
+++ b/utils/promo-items/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/feeds-promo-items",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Shared arcio promo_items module",
   "main": "dist/feeds-promo-items.cjs.js",
   "module": "dist/feeds-promo-items.esm.js",
@@ -21,10 +21,10 @@
     "access": "restricted"
   },
   "author": "Tim Kosmider <timothy.kosmider@washpost.com>",
-  "license": "UNLICENSED",
+  "license": "CC-BY-NC-ND-4.0",
   "dependencies": {
-    "@wpmedia/feeds-find-video-stream": "1.0.6",
-    "@wpmedia/feeds-resizer": "1.0.6",
+    "@wpmedia/feeds-find-video-stream": "1.0.7",
+    "@wpmedia/feeds-resizer": "1.0.7",
     "jmespath": "^0.15.0"
   }
 }

--- a/utils/prop-types/package-lock.json
+++ b/utils/prop-types/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/feeds-prop-types",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/utils/prop-types/package.json
+++ b/utils/prop-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/feeds-prop-types",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Shared fusion prop-type tag info",
   "main": "dist/feeds-prop-types.cjs.js",
   "module": "dist/feeds-prop-types.esm.js",
@@ -17,7 +17,7 @@
     "access": "restricted"
   },
   "author": "Cameron Woodmansee",
-  "license": "UNLICENSED",
+  "license": "CC-BY-NC-ND-4.0",
   "dependencies": {
     "prop-types": "^15.7.2"
   }

--- a/utils/resizer/package-lock.json
+++ b/utils/resizer/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/feeds-resizer",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/utils/resizer/package.json
+++ b/utils/resizer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wpmedia/feeds-resizer",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Utilities to manage image resizing",
   "main": "dist/feeds-resizer.cjs.js",
   "module": "dist/feeds-resizer.esm.js",
@@ -21,7 +21,7 @@
     "access": "restricted"
   },
   "author": "Cameron Woodmansee <cameron.woodmansee@washpost.com>",
-  "license": "UNLICENSED",
+  "license": "CC-BY-NC-ND-4.0",
   "dependencies": {
     "thumbor-lite": "^0.1.8"
   }

--- a/utils/xml-output/package.json
+++ b/utils/xml-output/package.json
@@ -17,7 +17,7 @@
     "access": "restricted"
   },
   "author": "Cameron Woodmansee",
-  "license": "UNLICENSED",
+  "license": "CC-BY-NC-ND-4.0",
   "dependencies": {
     "xmlbuilder2": "2.1.2"
   }


### PR DESCRIPTION
Reduce size of response  AIO-720

   Create utils feeds-content-source-utils 
   Use _sourceIncludes and _sourceExcludes to remove all websites but calling one.
   Use list ansFields from @wpmedia/feeds-content-source-utils
   defaultANSFields  = [
        'canonical_url',
        'canonical_website',
        'created_date',
        'credits',
        'description',
        'display_date',
        'duration',
        'first_publish_date',
        'headlines',
        'last_updated_date',
        'promo_image',
        'promo_items',
        'publish_date',
        'streams',
        'subheadlines',
        'subtitles',
        'subtype',
        'taxonomy.primary_section',
        'taxonomy.seo_keywords',
        'taxonomy.tags',
        'type',
        'video_type',
      ]
      validANSDateFields
    Add website.{arc-site} to only include calling website
    remove fields in sourceExcludes from ansFields
    Add fields in sourceIncludes from ansFields
    use transform to move website.*.website_section to taxonomy.sections
    add website_url and website that are missing from use of sourceInclude