### PR TITLE
Use combo box for raw_html customfield

### DIFF
--- a/.changeset/many-waves-cough.md
+++ b/.changeset/many-waves-cough.md
@@ -1,0 +1,5 @@
+---
+'@wpmedia/rss-fbia-feature-block': patch
+---
+
+Added raw_html_processing customField

--- a/blocks/rss-fbia-feature-block/README.md
+++ b/blocks/rss-fbia-feature-block/README.md
@@ -37,5 +37,7 @@ adPlacement: Enables automatic placement of ads within this article. This parame
 adDensity: How frequently you would like ads to appear in your article: default (<250 word gap), medium (350 word gap), low (>450 word gap)
 placementSection: Enter Javascript that goes between <section class="op-ad-template"></section> in beginning of the body\'s header for recirculation ads that come from Facebook advertisers; leave blank if not used.,
 adScripts: Javascript wrapped in the <figure class=‘op-tracker’> tag can be added to the article for ads and analytics. Multiple scripts can be included, usually each in the own iframe
+iframeHxW: Height and/or width to use in oembed iframes
+raw_html_processing: should raw_html be excluded, included or wrapped in <figure><iframe> tags
 
 ### Usage

--- a/blocks/rss-fbia-feature-block/features/rss/__snapshots__/xml.test.js.snap
+++ b/blocks/rss-fbia-feature-block/features/rss/__snapshots__/xml.test.js.snap
@@ -141,7 +141,7 @@ Object {
             },
           ],
           "content:encoded": Object {
-            "$": "<!doctype html><html lang=\\"en\\"><head><link rel=\\"canonical\\" href=\\"http://demo-prod.origin.arcpublishing.com/food/2020/04/07/tips-for-safe-hand-washing\\"/><title>Tips for Safe Hand washing</title><meta property=\\"og:title\\" content=\\"Tips for Safe Hand washing\\"/><meta property=\\"og:url\\" content=\\"http://demo-prod.origin.arcpublishing.com/food/2020/04/07/tips-for-safe-hand-washing\\"/><meta property=\\"og:description\\" content=\\"Tips to keep you wash for 20 seconds\\"/><meta property=\\"fb:use_automatic_ad_placement\\" content=\\"enable=false\\"/><meta property=\\"op:markup_version\\" content=\\"v1.0\\"/><meta property=\\"fb:article_style\\" content=\\"default\\"/><meta property=\\"og:image\\" content=\\"hi/abcdefghijklmnopqrstuvwxyz=/arc-anglerfish-arc2-prod-demo.s3.amazonaws.com/public/JTWX7EUOLJE4FCHYGN2COQAERY.png\\"/><meta property=\\"fb:likes_and_comments\\" content=\\"disable\\"/></head><body><article><header><h1>Tips for Safe Hand washing</h1><h2>Tips to keep you wash for 20 seconds</h2><time datetime=\\"2020-04-08T10:34:41.432Z\\" class=\\"op-modified\\">2020-04-08T10:34:41.432Z</time><time datetime=\\"2020-04-07T15:02:08.918Z\\" class=\\"op-published\\">2020-04-07T15:02:08.918Z</time><address><a>JOHN SMITH</a><a>JANE DOE</a></address><figure class=\\"fb-feed-cover\\"><img src=\\"hi/abcdefghijklmnopqrstuvwxyz=/arc-anglerfish-arc2-prod-demo.s3.amazonaws.com/public/JTWX7EUOLJE4FCHYGN2COQAERY.png\\"/><figcaption class=\\"op-vertical-below op-small\\">Hand washing can be fun if you make it a song<cite class=\\"op-small\\">Harold Hands</cite></figcaption></figure><h2 class=\\"op-kicker\\">coronvirus</h2></header><p id=\\"AAAAA\\">try singing the happy birthday song<br></p><p id=\\"BBBBB\\">be sure to <i>wash</i> your thumbs</p><p id=\\"CCCCC\\"><div style=\\"background:#ffffff; color: #333; margin:100px 0 1rem 0; line-height:28px; font-family: 'Merriweather', serif;\\"><img style=\\"height:120px; width: 120px; float: left; margin-right: 20px;\\" src=\\"https://www.example.com.mx/graficos/img/novedad-180321.jpg\\" class=\\"img-responsive\\" alt=\\"logo\\" /><img style=\\"height:120px; width: 120px; float: right; \\" src=\\"https://example.com.mx/graficos/interior-nota/abcd_novedad.png\\" class=\\"img-responsive\\" alt=\\"logo\\" /><span style=\\"font-size: 1.1rem; font-weight: 700;\\"> Concertos for Oboe, Clarinet and Orchestra </span><hr style=\\"border: 0;  height: 1px;   background-image: -webkit-linear-gradient(left, #666666, #ffffff);  background-image: -moz-linear-gradient(left, #666666, #ffffff);  background-image: -ms-linear-gradient(left, #666666, #ffffff);  background-image: -o-linear-gradient(left,  #666666, #ffffff); padding: 0; margin: 0;\\"/><span style=\\"font-size: .9rem\\">ARTISTA: Camerata de las Américas, dirigida por Ludwig Carrasco </span><br><span style=\\"font-size: .9rem\\">SELLO:   Urtext </span><br><span style=\\"font-size: .9rem\\">PRECIO:   $168n </span></div></p><figure class=\\"op-interactive\\"><iframe><blockquote class=\\"twitter-tweet\\"><p lang=\\"fr\\" dir=\\"ltr\\">21. Je déploie le robot pour reconnaitre OSCAR3.<br>Retour en images sur l’exercice de recherche appliquée organisé les 30 et 31 mars par l’EMIA et le centre de recherche. Robotisation du champ de bataille : sensibiliser les élèves aux enjeux de demain. <a href=\\"https://twitter.com/hashtag/CapaciTERRE?src=hash&amp;ref_src=twsrc%5Etfw\\">#CapaciTERRE</a> <a href=\\"https://twitter.com/hashtag/Robots?src=hash&amp;ref_src=twsrc%5Etfw\\">#Robots</a> <a href=\\"https://t.co/HiZ2BFOZPY\\">pic.twitter.com/HiZ2BFOZPY</a></p>&mdash; Saint-Cyr Coëtquidan (@SaintCyrCoet) <a href=\\"https://twitter.com/SaintCyrCoet/status/1379457690020294665?ref_src=twsrc%5Etfw\\">April 6, 2021</a></blockquote>
+            "$": "<!doctype html><html lang=\\"en\\"><head><link rel=\\"canonical\\" href=\\"http://demo-prod.origin.arcpublishing.com/food/2020/04/07/tips-for-safe-hand-washing\\"/><title>Tips for Safe Hand washing</title><meta property=\\"og:title\\" content=\\"Tips for Safe Hand washing\\"/><meta property=\\"og:url\\" content=\\"http://demo-prod.origin.arcpublishing.com/food/2020/04/07/tips-for-safe-hand-washing\\"/><meta property=\\"og:description\\" content=\\"Tips to keep you wash for 20 seconds\\"/><meta property=\\"fb:use_automatic_ad_placement\\" content=\\"enable=false\\"/><meta property=\\"op:markup_version\\" content=\\"v1.0\\"/><meta property=\\"fb:article_style\\" content=\\"default\\"/><meta property=\\"og:image\\" content=\\"hi/abcdefghijklmnopqrstuvwxyz=/arc-anglerfish-arc2-prod-demo.s3.amazonaws.com/public/JTWX7EUOLJE4FCHYGN2COQAERY.png\\"/><meta property=\\"fb:likes_and_comments\\" content=\\"disable\\"/></head><body><article><header><h1>Tips for Safe Hand washing</h1><h2>Tips to keep you wash for 20 seconds</h2><time datetime=\\"2020-04-08T10:34:41.432Z\\" class=\\"op-modified\\">2020-04-08T10:34:41.432Z</time><time datetime=\\"2020-04-07T15:02:08.918Z\\" class=\\"op-published\\">2020-04-07T15:02:08.918Z</time><address><a>JOHN SMITH</a><a>JANE DOE</a></address><figure class=\\"fb-feed-cover\\"><img src=\\"hi/abcdefghijklmnopqrstuvwxyz=/arc-anglerfish-arc2-prod-demo.s3.amazonaws.com/public/JTWX7EUOLJE4FCHYGN2COQAERY.png\\"/><figcaption class=\\"op-vertical-below op-small\\">Hand washing can be fun if you make it a song<cite class=\\"op-small\\">Harold Hands</cite></figcaption></figure><h2 class=\\"op-kicker\\">coronvirus</h2></header><p id=\\"AAAAA\\">try singing the happy birthday song<br></p><p id=\\"BBBBB\\">be sure to <i>wash</i> your thumbs</p><figure class=\\"op-interactive\\"><iframe><blockquote class=\\"twitter-tweet\\"><p lang=\\"fr\\" dir=\\"ltr\\">21. Je déploie le robot pour reconnaitre OSCAR3.<br>Retour en images sur l’exercice de recherche appliquée organisé les 30 et 31 mars par l’EMIA et le centre de recherche. Robotisation du champ de bataille : sensibiliser les élèves aux enjeux de demain. <a href=\\"https://twitter.com/hashtag/CapaciTERRE?src=hash&amp;ref_src=twsrc%5Etfw\\">#CapaciTERRE</a> <a href=\\"https://twitter.com/hashtag/Robots?src=hash&amp;ref_src=twsrc%5Etfw\\">#Robots</a> <a href=\\"https://t.co/HiZ2BFOZPY\\">pic.twitter.com/HiZ2BFOZPY</a></p>&mdash; Saint-Cyr Coëtquidan (@SaintCyrCoet) <a href=\\"https://twitter.com/SaintCyrCoet/status/1379457690020294665?ref_src=twsrc%5Etfw\\">April 6, 2021</a></blockquote>
 <script async src=\\"https://platform.twitter.com/widgets.js\\" charset=\\"utf-8\\"></script>
 </iframe></figure><footer><aside>John is a journalist</aside><small>© 2021 google news</small></footer></article></body></html>",
           },
@@ -239,6 +239,106 @@ Object {
       "title": Object {
         "$": "google news",
       },
+    },
+  },
+}
+`;
+
+exports[`returns FB-IA template with include value 1`] = `
+Object {
+  "rss": Object {
+    "@version": "2.0",
+    "@xmlns:atom": "http://www.w3.org/2005/Atom",
+    "@xmlns:content": "http://purl.org/rss/1.0/modules/content/",
+    "@xmlns:dc": "http://purl.org/dc/elements/1.1/",
+    "@xmlns:media": "http://search.yahoo.com/mrss/",
+    "@xmlns:sy": "http://purl.org/rss/1.0/modules/syndication/",
+    "channel": Object {
+      "atom:link": Object {
+        "@href": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/fb-ia/",
+        "@rel": "self",
+        "@type": "application/rss+xml",
+      },
+      "category": "News",
+      "copyright": "Copyright 2021",
+      "description": Object {
+        "$": "Only the best for FB",
+      },
+      "image": Object {
+        "link": "http://demo-prod.origin.arcpublishing.com",
+        "title": "Facebook Instant Articles Feed",
+        "url": "hi/abcdefghijklmnopqrstuvwxyz=/example.com/logo.png",
+      },
+      "item": Array [
+        Object {
+          "#": Array [
+            Object {
+              "media:content": Object {
+                "@type": "image/png",
+                "@url": "hi/abcdefghijklmnopqrstuvwxyz=/arc-anglerfish-arc2-prod-demo.s3.amazonaws.com/public/JTWX7EUOLJE4FCHYGN2COQAERY.png",
+                "media:credit": Object {
+                  "#": "Harold Hands",
+                  "@role": "author",
+                  "@scheme": "urn:ebu",
+                },
+                "media:description": Object {
+                  "$": "Hand washing can be fun if you make it a song",
+                  "@type": "plain",
+                },
+                "media:title": Object {
+                  "$": "Hand Washing",
+                },
+              },
+            },
+          ],
+          "content:encoded": Object {
+            "$": "<!doctype html><html lang=\\"en\\"><head><link rel=\\"canonical\\" href=\\"http://demo-prod.origin.arcpublishing.com/food/2020/04/07/tips-for-safe-hand-washing\\"/><title>Tips for Safe Hand washing</title><meta property=\\"og:title\\" content=\\"Tips for Safe Hand washing\\"/><meta property=\\"og:url\\" content=\\"http://demo-prod.origin.arcpublishing.com/food/2020/04/07/tips-for-safe-hand-washing\\"/><meta property=\\"og:description\\" content=\\"This is from the subheadlines\\"/><meta property=\\"fb:use_automatic_ad_placement\\" content=\\"enable=true ad_density=low\\"/><meta property=\\"op:markup_version\\" content=\\"v1.0\\"/><meta property=\\"fb:article_style\\" content=\\"times-bold\\"/><meta property=\\"og:image\\" content=\\"hi/abcdefghijklmnopqrstuvwxyz=/arc-anglerfish-arc2-prod-demo.s3.amazonaws.com/public/JTWX7EUOLJE4FCHYGN2COQAERY.png\\"/><meta property=\\"fb:likes_and_comments\\" content=\\"enable\\"/><meta property=\\"something\\" content=\\"other thing\\"/></head><body><article><header><section class=\\"op-ad-template\\"><script>myscript()</script></section><h1>Tips for Safe Hand washing</h1><h2>This is from the subheadlines</h2><time datetime=\\"2020-04-08T10:34:41.432Z\\" class=\\"op-modified\\">2020-04-08T10:34:41.432Z</time><time datetime=\\"2020-04-08T10:34:41.432Z\\" class=\\"op-published\\">2020-04-08T10:34:41.432Z</time><address><a>JOHN-SMITH</a><a>JANE-DOE</a></address><figure class=\\"fb-feed-cover\\"><img src=\\"hi/abcdefghijklmnopqrstuvwxyz=/arc-anglerfish-arc2-prod-demo.s3.amazonaws.com/public/JTWX7EUOLJE4FCHYGN2COQAERY.png\\"/><figcaption class=\\"op-vertical-below op-small\\">Hand washing can be fun if you make it a song<cite class=\\"op-small\\">Harold Hands</cite></figcaption></figure><h2 class=\\"op-kicker\\">coronvirus</h2></header><p id=\\"AAAAA\\">try singing the happy birthday song<br></p><p id=\\"BBBBB\\">be sure to <i>wash</i> your thumbs</p><div style=\\"background:#ffffff; color: #333; margin:100px 0 1rem 0; line-height:28px; font-family: 'Merriweather', serif;\\"><img style=\\"height:120px; width: 120px; float: left; margin-right: 20px;\\" src=\\"https://www.example.com.mx/graficos/img/novedad-180321.jpg\\" class=\\"img-responsive\\" alt=\\"logo\\" /><img style=\\"height:120px; width: 120px; float: right; \\" src=\\"https://example.com.mx/graficos/interior-nota/abcd_novedad.png\\" class=\\"img-responsive\\" alt=\\"logo\\" /><span style=\\"font-size: 1.1rem; font-weight: 700;\\"> Concertos for Oboe, Clarinet and Orchestra </span><hr style=\\"border: 0;  height: 1px;   background-image: -webkit-linear-gradient(left, #666666, #ffffff);  background-image: -moz-linear-gradient(left, #666666, #ffffff);  background-image: -ms-linear-gradient(left, #666666, #ffffff);  background-image: -o-linear-gradient(left,  #666666, #ffffff); padding: 0; margin: 0;\\"/><span style=\\"font-size: .9rem\\">ARTISTA: Camerata de las Américas, dirigida por Ludwig Carrasco </span><br><span style=\\"font-size: .9rem\\">SELLO:   Urtext </span><br><span style=\\"font-size: .9rem\\">PRECIO:   $168n </span></div><figure class=\\"op-interactive\\"><iframe width=\\"560\\"><blockquote class=\\"twitter-tweet\\"><p lang=\\"fr\\" dir=\\"ltr\\">21. Je déploie le robot pour reconnaitre OSCAR3.<br>Retour en images sur l’exercice de recherche appliquée organisé les 30 et 31 mars par l’EMIA et le centre de recherche. Robotisation du champ de bataille : sensibiliser les élèves aux enjeux de demain. <a href=\\"https://twitter.com/hashtag/CapaciTERRE?src=hash&amp;ref_src=twsrc%5Etfw\\">#CapaciTERRE</a> <a href=\\"https://twitter.com/hashtag/Robots?src=hash&amp;ref_src=twsrc%5Etfw\\">#Robots</a> <a href=\\"https://t.co/HiZ2BFOZPY\\">pic.twitter.com/HiZ2BFOZPY</a></p>&mdash; Saint-Cyr Coëtquidan (@SaintCyrCoet) <a href=\\"https://twitter.com/SaintCyrCoet/status/1379457690020294665?ref_src=twsrc%5Etfw\\">April 6, 2021</a></blockquote>
+<script async src=\\"https://platform.twitter.com/widgets.js\\" charset=\\"utf-8\\"></script>
+</iframe></figure><figure class=\\"op-tracker\\"><iframe><script>alert(\\"hi\\");</script></iframe></figure><footer><aside>John is a journalist</aside><small>Copyright 2021</small></footer></article></body></html>",
+          },
+          "dc:creator": Object {
+            "$": "john-smith, jane-doe",
+          },
+          "description": Object {
+            "$": "This is from the subheadlines",
+          },
+          "guid": Object {
+            "#": "http://demo-prod.origin.arcpublishing.com/food/2020/04/07/tips-for-safe-hand-washing",
+            "@isPermaLink": true,
+          },
+          "link": "http://demo-prod.origin.arcpublishing.com/food/2020/04/07/tips-for-safe-hand-washing",
+          "pubDate": "Wed, 08 Apr 2020 10:34:41 +0000",
+          "title": Object {
+            "$": "Tips for Safe Hand washing",
+          },
+        },
+        Object {
+          "content:encoded": Object {
+            "$": "<!doctype html><html lang=\\"en\\"><head><link rel=\\"canonical\\" href=\\"http://demo-prod.origin.arcpublishing.com/food/empty-recipe\\"/><title>I'm out of ideas</title><meta property=\\"og:title\\" content=\\"I'm out of ideas\\"/><meta property=\\"og:url\\" content=\\"http://demo-prod.origin.arcpublishing.com/food/empty-recipe\\"/><meta property=\\"og:description\\" content=\\"\\"/><meta property=\\"fb:use_automatic_ad_placement\\" content=\\"enable=true ad_density=low\\"/><meta property=\\"op:markup_version\\" content=\\"v1.0\\"/><meta property=\\"fb:article_style\\" content=\\"times-bold\\"/><meta property=\\"og:image\\" content=\\"\\"/><meta property=\\"fb:likes_and_comments\\" content=\\"enable\\"/><meta property=\\"something\\" content=\\"other thing\\"/></head><body><article><header><section class=\\"op-ad-template\\"><script>myscript()</script></section><h1>I'm out of ideas</h1><time datetime=\\"2021-04-08T10:34:41.432Z\\" class=\\"op-modified\\">2021-04-08T10:34:41.432Z</time><time datetime=\\"2021-04-08T10:34:41.432Z\\" class=\\"op-published\\">2021-04-08T10:34:41.432Z</time></header><figure class=\\"op-tracker\\"><iframe><script>alert(\\"hi\\");</script></iframe></figure><footer><small>Copyright 2021</small></footer></article></body></html>",
+          },
+          "description": Object {
+            "$": "",
+          },
+          "guid": Object {
+            "#": "http://demo-prod.origin.arcpublishing.com/food/empty-recipe",
+            "@isPermaLink": true,
+          },
+          "link": "http://demo-prod.origin.arcpublishing.com/food/empty-recipe",
+          "pubDate": "Thu, 08 Apr 2021 10:34:41 +0000",
+          "title": Object {
+            "$": "I'm out of ideas",
+          },
+        },
+      ],
+      "language": "en",
+      "lastBuildDate": StringMatching /\\\\w\\+, \\\\d\\+ \\\\w\\+ \\\\d\\{4\\} \\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\} \\\\\\+0000/,
+      "link": "http://demo-prod.origin.arcpublishing.com",
+      "sy:updateFrequency": "4",
+      "sy:updatePeriod": "weekly",
+      "title": Object {
+        "$": "Facebook Instant Articles Feed",
+      },
+      "ttl": "5",
     },
   },
 }

--- a/blocks/rss-fbia-feature-block/features/rss/xml.js
+++ b/blocks/rss-fbia-feature-block/features/rss/xml.js
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 import PropTypes from 'fusion:prop-types'
 import Consumer from 'fusion:consumer'
 import moment from 'moment'
@@ -187,7 +188,7 @@ export function FbiaRss({ globalContent, customFields, arcSite, requestUri }) {
     adScripts,
     videoSelect,
     iframeHxW = {},
-    wrapRawHTML,
+    raw_html_processing = 'exclulde',
   }) {
     BuildContent.call(this)
 
@@ -414,16 +415,25 @@ export function FbiaRss({ globalContent, customFields, arcSite, requestUri }) {
       let item
       const { width = 0, height = 0 } = iframeHxW
       if (element.content && typeof element.content === 'string') {
-        if (element.type === 'raw_html' && wrapRawHTML) {
-          return {
-            figure: {
-              '@class': 'op-interactive',
-              iframe: {
-                ...(width && { '@width': width }),
-                ...(height && { '@height': height }),
+        if (element.type === 'raw_html') {
+          switch (raw_html_processing) {
+            case 'wrap':
+              item = {
+                figure: {
+                  '@class': 'op-interactive',
+                  iframe: {
+                    ...(width && { '@width': width }),
+                    ...(height && { '@height': height }),
+                    '#': element.content,
+                  },
+                },
+              }
+              break
+            case 'include':
+              item = {
                 '#': element.content,
-              },
-            },
+              }
+              break
           }
         } else {
           item = {
@@ -585,12 +595,16 @@ FbiaRss.propTypes = {
         height: 0,
       },
     }),
-    wrapRawHTML: PropTypes.bool.tag({
-      label: 'Wrap raw_html in figure',
+    raw_html_processing: PropTypes.oneOf(['exclude', 'include', 'wrap']).tag({
+      label: {
+        exclude: 'raw_html elements',
+        include: 'raw_html elements',
+        wrap: 'wrap in <figure class="op-interactive"> <iframe>',
+      },
       group: 'Facebook Options',
       description:
-        'Put raw_html in <figure class="op-interactive"> <iframe> tags',
-      defaultValue: false,
+        'Should raw_html elements be excluded, included or wrapped in <figure class="op-interactive"> <iframe> tags. default exclude',
+      defaultValue: 'exclude',
     }),
     ...generatePropsForFeed('rss', PropTypes),
   }),

--- a/blocks/rss-fbia-feature-block/features/rss/xml.test.js
+++ b/blocks/rss-fbia-feature-block/features/rss/xml.test.js
@@ -149,7 +149,56 @@ it('returns FB-IA template with custom values', () => {
       adScripts:
         '<figure class="op-tracker"><iframe><script>alert("hi");</script></iframe></figure>',
       iframeHxW: { width: '560' },
-      wrapRawHTML: true,
+      raw_html_processing: 'wrap',
+    },
+  })
+  expect(rss).toMatchSnapshot({
+    rss: {
+      channel: {
+        lastBuildDate: expect.stringMatching(
+          /\w+, \d+ \w+ \d{4} \d{2}:\d{2}:\d{2} \+0000/,
+        ),
+      },
+    },
+  })
+})
+
+it('returns FB-IA template with include value', () => {
+  const rss = FbiaRss({
+    requestUri: 'https://localhost.com/arc/outboundfeeds/fb-ia/?outputType=xml',
+    arcSite: 'demo',
+    globalContent: {
+      ...articles,
+    },
+    customFields: {
+      channelTitle: 'Facebook Instant Articles Feed',
+      channelDescription: 'Only the best for FB',
+      channelCopyright: 'Copyright 2021',
+      channelTTL: '5',
+      channelUpdatePeriod: 'weekly',
+      channelUpdateFrequency: '4',
+      channelCategory: 'News',
+      channelLogo: 'https://example.com/logo.png',
+      itemTitle: 'headlines.basic',
+      itemDescription: 'subheadlines.basic || description.basic',
+      pubDate: 'last_updated_date',
+      itemCredits: 'credits.by[]._id',
+      itemCategory: 'News',
+      includePromo: true,
+      imageTitle: 'title',
+      imageCaption: 'caption',
+      imageCredits: 'credits.by[].name',
+      includeContent: 'all',
+      articleStyle: 'times-bold',
+      likesAndComments: 'enable',
+      metaTags: '<meta property="something" content="other thing" />',
+      adPlacement: 'enable',
+      adDensity: 'low',
+      placementSection: '<script>myscript()</script>',
+      adScripts:
+        '<figure class="op-tracker"><iframe><script>alert("hi");</script></iframe></figure>',
+      iframeHxW: { width: '560' },
+      raw_html_processing: 'include',
     },
   })
   expect(rss).toMatchSnapshot({


### PR DESCRIPTION
Apon further investigation of how partner-feeds currently handles
raw_html in fb-ia, we need to support 3 options.
exclude raw_html - This is the default in partner-feeds
include raw_html - the raw_html will be included as is in fb-ia
wrap - wrap the raw_html in a <figure><iframe> tag

Switch customField from a bool to a oneOf (combo box).  I used underscores in the variable 'raw_html_processing' because that is displayed in the editor and is readable with the underscores and more closely matches the ANS field raw_html