### PR TITLE
Prevent 414 errors URI too large AIO-783

### DIFF
--- a/.changeset/olive-bears-joke.md
+++ b/.changeset/olive-bears-joke.md
@@ -1,0 +1,9 @@
+---
+'@wpmedia/feeds-source-collections-block': patch
+'@wpmedia/feeds-source-content-api-block': patch
+'@wpmedia/feeds-source-content-api-by-day-block': patch
+'@wpmedia/feeds-source-content-api-by-day2-block': patch
+'@wpmedia/feeds-source-content-api-by-day3-block': patch
+---
+
+Move ansFields into fetch

--- a/blocks/feeds-source-collections-block/sources/collections.js
+++ b/blocks/feeds-source-collections-block/sources/collections.js
@@ -27,7 +27,11 @@ const fetch = async (key = {}) => {
     auth: { bearer: ARC_ACCESS_TOKEN },
   }
 
-  const ansFields = [...defaultANSFields, 'content_elements']
+  const ansFields = [
+    ...defaultANSFields,
+    'content_elements',
+    `websites.${site}`,
+  ]
 
   const sortStories = (idsResp, collectionResp, ids, site) => {
     idsResp.content_elements.forEach((item) => {
@@ -47,9 +51,6 @@ const fetch = async (key = {}) => {
     })
     return collectionResp
   }
-
-  // limit C-API response to just this websites sections to reduce size
-  ansFields.push(`websites.${site}`)
 
   if (excludeFields) {
     excludeFields.split(',').forEach((i) => {

--- a/blocks/feeds-source-content-api-block/sources/feeds-content-api.js
+++ b/blocks/feeds-source-content-api-block/sources/feeds-content-api.js
@@ -10,8 +10,11 @@ import {
 
 const resolve = function resolve(key) {
   const requestUri = `${CONTENT_BASE}/content/v4/search/published`
-  // const ansFields = [...defaultANSFields, 'content_elements']
-  const ansFields = [...defaultANSFields, 'content_elements']
+  const ansFields = [
+    ...defaultANSFields,
+    'content_elements',
+    `websites.${key['arc-site']}`,
+  ]
 
   const paramList = {
     website: key['arc-site'],
@@ -20,9 +23,6 @@ const resolve = function resolve(key) {
     sort: key.Sort || 'publish_date:desc',
   }
   generateDistributor(key, paramList)
-
-  // limit C-API response to just this websites sections to reduce size
-  ansFields.push(`websites.${key['arc-site']}`)
 
   if (key['Source-Exclude']) {
     const sourceExcludes = []

--- a/blocks/feeds-source-content-api-by-day-block/sources/feeds-content-api-by-day.js
+++ b/blocks/feeds-source-content-api-by-day-block/sources/feeds-content-api-by-day.js
@@ -12,7 +12,6 @@ import {
 
 const contentURL = `${CONTENT_BASE}/content/v4/search/published/`
 // Excludes content_elements
-const ansFields = [...defaultANSFields]
 
 const options = {
   gzip: true,
@@ -29,7 +28,7 @@ const fetch = async (key = {}) => {
   generateDistributor(key, paramList)
 
   // limit C-API response to just this websites sections to reduce size
-  ansFields.push(`websites.${key['arc-site']}`)
+  const ansFields = [...defaultANSFields, `websites.${key['arc-site']}`]
 
   if (key['Source-Exclude']) {
     const sourceExcludes = []

--- a/blocks/feeds-source-content-api-by-day2-block/sources/feeds-content-api-by-day2.js
+++ b/blocks/feeds-source-content-api-by-day2-block/sources/feeds-content-api-by-day2.js
@@ -11,8 +11,6 @@ import {
 } from '@wpmedia/feeds-content-source-utils'
 
 const contentURL = `${CONTENT_BASE}/content/v4/search/published/`
-// Excludes content_elements
-const ansFields = [...defaultANSFields]
 
 const options = {
   gzip: true,
@@ -29,7 +27,7 @@ const fetch = async (key = {}) => {
   generateDistributor(key, paramList)
 
   // limit C-API response to just this websites sections to reduce size
-  ansFields.push(`websites.${key['arc-site']}`)
+  const ansFields = [...defaultANSFields, `websites.${key['arc-site']}`]
 
   if (key['Source-Exclude']) {
     const sourceExcludes = []

--- a/blocks/feeds-source-content-api-by-day3-block/sources/feeds-content-api-by-day3.js
+++ b/blocks/feeds-source-content-api-by-day3-block/sources/feeds-content-api-by-day3.js
@@ -11,8 +11,6 @@ import {
 } from '@wpmedia/feeds-content-source-utils'
 
 const contentURL = `${CONTENT_BASE}/content/v4/search/published/`
-// Excludes content_elements
-const ansFields = [...defaultANSFields]
 
 const options = {
   gzip: true,
@@ -29,7 +27,7 @@ const fetch = async (key = {}) => {
   generateDistributor(key, paramList)
 
   // limit C-API response to just this websites sections to reduce size
-  ansFields.push(`websites.${key['arc-site']}`)
+  const ansFields = [...defaultANSFields, `websites.${key['arc-site']}`]
 
   if (key['Source-Exclude']) {
     const sourceExcludes = []


### PR DESCRIPTION
The content-api-by-day(*) sources are modifing the global andFields.  It shouldn't be global.
- create ansFields inside of fetch using defaults and websites.{arc-site}