### PR TITLE
Fix imageTitle group name  AIO-799

### DIFF
--- a/.changeset/cyan-dingos-reflect.md
+++ b/.changeset/cyan-dingos-reflect.md
@@ -1,0 +1,5 @@
+---
+'@wpmedia/sitemap-news-feature-block': patch
+---
+
+Fix customField group name

--- a/blocks/sitemap-news-feature-block/features/news-sitemap/xml.js
+++ b/blocks/sitemap-news-feature-block/features/news-sitemap/xml.js
@@ -121,7 +121,7 @@ GoogleSitemap.propTypes = {
   customFields: PropTypes.shape({
     imageTitle: PropTypes.string.tag({
       label: 'ANS image title key',
-      group: 'Feaured Media',
+      group: 'Featured Media',
       description:
         'ANS value for associated story used for the <image:title> sitemap tag',
       defaultValue: 'title',


### PR DESCRIPTION
The group name was misspelled so it shows up as another group instead of being included
with the Featured media group.