### PR TITLE
Make URL parameters optional in generated links AIO-817

### DIFF
--- a/.changeset/chilled-jars-knock.md
+++ b/.changeset/chilled-jars-knock.md
@@ -1,0 +1,7 @@
+---
+'@wpmedia/sitemap-feature-block': patch
+'@wpmedia/sitemap-index-by-day-feature-block': patch
+'@wpmedia/sitemap-section-index-feature-block': patch
+---
+
+Make URL parameters optional

--- a/blocks/sitemap-index-by-day-feature-block/features/sitemap-index/__snapshots__/xml.test.js.snap
+++ b/blocks/sitemap-index-by-day-feature-block/features/sitemap-index/__snapshots__/xml.test.js.snap
@@ -54,10 +54,10 @@ Object {
     "@xmlns": "http://www.sitemaps.org/schemas/sitemap/0.9",
     "sitemap": Array [
       Object {
-        "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap/latest/?",
+        "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap/latest/",
       },
       Object {
-        "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap/2021-04-08/?",
+        "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap/2021-04-08/",
       },
     ],
   },
@@ -104,6 +104,22 @@ Object {
       },
       Object {
         "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap3/2021-04-01/?outputType=xml",
+      },
+    ],
+  },
+}
+`;
+
+exports[`returns template without outputType 1`] = `
+Object {
+  "sitemapindex": Object {
+    "@xmlns": "http://www.sitemaps.org/schemas/sitemap/0.9",
+    "sitemap": Array [
+      Object {
+        "loc": "http://demo-prod.origin.arcpublishing.com/sitemap/latest/",
+      },
+      Object {
+        "loc": "http://demo-prod.origin.arcpublishing.com/sitemap/2021-04-08/",
       },
     ],
   },

--- a/blocks/sitemap-index-by-day-feature-block/features/sitemap-index/xml.js
+++ b/blocks/sitemap-index-by-day-feature-block/features/sitemap-index/xml.js
@@ -64,28 +64,24 @@ export function SitemapIndexByDay({
   ) => {
     const arr = []
     const now = moment.utc(new Date())
+    const parameters = feedParam ? `?${feedParam}` : ''
     const splitAllDates =
       feedDates2Split.all || feedDates2Split.All || feedDates2Split.ALL
     const feedPathKeys = Object.keys(feedPath).map((i) => parseInt(i))
-    let pathValue = '/arc/outboundfeeds/sitemap/'
+    let pathValue = '/arc/outboundfeeds/sitemap/' // This is only used if feedPath is empty
     for (let i = 0; i < maxDays; i++) {
-      const pathIndex = feedPathKeys.indexOf(i)
-      if (pathIndex !== -1) pathValue = feedPath[i]
+      if (feedPathKeys.indexOf(i) !== -1) pathValue = feedPath[i]
       const formattedDate = i === 0 ? 'latest' : now.format('YYYY-MM-DD')
       const numSplits = feedDates2Split[formattedDate] || splitAllDates
       if (numSplits) {
         for (let splits = 1; splits <= numSplits; splits++) {
           arr.push({
-            loc: `${feedDomainURL}${pathValue}${section}${formattedDate}-${splits}/?${
-              feedParam || ''
-            }`,
+            loc: `${feedDomainURL}${pathValue}${section}${formattedDate}-${splits}/${parameters}`,
           })
         }
       } else {
         arr.push({
-          loc: `${feedDomainURL}${pathValue}${section}${formattedDate}/?${
-            feedParam || ''
-          }`,
+          loc: `${feedDomainURL}${pathValue}${section}${formattedDate}/${parameters}`,
         })
       }
       now.subtract(1, 'days')
@@ -130,7 +126,7 @@ SitemapIndexByDay.propTypes = {
       defaultValue: '/sitemap-index/',
     }),
     feedParam: PropTypes.string.tag({
-      label: 'Additional URL Parameters',
+      label: 'URL Parameters',
       group: 'Format',
       description:
         'Optional parameters to append to URL. Separate values with an &, do not include a ?',

--- a/blocks/sitemap-index-by-day-feature-block/features/sitemap-index/xml.test.js
+++ b/blocks/sitemap-index-by-day-feature-block/features/sitemap-index/xml.test.js
@@ -21,6 +21,21 @@ it('returns template with default values', () => {
   expect(sitemapindex).toMatchSnapshot()
 })
 
+it('returns template without outputType', () => {
+  const sitemapindex = SitemapIndexByDay({
+    arcSite: 'demo',
+    customFields: {
+      feedPath: { 0: '/sitemap/' },
+      feedName: '/sitemap-index/',
+      feedParam: '',
+      numberOfDays: '',
+      feedDates2Split: {},
+    },
+    requestUri: '/sitemap-index/?outputType=xml',
+  })
+  expect(sitemapindex).toMatchSnapshot()
+})
+
 it('returns template with set end date 2021-04-01', () => {
   const sitemapindex = SitemapIndexByDay({
     arcSite: 'demo',

--- a/blocks/sitemap-index-feature-block/features/sitemap-index/__snapshots__/xml.test.js.snap
+++ b/blocks/sitemap-index-feature-block/features/sitemap-index/__snapshots__/xml.test.js.snap
@@ -66,7 +66,7 @@ Object {
     "@xmlns": "http://www.sitemaps.org/schemas/sitemap/0.9",
     "sitemap": Array [
       Object {
-        "loc": "http://demo-prod.origin.arcpublishing.com?",
+        "loc": "http://demo-prod.origin.arcpublishing.com",
       },
       Object {
         "loc": "http://demo-prod.origin.arcpublishing.com?from=100",

--- a/blocks/sitemap-index-feature-block/features/sitemap-index/xml.js
+++ b/blocks/sitemap-index-feature-block/features/sitemap-index/xml.js
@@ -60,11 +60,12 @@ export function SitemapIndex({
     if (maxCount) {
       for (let i = 0; i <= maxCount; i += 100) {
         // only push from param if it's not zero
-        const newParamList = [...paramList, ...(i ? [`from=${i}`] : [])]
+        const newParamList = [...paramList, ...(i ? [`from=${i}`] : [])].join(
+          '&',
+        )
+        const parameters = newParamList ? `?${newParamList}` : ''
         arr.push({
-          loc: `${feedDomainURL}${feedPath}${section}?${newParamList.join(
-            '&',
-          )}`,
+          loc: `${feedDomainURL}${feedPath}${section}${parameters}`,
           ...(lastModDate && { lastmod: lastModDate }),
         })
       }
@@ -113,7 +114,7 @@ SitemapIndex.propTypes = {
       defaultValue: '/sitemap-index/',
     }),
     feedParam: PropTypes.string.tag({
-      label: 'Additional URL Parameters',
+      label: 'URL Parameters',
       group: 'Format',
       description: 'Optional parameters to append to URL, start with &',
       defaultValue: '&outputType=xml',

--- a/blocks/sitemap-section-index-feature-block/README.md
+++ b/blocks/sitemap-section-index-feature-block/README.md
@@ -1,7 +1,15 @@
 # Sitemap-Section-Index
 
 Sitemaps provide search engines with metadata regarding the specific news content on a website. Using the Sitemap, bots can quickly find the news articles contained on a site
-These Sitemap identify the url of every section in Site Service.
+This Sitemap identifies the url of every section in Site Service.
+
+This feed can be used to generate links to sitemaps like
+
+`http://wwww.example.com/arc/outboundfeeds/sitemap/category/{category}/`
+
+or it can be used to link directory to website sections like
+
+`http://wwww.example.com/{category}/`
 
 Requires a Site Service Content Source like this one from themes
 "@wpmedia/site-hierarchy-content-block"
@@ -9,5 +17,5 @@ Requires a Site Service Content Source like this one from themes
 ## Custom Fields
 
 - feedPath - path to use to call feed used to display sitemap. default - /arc/outboundfeeds/sitemap/category
-- feedParam - Additional params to add to sitemap request. default - ?outputType=xml
+- feedParam - Additional params to add to sitemap request. default - outputType=xml
 - excludeSections - sections to exclude from results

--- a/blocks/sitemap-section-index-feature-block/features/sitemap-section-front-index/__snapshots__/xml.test.js.snap
+++ b/blocks/sitemap-section-index-feature-block/features/sitemap-section-front-index/__snapshots__/xml.test.js.snap
@@ -1,13 +1,90 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`returns template with links to sections without outputType 1`] = `
+Object {
+  "sitemapindex": Object {
+    "@xmlns": "http://www.sitemaps.org/schemas/sitemap/0.9",
+    "sitemap": Array [
+      Object {
+        "loc": "http://demo-prod.origin.arcpublishing.com/politics/",
+      },
+      Object {
+        "loc": "http://demo-prod.origin.arcpublishing.com/opinion/",
+      },
+      Object {
+        "loc": "http://demo-prod.origin.arcpublishing.com/economy/",
+      },
+      Object {
+        "loc": "http://demo-prod.origin.arcpublishing.com/sports/",
+      },
+      Object {
+        "loc": "http://demo-prod.origin.arcpublishing.com/sports/football/",
+      },
+      Object {
+        "loc": "http://demo-prod.origin.arcpublishing.com/sports/baseball/",
+      },
+      Object {
+        "loc": "http://demo-prod.origin.arcpublishing.com/sports/basketball/",
+      },
+      Object {
+        "loc": "http://demo-prod.origin.arcpublishing.com/entertainment/",
+      },
+      Object {
+        "loc": "http://demo-prod.origin.arcpublishing.com/entertainment/tv/",
+      },
+      Object {
+        "loc": "http://demo-prod.origin.arcpublishing.com/entertainment/movies/",
+      },
+    ],
+  },
+}
+`;
+
 exports[`returns template with sitemap index by section links 1`] = `
 Object {
   "sitemapindex": Object {
     "@xmlns": "http://www.sitemaps.org/schemas/sitemap/0.9",
     "sitemap": Array [
       Object {
-        "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap/category/politics/?outputType=xml",
+        "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap/category/politics/",
       },
+      Object {
+        "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap/category/opinion/",
+      },
+      Object {
+        "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap/category/economy/",
+      },
+      Object {
+        "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap/category/sports/",
+      },
+      Object {
+        "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap/category/sports/football/",
+      },
+      Object {
+        "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap/category/sports/baseball/",
+      },
+      Object {
+        "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap/category/sports/basketball/",
+      },
+      Object {
+        "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap/category/entertainment/",
+      },
+      Object {
+        "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap/category/entertainment/tv/",
+      },
+      Object {
+        "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap/category/entertainment/movies/",
+      },
+    ],
+  },
+}
+`;
+
+exports[`returns template with sitemap index by section links with excluded links 1`] = `
+Object {
+  "sitemapindex": Object {
+    "@xmlns": "http://www.sitemaps.org/schemas/sitemap/0.9",
+    "sitemap": Array [
       Object {
         "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap/category/opinion/?outputType=xml",
       },
@@ -29,24 +106,8 @@ Object {
       Object {
         "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap/category/entertainment/?outputType=xml",
       },
-    ],
-  },
-}
-`;
-
-exports[`returns template with sitemap index by section links with excluded links 1`] = `
-Object {
-  "sitemapindex": Object {
-    "@xmlns": "http://www.sitemaps.org/schemas/sitemap/0.9",
-    "sitemap": Array [
       Object {
-        "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap/category/opinion/?outputType=xml",
-      },
-      Object {
-        "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap/category/economy/?outputType=xml",
-      },
-      Object {
-        "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap/category/sports/?outputType=xml",
+        "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap/category/entertainment/movies/?outputType=xml",
       },
     ],
   },

--- a/blocks/sitemap-section-index-feature-block/features/sitemap-section-front-index/xml.js
+++ b/blocks/sitemap-section-index-feature-block/features/sitemap-section-front-index/xml.js
@@ -37,11 +37,12 @@ export function SitemapSectionFrontIndex({
     feedPath,
     feedParam,
   ) => {
+    const parameters = feedParam ? `?${feedParam}` : ''
     return sections.reduce((accum, section) => {
       const sectionId = section._id || ''
       if (sectionId && !excludeSections.includes(sectionId)) {
         accum.push({
-          loc: `${feedDomainURL}${feedPath}${sectionId}/?${feedParam || ''}`,
+          loc: `${feedDomainURL}${feedPath}${sectionId}/${parameters}`,
         })
         if (section.children?.length) {
           const subSections = buildSitemapIndexLinks(
@@ -73,11 +74,11 @@ SitemapSectionFrontIndex.propTypes = {
     feedPath: PropTypes.string.tag({
       label: 'Feed Path',
       group: 'Format',
-      description: 'Relative URL path to the specific sitemap call',
+      description: 'Relative URL path used in the generated link',
       defaultValue: '/arc/outboundfeeds/sitemap/category',
     }),
     feedParam: PropTypes.string.tag({
-      label: 'Additional URL Parameters',
+      label: 'URL Parameters',
       group: 'Format',
       description:
         'Optional parameters to append to URL, join multiple parameters with &',

--- a/blocks/sitemap-section-index-feature-block/features/sitemap-section-front-index/xml.test.js
+++ b/blocks/sitemap-section-index-feature-block/features/sitemap-section-front-index/xml.test.js
@@ -2,28 +2,36 @@
 import Consumer from 'fusion:consumer'
 import { SitemapSectionFrontIndex } from './xml'
 
+const siteService = {
+  children: [
+    { _id: '/politics' },
+    { _id: '/opinion' },
+    { _id: '/economy' },
+    {
+      _id: '/sports',
+      children: [
+        { _id: '/sports/football' },
+        { _id: '/sports/baseball' },
+        { _id: '/sports/basketball' },
+      ],
+    },
+    {
+      _id: '/entertainment',
+      children: [
+        { _id: '/entertainment/tv' },
+        { _id: '/entertainment/movies' },
+      ],
+    },
+  ],
+}
+
 it('returns template with sitemap index by section links', () => {
   const sitemapsectionindex = SitemapSectionFrontIndex({
     arcSite: 'demo',
-    globalContent: {
-      children: [
-        { _id: '/politics' },
-        { _id: '/opinion' },
-        { _id: '/economy' },
-        {
-          _id: '/sports',
-          children: [
-            { _id: '/sports/football' },
-            { _id: '/sports/baseball' },
-            { _id: '/sports/basketball' },
-          ],
-        },
-        { _id: '/entertainment' },
-      ],
-    },
+    globalContent: siteService,
     customFields: {
       feedPath: '/arc/outboundfeeds/sitemap/category',
-      feedParam: 'outputType=xml',
+      feedParam: '',
     },
   })
   expect(sitemapsectionindex).toMatchSnapshot()
@@ -32,19 +40,24 @@ it('returns template with sitemap index by section links', () => {
 it('returns template with sitemap index by section links with excluded links', () => {
   const sitemapsectionindex = SitemapSectionFrontIndex({
     arcSite: 'demo',
-    globalContent: {
-      children: [
-        { _id: '/politics' },
-        { _id: '/opinion' },
-        { _id: '/economy' },
-        { _id: '/sports' },
-        { _id: '/entertainment' },
-      ],
-    },
+    globalContent: siteService,
     customFields: {
       feedPath: '/arc/outboundfeeds/sitemap/category',
       feedParam: 'outputType=xml',
-      excludeSections: '/politics,/entertainment',
+      excludeSections: '/politics,/entertainment/tv',
+    },
+  })
+  expect(sitemapsectionindex).toMatchSnapshot()
+})
+
+it('returns template with links to sections without outputType', () => {
+  const sitemapsectionindex = SitemapSectionFrontIndex({
+    arcSite: 'demo',
+    globalContent: siteService,
+    customFields: {
+      feedPath: '',
+      feedParam: '',
+      excludeSections: '',
     },
   })
   expect(sitemapsectionindex).toMatchSnapshot()


### PR DESCRIPTION
This impacts sitemap-index, sitemap-index-by-day and sitemap-section
Originally all OBF requests required an outputType= parameter, so all generated links
used a hardcoded ? to start the parameter list.  But now that outputType isn't required
we need to add logic to only include a ? if there are parameters to include.