### PR TITLE
queryBuilder content source AIO-778

### DIFF
--- a/blocks/story-feed-querybuilder-content-source-block/README.md
+++ b/blocks/story-feed-querybuilder-content-source-block/README.md
@@ -1,0 +1,34 @@
+# `@wpmedia/story-feed-querybuilder-content-source-block`
+
+_Content source block for for use with PB Editor/queryBuilder integration. It QB integration will cause a content source with a queryBuilder property to trigger the queryBuilder component to all the configuration of ES queries. When used with the integration component, the parameters will not be displayed to the user._
+
+// TODO: add badge for passing/failing tests
+
+## Acceptance Criteria
+
+- Add AC relevant to the block
+
+## Endpoint
+
+- /content/v4/search/published?body={queryBody}&{queryParams.join('&')}
+
+## ANS Schema
+
+This returns a story feed. The GraphQL schema for story feeds can be found [here](https://github.com/wapopartners/core-components/blob/dev/packages/content-schema_ans-feed-v0.6.2/src/index.js).
+
+## Configurable Params
+
+| **Param**       | **Type** | **Description**                                                   |
+| --------------- | -------- | ----------------------------------------------------------------- |
+| **queryName**   | text     | The name of the query from queryBuilder                           |
+| **queryBody**   | text     | string of ElasticSearch DSL query used with ?body= parameter      |
+| **queryParams** | text     | string of Content-API query parameters; sort, size, from, website |
+| **arcQL**       | text     | string of queryBuilder internal state                             |
+
+## TTL
+
+- `300`
+
+## Additional Considerations
+
+_This content source should only be added to blocks.json one the queryBuilder integration is available._

--- a/blocks/story-feed-querybuilder-content-source-block/index.js
+++ b/blocks/story-feed-querybuilder-content-source-block/index.js
@@ -1,0 +1,1 @@
+module.exports = {}

--- a/blocks/story-feed-querybuilder-content-source-block/package-lock.json
+++ b/blocks/story-feed-querybuilder-content-source-block/package-lock.json
@@ -1,0 +1,5 @@
+{
+  "name": "@wpmedia/story-feed-querybuilder-content-source-block",
+  "version": "0.0.1",
+  "lockfileVersion": 1
+}

--- a/blocks/story-feed-querybuilder-content-source-block/package.json
+++ b/blocks/story-feed-querybuilder-content-source-block/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@wpmedia/story-feed-querybuilder-content-source-block",
+  "version": "0.0.1",
+  "description": "Content source block to use with queryBuilder integration",
+  "main": "index.js",
+  "files": [
+    "sources"
+  ],
+  "license": "CC-BY-NC-ND-4.0",
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/WPMedia/feed-components.git",
+    "directory": "blocks/story-feed-querybuilder-content-source-block"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/",
+    "access": "public"
+  },
+  "author": "Tim Kosmider <timothy.kosmider@washpost.com",
+  "homepage": "https://github.com/WPMedia/feed-components#readme",
+  "peerDependencies": {
+    "@wpmedia/resizer-image-block": "*"
+  }
+}

--- a/blocks/story-feed-querybuilder-content-source-block/sources/story-feed-querybuilder.js
+++ b/blocks/story-feed-querybuilder-content-source-block/sources/story-feed-querybuilder.js
@@ -1,0 +1,24 @@
+import getResizedImageData from '@wpmedia/resizer-image-block'
+
+export default {
+  resolve: (params) => {
+    const paramList = [
+      ...(params.queryParams || '').split(','),
+      `website=${params['arc-site']}`,
+    ]
+    return `/content/v4/search/published?body=${encodeURI(
+      params.queryBody,
+    )}&${paramList.join('&')}`
+  },
+  schemaName: 'ans-feed',
+  queryBuilder: true,
+  params: {
+    queryName: 'text',
+    queryBody: 'text',
+    queryParams: 'text',
+    arcQL: 'text',
+  },
+  transform: (data, query) =>
+    getResizedImageData(data, null, null, null, query['arc-site']),
+  ttl: 300,
+}


### PR DESCRIPTION
This is the content source that will trigger the queriBuilder component in Editor
It does this by having a queryBuilder property
The parameters are intended to be populated by the component not the user
Adding it to feed-components while it's under development.