### PR TITLE
Support single ANS types like story  AIO-847

### DIFF
--- a/.changeset/silent-socks-lick.md
+++ b/.changeset/silent-socks-lick.md
@@ -1,0 +1,5 @@
+---
+'@wpmedia/ans-feature-block': patch
+---
+
+Support single content types in ANS

--- a/blocks/ans-feature-block/features/ans/__snapshots__/json.test.js.snap
+++ b/blocks/ans-feature-block/features/ans/__snapshots__/json.test.js.snap
@@ -1,5 +1,125 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ANS undefined test 1`] = `
+Array [
+  Array [
+    Object {},
+  ],
+]
+`;
+
+exports[`returns ANS for story 1`] = `
+Array [
+  Array [
+    Object {
+      "_id": "ABCD1234",
+      "content_elements": Array [
+        Object {
+          "content": "body goes here",
+          "type": "text",
+        },
+        Object {
+          "content": "second paragraph goes here",
+          "type": "text",
+        },
+      ],
+      "last_updated_date": "2020-04-07T15:02:08.918Z",
+      "promo_items": Object {
+        "basic": Object {
+          "title": "Hand Washing",
+          "url": "hi/abcdefghijklmnopqrstuvwxyz=/arc-anglerfish-arc2-prod-demo.s3.amazonaws.com/public/JTWX7EUOLJE4FCHYGN2COQAERY.png",
+        },
+      },
+      "type": "story",
+      "website_url": "/food/2020/04/07/tips-for-safe-hand-washing",
+    },
+  ],
+]
+`;
+
+exports[`returns ANS from navigation set 1`] = `
+Array [
+  Array [
+    Object {
+      "_id": "/channels",
+      "_website": "demo",
+      "children": Array [
+        Object {
+          "_id": "/channels/ms-teams",
+          "_website": "demo",
+          "children": Array [],
+          "inactive": false,
+          "name": "MS Teams",
+          "node_type": "section",
+        },
+        Object {
+          "_id": "/channels/slack",
+          "_website": "demo",
+          "children": Array [],
+          "inactive": false,
+          "name": "Slack",
+          "node_type": "section",
+        },
+        Object {
+          "_id": "/channels/twitter",
+          "_website": "demo",
+          "children": Array [],
+          "inactive": false,
+          "name": "Twitter",
+          "node_type": "section",
+        },
+      ],
+      "inactive": false,
+      "name": "Channels",
+      "node_type": "section",
+    },
+  ],
+]
+`;
+
+exports[`returns ANS from results set 1`] = `
+Array [
+  Array [
+    Object {
+      "last_updated_date": "2020-04-07T15:02:08.918Z",
+      "promo_items": Object {
+        "basic": Object {
+          "title": "Hand Washing",
+          "url": "hi/abcdefghijklmnopqrstuvwxyz=/arc-anglerfish-arc2-prod-demo.s3.amazonaws.com/public/JTWX7EUOLJE4FCHYGN2COQAERY.png",
+        },
+      },
+      "type": "story",
+      "website_url": "/food/2020/04/07/tips-for-safe-hand-washing",
+    },
+    Object {
+      "content_elements": Array [
+        Object {
+          "type": "image",
+          "url": "hi/abcdefghijklmnopqrstuvwxyz=/arc-anglerfish-arc2-prod-demo.s3.amazonaws.com/public/JTWX7EUOLJE4FCHYGN2COQAERY.png",
+        },
+      ],
+      "last_updated_date": "2021-04-07T17:02:08.918Z",
+      "type": "story",
+      "website_url": "/food/2021/04/07/will-we-ever-stop-hand-washing",
+    },
+    Object {
+      "last_updated_date": "2021-04-03T13:02:08.918Z",
+      "promo_image": Object {
+        "title": "No kneed recipes",
+        "url": "hi/abcdefghijklmnopqrstuvwxyz=/arc-anglerfish-arc2-prod-demo.s3.amazonaws.com/public/JTWX7EUOLJE4FCHYGN2COQAERY.png",
+      },
+      "promo_items": Object {
+        "basic": Object {
+          "type": "video",
+        },
+      },
+      "type": "video",
+      "website_url": "/food/2021/04/03/best-sourdough-recipes",
+    },
+  ],
+]
+`;
+
 exports[`returns template with default values 1`] = `
 Array [
   Array [

--- a/blocks/ans-feature-block/features/ans/json.js
+++ b/blocks/ans-feature-block/features/ans/json.js
@@ -3,7 +3,7 @@ import getProperties from 'fusion:properties'
 import { resizerKey } from 'fusion:environment'
 import { buildResizerURL } from '@wpmedia/feeds-resizer'
 
-export function ANSFeed({ globalContent, customFields, arcSite }) {
+export function ANSFeed({ globalContent = {}, customFields, arcSite }) {
   const { resizerURL = '', feedDomainURL = '' } = getProperties(arcSite)
   const { width = 0, height = 0 } = customFields.resizerKVP || {}
 
@@ -27,7 +27,19 @@ export function ANSFeed({ globalContent, customFields, arcSite }) {
     }
   }
 
-  const resizedContent = globalContent.content_elements.map((i) => {
+  let contentMap = []
+  if (
+    globalContent?.type === 'results' ||
+    globalContent?.type === 'collection'
+  ) {
+    contentMap = globalContent.content_elements
+  } else if (globalContent?.children) {
+    contentMap = globalContent.children
+  } else {
+    contentMap = [globalContent]
+  }
+
+  const resizedContent = contentMap.map((i) => {
     i.promo_items &&
       Object.keys(i.promo_items).forEach((e) => {
         const promo = i.promo_items[e]

--- a/blocks/ans-feature-block/features/ans/json.test.js
+++ b/blocks/ans-feature-block/features/ans/json.test.js
@@ -2,10 +2,20 @@
 import Consumer from 'fusion:consumer'
 import { ANSFeed } from './json'
 
-it('returns template with default values', () => {
+it('ANS undefined test', () => {
+  const ans = ANSFeed({
+    arcSite: 'the-globe',
+    globalContent: undefined,
+    customFields: {},
+  })
+  expect(ans).toMatchSnapshot()
+})
+
+it('returns ANS from results set', () => {
   const ans = ANSFeed({
     arcSite: 'the-globe',
     globalContent: {
+      type: 'results',
       content_elements: [
         {
           type: 'story',
@@ -40,6 +50,83 @@ it('returns template with default values', () => {
           },
         },
       ],
+    },
+    customFields: {},
+  })
+  expect(ans).toMatchSnapshot()
+})
+
+it('returns ANS from navigation set', () => {
+  const ans = ANSFeed({
+    arcSite: 'the-globe',
+    globalContent: {
+      _id: '/',
+      _website: 'demo',
+      name: 'Demo',
+      inactive: false,
+      node_type: 'section',
+      parent: null,
+      ancestors: null,
+      order: null,
+      children: [
+        {
+          _id: '/channels',
+          name: 'Channels',
+          _website: 'demo',
+          inactive: false,
+          node_type: 'section',
+          children: [
+            {
+              _id: '/channels/ms-teams',
+              name: 'MS Teams',
+              _website: 'demo',
+              inactive: false,
+              node_type: 'section',
+              children: [],
+            },
+            {
+              _id: '/channels/slack',
+              name: 'Slack',
+              _website: 'demo',
+              inactive: false,
+              node_type: 'section',
+              children: [],
+            },
+            {
+              _id: '/channels/twitter',
+              name: 'Twitter',
+              _website: 'demo',
+              inactive: false,
+              node_type: 'section',
+              children: [],
+            },
+          ],
+        },
+      ],
+    },
+    customFields: {},
+  })
+  expect(ans).toMatchSnapshot()
+})
+
+it('returns ANS for story', () => {
+  const ans = ANSFeed({
+    arcSite: 'the-globe',
+    globalContent: {
+      _id: 'ABCD1234',
+      type: 'story',
+      last_updated_date: '2020-04-07T15:02:08.918Z',
+      website_url: '/food/2020/04/07/tips-for-safe-hand-washing',
+      content_elements: [
+        { type: 'text', content: 'body goes here' },
+        { type: 'text', content: 'second paragraph goes here' },
+      ],
+      promo_items: {
+        basic: {
+          title: 'Hand Washing',
+          url: 'https://arc-anglerfish-arc2-prod-demo.s3.amazonaws.com/public/JTWX7EUOLJE4FCHYGN2COQAERY.png',
+        },
+      },
     },
     customFields: {},
   })


### PR DESCRIPTION
The previous ANS change only fixed navigation, not story.  THat fix only looked if
content_elements existed.  But both results set and story contain content_elements
so changed it to look at type.  If results or collection use content_elements, if children
use it, otherwise wrap in an array and convert the top level items