### PR TITLE
Fix adScript customField type to string  AIO-911

### DIFF
--- a/.changeset/four-rats-kneel.md
+++ b/.changeset/four-rats-kneel.md
@@ -1,0 +1,5 @@
+---
+'@wpmedia/rss-fbia-feature-block': patch
+---
+
+Fix customField type

--- a/blocks/rss-fbia-feature-block/features/rss/xml.js
+++ b/blocks/rss-fbia-feature-block/features/rss/xml.js
@@ -641,11 +641,11 @@ FbiaRss.propTypes = {
         'Enter Facebook ad tag that goes between <section class="op-ad-template"></section> tag. It will be added to the beginning of the body\'s header for recirculation ads that come from Facebook advertisers; leave blank if not used.',
       defaultValue: '',
     }),
-    adScripts: PropTypes.json.tag({
+    adScripts: PropTypes.string.tag({
       label: 'Analytic Scripts',
       group: 'Facebook Options',
       description:
-        'Enter third party scripts wrapped in a <figure class=‘op-tracker’> tag. It will be added to the end of the article body. Multiple scripts can be included, usually each in its own iframe. If you need to reference data from the ANS content, use place holders in the format of <<ANS_field>> like <<taxonomy.primary_section._id>>',
+        'Enter third party scripts wrapped in a <figure class="op-tracker"> tag. It will be added to the end of the article body. Multiple scripts can be included, usually each in its own iframe. If you need to reference data from the ANS content, use place holders in the format of <<ANS_field>> like <<taxonomy.primary_section._id>>',
       defaultValue: '',
     }),
     iframeHxW: PropTypes.kvp.tag({


### PR DESCRIPTION
I changed the customField adScript type from string to json.  But the intended value is actually xml like <figure><iframe><script</script></iframe></figure> so the type needs to be string or Editor will not take the entry. I must have put in my test data before I switched they types so it looked like it was working locally.