### PR TITLE
Support xmlbuilder2 3.x  AIO-677

### DIFF
--- a/.changeset/nice-hornets-rush.md
+++ b/.changeset/nice-hornets-rush.md
@@ -1,0 +1,5 @@
+---
+'@wpmedia/rss-fbia-feature-block': patch
+---
+
+Support xmlbuilder2@3.x.x versions

--- a/blocks/rss-fbia-feature-block/README.md
+++ b/blocks/rss-fbia-feature-block/README.md
@@ -36,8 +36,15 @@ likesAndComments: Enable or disable, defaults to disable
 adPlacement: Enables automatic placement of ads within this article. This parameter is optional and defaults to false if you do not specify
 adDensity: How frequently you would like ads to appear in your article: default (<250 word gap), medium (350 word gap), low (>450 word gap)
 placementSection: Enter Javascript that goes between <section class="op-ad-template"></section> in beginning of the body\'s header for recirculation ads that come from Facebook advertisers; leave blank if not used.,
-adScripts: Enter third party scripts wrapped in a <figure class=‘op-tracker’> tag. It will be added to the end of the article body. Multiple scripts can be included, usually each in its own iframe. If you need to reference data from the ANS content, use place holders in the format of <<ANS_field>> like <<taxonomy.primary_section._id>>
+adScripts: Enter third party scripts wrapped in a <figure class=‘op-tracker’> tag. It will be added to the end of the article body. Multiple scripts can be included, usually each in its own iframe. If you need to reference data from the ANS content, use place holders in the format of <<ANS_field>> like <<taxonomy.primary_section.\_id>>
+`<figure class="op-tracker"><iframe><script>console.log("_id=<<_id>> headlines=<<headlines.basic>> primary_section=<<taxonomy.sections[0]._id>> junk=<<invalid.field>> empty=<<>>");</script></iframe></figure>`
 iframeHxW: Height and/or width to use in oembed iframes
 raw_html_processing: should raw_html be excluded, included or wrapped in <figure><iframe> tags
 
 ### Usage
+
+To use this feature in your repo, add the dependencies to your repos package.json
+"jmespath": "^0.15.0",
+"moment": "^2.24.0",
+"xmlbuilder2": "2.1.7",
+For xmlbuilder2 be sure to use version <= 2.1.7 or >= 3.0.0

--- a/blocks/rss-fbia-feature-block/features/rss/xml.js
+++ b/blocks/rss-fbia-feature-block/features/rss/xml.js
@@ -13,7 +13,7 @@ import { convert, fragment } from 'xmlbuilder2'
  * If you are building a custom fb-ia format be sure to
  * add moment and xmlbuilder2 to your repo's dependencies
  * There is an issue with newer versions of xmlbuilder2.  You must
- * only use version 2.1.7 like this "xmlbuilder2": "2.1.7"
+ * use version <= 2.1.7 or version >= 3.0.0 like this "xmlbuilder2": "2.1.7"
  */
 import URL from 'url'
 const jmespath = require('jmespath')
@@ -182,7 +182,7 @@ export function FbiaRss({ globalContent, customFields, arcSite, requestUri }) {
   }
   // Look for placeholders like <<_id>> in adscripts, returns an array | null
   // can't use {{}} since fusion strips them out
-  const adScripts = customFields.adScripts ?? ''
+  const adScripts = customFields.adScripts ?? '' // Add your custom analystics logic here
   const adScriptPlaceholders = adScripts.match(/(<<.*?>>)/gm)
 
   const replacePlaceholders = (s) => {
@@ -291,7 +291,7 @@ export function FbiaRss({ globalContent, customFields, arcSite, requestUri }) {
         header.push({
           section: {
             '@class': 'op-ad-template',
-            '#': [placementSection],
+            '!': ['tHe_FbAd_GoEs_HeRe'],
           },
         })
 
@@ -379,7 +379,7 @@ export function FbiaRss({ globalContent, customFields, arcSite, requestUri }) {
           header: {
             '#': header,
           },
-          '#': ['<tHe_BoDy_GoEs_HeRe/>', '<tHe_AdScRiPt_GoEs_HeRe/>'],
+          '!': ['tHe_BoDy_GoEs_HeRe', 'tHe_AdScRiPt_GoEs_HeRe'],
           footer: {
             '#': {
               ...(authorDescription.length && {
@@ -571,8 +571,9 @@ export function FbiaRss({ globalContent, customFields, arcSite, requestUri }) {
         videoSelect,
       )
       return htmlBody
-        .replace('<tHe_BoDy_GoEs_HeRe/>', parsedBody)
-        .replace('<tHe_AdScRiPt_GoEs_HeRe/>', replacePlaceholders(s)) // Add custom analytics scripts here as an xml string
+        .replace('<!--tHe_BoDy_GoEs_HeRe-->', parsedBody)
+        .replace('<!--tHe_AdScRiPt_GoEs_HeRe-->', replacePlaceholders(s)) // analytics scripts processed here
+        .replace('<!--tHe_FbAd_GoEs_HeRe-->', placementSection)
     }
   }
 


### PR DESCRIPTION
xmlbuilder2@3.0.0 fixed the mixed content bug, but 3.x changes the
way some tags are encoded.  Tags like <ThE_bOdY_gOeS_hErE/> are added
to the content then replaced with the customFields, this prevents the
tags from becoming encoded like &lt;script&gt;
But 3.x is encoding those so I had to switch them to comments <!-- -->
which it doesn't mess with.