### PR TITLE
Handle missing default value OBF-1.12_hotfix

### DIFF
--- a/.changeset/curly-tigers-serve.md
+++ b/.changeset/curly-tigers-serve.md
@@ -1,0 +1,5 @@
+---
+'@wpmedia/sitemap-section-feature-block': patch
+---
+
+Handle missing default values

--- a/blocks/sitemap-section-feature-block/features/sitemap-section/__snapshots__/xml.test.js.snap
+++ b/blocks/sitemap-section-feature-block/features/sitemap-section/__snapshots__/xml.test.js.snap
@@ -67,52 +67,52 @@ Object {
     "url": Array [
       Object {
         "changefreq": "always",
-        "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap/category/politics/",
+        "loc": "http://demo-prod.origin.arcpublishing.com/politics/",
         "priority": "0.5",
       },
       Object {
         "changefreq": "always",
-        "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap/category/opinion/",
+        "loc": "http://demo-prod.origin.arcpublishing.com/opinion/",
         "priority": "0.5",
       },
       Object {
         "changefreq": "always",
-        "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap/category/economy/",
+        "loc": "http://demo-prod.origin.arcpublishing.com/economy/",
         "priority": "0.5",
       },
       Object {
         "changefreq": "always",
-        "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap/category/sports/",
+        "loc": "http://demo-prod.origin.arcpublishing.com/sports/",
         "priority": "0.5",
       },
       Object {
         "changefreq": "0.5",
-        "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap/category/sports/football/",
+        "loc": "http://demo-prod.origin.arcpublishing.com/sports/football/",
         "priority": "always",
       },
       Object {
         "changefreq": "0.5",
-        "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap/category/sports/baseball/",
+        "loc": "http://demo-prod.origin.arcpublishing.com/sports/baseball/",
         "priority": "always",
       },
       Object {
         "changefreq": "0.5",
-        "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap/category/sports/basketball/",
+        "loc": "http://demo-prod.origin.arcpublishing.com/sports/basketball/",
         "priority": "always",
       },
       Object {
         "changefreq": "always",
-        "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap/category/entertainment/",
+        "loc": "http://demo-prod.origin.arcpublishing.com/entertainment/",
         "priority": "0.5",
       },
       Object {
         "changefreq": "0.5",
-        "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap/category/entertainment/tv/",
+        "loc": "http://demo-prod.origin.arcpublishing.com/entertainment/tv/",
         "priority": "always",
       },
       Object {
         "changefreq": "0.5",
-        "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap/category/entertainment/movies/",
+        "loc": "http://demo-prod.origin.arcpublishing.com/entertainment/movies/",
         "priority": "always",
       },
     ],

--- a/blocks/sitemap-section-feature-block/features/sitemap-section/xml.js
+++ b/blocks/sitemap-section-feature-block/features/sitemap-section/xml.js
@@ -54,7 +54,7 @@ export function SitemapSection({ globalContent, customFields, arcSite }) {
         !checkForLinks(section)
       ) {
         accum.push({
-          loc: `${domain}${feedPath}${sectionId}/${parameters}`,
+          loc: `${domain}${feedPath ?? ''}${sectionId}/${parameters}`,
           ...(changeFreq !== 'Exclude field' &&
             changeFreq !== 'Exclude from sitemap' && {
               changefreq: changeFreq,

--- a/blocks/sitemap-section-feature-block/features/sitemap-section/xml.test.js
+++ b/blocks/sitemap-section-feature-block/features/sitemap-section/xml.test.js
@@ -31,7 +31,7 @@ it('returns template with sitemap by section links', () => {
     arcSite: 'demo',
     globalContent: siteService,
     customFields: {
-      feedPath: '/arc/outboundfeeds/sitemap/category',
+      feedPath: '',
       feedParam: '',
       priority: '0.5',
       changeFreq: 'always',
@@ -60,9 +60,6 @@ it('returns template with links to sections without outputType', () => {
     arcSite: 'demo',
     globalContent: siteService,
     customFields: {
-      feedPath: '',
-      feedParam: '',
-      excludeSections: '',
       priority: '',
       changeFreq: '',
     },


### PR DESCRIPTION
The sitemap-section block defines feedPath with a default of ''.  But that value is
not getting saved in the DB so it is undefined.  This gets displayed in the url
Added {feedPath ?? ''} to handle undefined values