### PR TITLE
Sitemaps at root  AIO-767

### DIFF
--- a/.changeset/nice-singers-smile.md
+++ b/.changeset/nice-singers-smile.md
@@ -1,0 +1,7 @@
+---
+'@wpmedia/feeds-source-content-api-block': patch
+'@wpmedia/sitemap-index-by-day-feature-block': patch
+'@wpmedia/sitemap-section-index-feature-block': patch
+---
+
+Support sitemap-at-root.xml url format

--- a/blocks/feeds-source-content-api-block/README.md
+++ b/blocks/feeds-source-content-api-block/README.md
@@ -9,17 +9,24 @@ Creates an ElasticSearch DSL syntax to query Content-API
 
 ## Parameters
 
-- Section: Maps to taxonomy.sections.\_id. It needs to start with a slash “/news”
+- Section: Comma separated list of sections, maps to taxonomy.sections.\_id
 - Author: Maps to credits.by.\_id
 - Keywords: Maps to taxonomy.seo_keywords. It can be a comma separated list of values
 - Tags-Text: Maps to taxonomy.tags.text. It can be a comma separated list of values
 - Tags-Slug: Maps to taxonomy.tags.slug
 - Include-Terms: If you don’t want to use the default query you can enter a query here. It must be an array formatted like `[{"term":{"type": "story"}},{"range":{"last_updated_date:{"gte":"now-2d","lte":"now"}}}]`
 - Exclude-Terms: If you need to exclude terms in your query (NOT) enter them here as an array formatted the same as the Include-Terms
+- Exclude-Sections: Comma separated list of sections to exclude, maps to taxonomy.sections.\_id
 - Feed-Size: Integer 1 to 100. Defaults to 100
 - Feed-Offset: Integer. Defaults to 0
-- Source-Exclude: ANS fields to exclude from the response. Defaults to `related_content`
 - Sort: Comma separated list of fields to sort on. Defaults to `publish_date:desc`
+- Source-Exclude: ANS fields to remove from \_sourceIncludes default values
+- Source-Include: ANS fields to add to \_sourceIncludes default values
+- Sitemap-at-root: (string) if set replaces all '-' with '/' in Section field
+- Include-Distributor-Name: pass to C-API only one distributor field can be set
+- Exclude-Distributor-Name: pass to C-API only one distributor field can be set
+- Include-Distributor-Category: pass to C-API only one distributor field can be set
+- Exclude-Distributor-Category: pass to C-API only one distributor field can be set
 
 ### Usage
 

--- a/blocks/feeds-source-content-api-block/sources/feeds-content-api.js
+++ b/blocks/feeds-source-content-api-block/sources/feeds-content-api.js
@@ -15,6 +15,9 @@ const resolve = function resolve(key) {
     'content_elements',
     `websites.${key['arc-site']}`,
   ]
+  // resolvers only support text or number, turn into bool.
+  const sitemapAtRoot =
+    key['Sitemap-at-root'] && key['Sitemap-at-root'].toLowerCase() !== 'false'
 
   const paramList = {
     website: key['arc-site'],
@@ -150,7 +153,8 @@ const resolve = function resolve(key) {
   }
 
   // if Section and/or Exclude-Sections append section query to basic query
-  const { Section } = key
+  const Section =
+    key.Section && sitemapAtRoot ? key.Section.replace(/-/g, '/') : key.Section
   const ExcludeSections = key['Exclude-Sections']
 
   if (Section || ExcludeSections) {
@@ -208,6 +212,7 @@ export default {
     Sort: 'text',
     'Source-Exclude': 'text',
     'Source-Include': 'text',
+    'Sitemap-at-root': 'text',
     'Include-Distributor-Name': 'text',
     'Exclude-Distributor-Name': 'text',
     'Include-Distributor-Category': 'text',

--- a/blocks/feeds-source-content-api-block/sources/feeds-content-api.test.js
+++ b/blocks/feeds-source-content-api-block/sources/feeds-content-api.test.js
@@ -21,6 +21,7 @@ it('validate params', () => {
     Sort: 'text',
     'Source-Exclude': 'text',
     'Source-Include': 'text',
+    'Sitemap-at-root': 'text',
     'Include-Distributor-Name': 'text',
     'Exclude-Distributor-Name': 'text',
     'Include-Distributor-Category': 'text',
@@ -44,6 +45,7 @@ it('returns query with default values', () => {
     Sort: '',
     'Source-Exclude': '',
     'Source-Include': '',
+    'Sitemap-at-root': '',
   })
   expect(query).toBe(
     'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22range%22:%7B%22last_updated_date%22:%7B%22gte%22:%22now-2d%22,%22lte%22:%22now%22%7D%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&sort=publish_date:desc&_sourceInclude=canonical_url,canonical_website,created_date,credits,description,display_date,duration,first_publish_date,headlines,last_updated_date,promo_image,promo_items,publish_date,streams,subheadlines,subtitles,subtype,taxonomy.primary_section,taxonomy.seo_keywords,taxonomy.tags,type,video_type,content_elements,websites.demo',
@@ -66,6 +68,7 @@ it('returns query with parameter values', () => {
     Sort: 'display_date:asc',
     'Source-Exclude': 'content_elements,taxonomy',
     'Source-Include': 'source,owner',
+    'Sitemap-at-root': '',
     'Include-Distributor-Name': 'AP',
     'Exclude-Distributor-Name': 'paid',
     'Include-Distributor-Category': 'promotions',
@@ -98,6 +101,7 @@ it('returns query by section', () => {
     Sort: '',
     'Source-Exclude': '',
     'Source-Include': '',
+    'Sitemap-at-root': '',
   })
   expect(query).toContain('%22taxonomy.sections._id%22:%5B%22/sports%22')
 })
@@ -118,6 +122,7 @@ it('returns query by Exclude-Sections', () => {
     Sort: '',
     'Source-Exclude': '',
     'Source-Include': '',
+    'Sitemap-at-root': '',
   })
   expect(query).toBe(
     'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22range%22:%7B%22last_updated_date%22:%7B%22gte%22:%22now-2d%22,%22lte%22:%22now%22%7D%7D%7D,%7B%22nested%22:%7B%22path%22:%22taxonomy.sections%22,%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22taxonomy.sections._website%22:%22demo%22%7D%7D%5D%7D%7D%7D%7D%5D,%22must_not%22:%5B%7B%22nested%22:%7B%22path%22:%22taxonomy.sections%22,%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22terms%22:%7B%22taxonomy.sections._id%22:%5B%22/food%22,%22/politics%22%5D%7D%7D%5D%7D%7D%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&sort=publish_date:desc&_sourceInclude=canonical_url,canonical_website,created_date,credits,description,display_date,duration,first_publish_date,headlines,last_updated_date,promo_image,promo_items,publish_date,streams,subheadlines,subtitles,subtype,taxonomy.primary_section,taxonomy.seo_keywords,taxonomy.tags,type,video_type,content_elements,websites.demo',
@@ -127,19 +132,9 @@ it('returns query by Exclude-Sections', () => {
 it('returns query by section and Exclude-Sections', () => {
   const query = resolver.default.resolve({
     Section: '/sports/,/news/',
-    Author: '',
-    Keywords: '',
-    'Tags-Text': '',
-    'Tags-Slug': '',
     'arc-site': 'demo',
-    'Include-Terms': '',
-    'Exclude-Terms': '',
     'Exclude-Sections': '/food,politics/',
-    'Feed-Size': '',
-    'Feed-Offset': '',
-    Sort: '',
-    'Source-Exclude': '',
-    'Source-Include': '',
+    'Sitemap-at-root': 'false',
   })
   expect(query).toBe(
     'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22range%22:%7B%22last_updated_date%22:%7B%22gte%22:%22now-2d%22,%22lte%22:%22now%22%7D%7D%7D,%7B%22nested%22:%7B%22path%22:%22taxonomy.sections%22,%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22taxonomy.sections._website%22:%22demo%22%7D%7D,%7B%22terms%22:%7B%22taxonomy.sections._id%22:%5B%22/sports%22,%22/news%22%5D%7D%7D%5D%7D%7D%7D%7D%5D,%22must_not%22:%5B%7B%22nested%22:%7B%22path%22:%22taxonomy.sections%22,%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22terms%22:%7B%22taxonomy.sections._id%22:%5B%22/food%22,%22/politics%22%5D%7D%7D%5D%7D%7D%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&sort=publish_date:desc&_sourceInclude=canonical_url,canonical_website,created_date,credits,description,display_date,duration,first_publish_date,headlines,last_updated_date,promo_image,promo_items,publish_date,streams,subheadlines,subtitles,subtype,taxonomy.primary_section,taxonomy.seo_keywords,taxonomy.tags,type,video_type,content_elements,websites.demo',
@@ -148,20 +143,8 @@ it('returns query by section and Exclude-Sections', () => {
 
 it('returns query by author', () => {
   const query = resolver.default.resolve({
-    Section: '',
     Author: 'John Smith',
-    Keywords: '',
-    'Tags-Text': '',
-    'Tags-Slug': '',
     'arc-site': 'demo',
-    'Include-Terms': '',
-    'Exclude-Terms': '',
-    'Exclude-Sections': '',
-    'Feed-Size': '',
-    'Feed-Offset': '',
-    Sort: '',
-    'Source-Exclude': '',
-    'Source-Include': '',
   })
   expect(query).toBe(
     'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22range%22:%7B%22last_updated_date%22:%7B%22gte%22:%22now-2d%22,%22lte%22:%22now%22%7D%7D%7D,%7B%22term%22:%7B%22credits.by._id%22:%22John%20Smith%22%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&sort=publish_date:desc&_sourceInclude=canonical_url,canonical_website,created_date,credits,description,display_date,duration,first_publish_date,headlines,last_updated_date,promo_image,promo_items,publish_date,streams,subheadlines,subtitles,subtype,taxonomy.primary_section,taxonomy.seo_keywords,taxonomy.tags,type,video_type,content_elements,websites.demo',
@@ -170,20 +153,8 @@ it('returns query by author', () => {
 
 it('returns query by author with slash', () => {
   const query = resolver.default.resolve({
-    Section: '',
     Author: '/John /Smith/',
-    Keywords: '',
-    'Tags-Text': '',
-    'Tags-Slug': '',
     'arc-site': 'demo',
-    'Include-Terms': '',
-    'Exclude-Terms': '',
-    'Exclude-Sections': '',
-    'Feed-Size': '',
-    'Feed-Offset': '',
-    Sort: '',
-    'Source-Exclude': '',
-    'Source-Include': '',
   })
   expect(query).toBe(
     'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22range%22:%7B%22last_updated_date%22:%7B%22gte%22:%22now-2d%22,%22lte%22:%22now%22%7D%7D%7D,%7B%22term%22:%7B%22credits.by._id%22:%22John%20Smith%22%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&sort=publish_date:desc&_sourceInclude=canonical_url,canonical_website,created_date,credits,description,display_date,duration,first_publish_date,headlines,last_updated_date,promo_image,promo_items,publish_date,streams,subheadlines,subtitles,subtype,taxonomy.primary_section,taxonomy.seo_keywords,taxonomy.tags,type,video_type,content_elements,websites.demo',
@@ -192,20 +163,8 @@ it('returns query by author with slash', () => {
 
 it('returns query by keywords', () => {
   const query = resolver.default.resolve({
-    Section: '',
-    Author: '',
     Keywords: 'washington football,sports',
-    'Tags-Text': '',
-    'Tags-Slug': '',
     'arc-site': 'demo',
-    'Include-Terms': '',
-    'Exclude-Terms': '',
-    'Exclude-Sections': '',
-    'Feed-Size': '',
-    'Feed-Offset': '',
-    Sort: '',
-    'Source-Exclude': '',
-    'Source-Include': '',
   })
   expect(query).toBe(
     'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22range%22:%7B%22last_updated_date%22:%7B%22gte%22:%22now-2d%22,%22lte%22:%22now%22%7D%7D%7D,%7B%22simple_query_string%22:%7B%22query%22:%22%5C%22washington%20football%5C%22%20%7C%20%5C%22sports%5C%22%22,%22fields%22:%5B%22taxonomy.seo_keywords%22%5D%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&sort=publish_date:desc&_sourceInclude=canonical_url,canonical_website,created_date,credits,description,display_date,duration,first_publish_date,headlines,last_updated_date,promo_image,promo_items,publish_date,streams,subheadlines,subtitles,subtype,taxonomy.primary_section,taxonomy.seo_keywords,taxonomy.tags,type,video_type,content_elements,websites.demo',
@@ -214,20 +173,8 @@ it('returns query by keywords', () => {
 
 it('returns query by tags text', () => {
   const query = resolver.default.resolve({
-    Section: '',
-    Author: '',
-    Keywords: '',
     'Tags-Text': 'football,sports',
-    'Tags-Slug': '',
     'arc-site': 'demo',
-    'Include-Terms': '',
-    'Exclude-Terms': '',
-    'Exclude-Sections': '',
-    'Feed-Size': '',
-    'Feed-Offset': '',
-    Sort: '',
-    'Source-Exclude': '',
-    'Source-Include': '',
   })
   expect(query).toBe(
     'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22range%22:%7B%22last_updated_date%22:%7B%22gte%22:%22now-2d%22,%22lte%22:%22now%22%7D%7D%7D,%7B%22terms%22:%7B%22taxonomy.tags.text.raw%22:%5B%22football%22,%22sports%22%5D%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&sort=publish_date:desc&_sourceInclude=canonical_url,canonical_website,created_date,credits,description,display_date,duration,first_publish_date,headlines,last_updated_date,promo_image,promo_items,publish_date,streams,subheadlines,subtitles,subtype,taxonomy.primary_section,taxonomy.seo_keywords,taxonomy.tags,type,video_type,content_elements,websites.demo',
@@ -236,20 +183,8 @@ it('returns query by tags text', () => {
 
 it('returns query by tags slug', () => {
   const query = resolver.default.resolve({
-    Section: '',
-    Author: '',
-    Keywords: '',
-    'Tags-Text': '',
     'Tags-Slug': '/football,/sports/',
     'arc-site': 'demo',
-    'Include-Terms': '',
-    'Exclude-Terms': '',
-    'Exclude-Sections': '',
-    'Feed-Size': '',
-    'Feed-Offset': '',
-    Sort: '',
-    'Source-Exclude': '',
-    'Source-Include': '',
   })
   expect(query).toBe(
     'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22range%22:%7B%22last_updated_date%22:%7B%22gte%22:%22now-2d%22,%22lte%22:%22now%22%7D%7D%7D,%7B%22terms%22:%7B%22taxonomy.tags.slug%22:%5B%22football%22,%22sports%22%5D%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&sort=publish_date:desc&_sourceInclude=canonical_url,canonical_website,created_date,credits,description,display_date,duration,first_publish_date,headlines,last_updated_date,promo_image,promo_items,publish_date,streams,subheadlines,subtitles,subtype,taxonomy.primary_section,taxonomy.seo_keywords,taxonomy.tags,type,video_type,content_elements,websites.demo',
@@ -258,20 +193,8 @@ it('returns query by tags slug', () => {
 
 it('returns query by Include-Terms', () => {
   const query = resolver.default.resolve({
-    Section: '',
-    Author: '',
-    Keywords: '',
-    'Tags-Text': '',
-    'Tags-Slug': '',
-    'arc-site': 'demo',
     'Include-Terms': '[{"term":{"type":"video"}}]',
-    'Exclude-Terms': '',
-    'Exclude-Sections': '',
-    'Feed-Size': '',
-    'Feed-Offset': '',
-    Sort: '',
-    'Source-Exclude': '',
-    'Source-Include': '',
+    'arc-site': 'demo',
   })
   expect(query).not.toContain('%22term%22:%7B%22type%22:%22story%22')
   expect(query).toContain('%22term%22:%7B%22type%22:%22video%22')
@@ -279,20 +202,8 @@ it('returns query by Include-Terms', () => {
 
 it('returns query by Exclude-Terms', () => {
   const query = resolver.default.resolve({
-    Section: '',
-    Author: '',
-    Keywords: '',
-    'Tags-Text': '',
-    'Tags-Slug': '',
     'arc-site': 'demo',
-    'Include-Terms': '',
     'Exclude-Terms': '[{"term":{"subtype":"premium"}}]',
-    'Exclude-Sections': '',
-    'Feed-Size': '',
-    'Feed-Offset': '',
-    Sort: '',
-    'Source-Exclude': '',
-    'Source-Include': '',
   })
   expect(query).toContain('%22term%22:%7B%22type%22:%22story%22')
   expect(query).toContain('%22term%22:%7B%22subtype%22:%22premium%22')
@@ -300,22 +211,19 @@ it('returns query by Exclude-Terms', () => {
 
 it('returns query by Exclude-Terms', () => {
   const query = resolver.default.resolve({
-    Section: '',
-    Author: '',
-    Keywords: '',
-    'Tags-Text': '',
-    'Tags-Slug': '',
-    'arc-site': 'demo',
-    'Include-Terms': '',
-    'Exclude-Terms': '',
-    'Exclude-Sections': '',
-    'Feed-Size': '',
-    'Feed-Offset': '',
-    Sort: '',
-    'Source-Exclude': '',
-    'Source-Include': '',
     'Include-Distributor-Name': 'AP',
   })
   expect(query).toContain('include_distributor_name=AP')
   expect(query).not.toContain('exclude_distributor_name=AP')
+})
+
+it('Sitemap at Root replace the slashes', () => {
+  const query = resolver.default.resolve({
+    Section: 'sports-football,news',
+    'arc-site': 'demo',
+    'Exclude-Sections': 'ffg-homepage',
+    'Sitemap-at-root': 'X',
+  })
+  expect(query).toContain(encodeURI('["/sports/football","/news"]'))
+  expect(query).toContain(encodeURI('["/ffg-homepage"]'))
 })

--- a/blocks/sitemap-index-by-day-feature-block/README.md
+++ b/blocks/sitemap-index-by-day-feature-block/README.md
@@ -12,6 +12,12 @@ Since this format doesn't need a content source, it can be created as a page.
 
 - numberOfDays - The number of links (days back) to generate. Optionally if a valid date is entered in YYYY-MM-DD format it will be used to calculate the maxDays.
 
-- feedPath - The path to the format to use in the generated links. Defaults to `/arc/outboundfeeds/sitemap-by-day/`
+- feedPath - kvp of number of days and the path to use
+  Defaults to { 0:'/arc/outboundfeeds/sitemap/', 2:'/arc/outboundfeeds/sitemap2', 7:'/arc/outboundfeeds/sitemap3'}
 
 - feedName - The name of the feed used in the resolver. Defaults to `/sitemap-index/` This is used to split the requestURI to get anything in the path after the feed like a section. If a request is made using `/arc/outboundfeeds/sitemap-index/category/sports`. This will be split on `/sitemap-index/` which results in an array of `['/arc/outboundfeeds', 'category/sports']` the second array element, if any, will be appended to the generated sitemap url.
+
+- feedExtension - file extention like .xml to add to urls, otherwise they end in '/'
+- feedParams - optional url parameters separated with '&' no leading '?'
+- feedDates2Split - kvp of dates to split and number of splits like
+  { '2022-03-14': '2'} to create /sitemap/2022-03-14-1, sitemap/2022-03-14-2

--- a/blocks/sitemap-index-by-day-feature-block/features/sitemap-index/__snapshots__/xml.test.js.snap
+++ b/blocks/sitemap-index-by-day-feature-block/features/sitemap-index/__snapshots__/xml.test.js.snap
@@ -125,3 +125,31 @@ Object {
   },
 }
 `;
+
+exports[`sitemaps at root 1`] = `
+Object {
+  "sitemapindex": Object {
+    "@xmlns": "http://www.sitemaps.org/schemas/sitemap/0.9",
+    "sitemap": Array [
+      Object {
+        "loc": "http://demo-prod.origin.arcpublishing.com/sitemap-latest.xml",
+      },
+      Object {
+        "loc": "http://demo-prod.origin.arcpublishing.com/sitemap-2021-04-08.xml",
+      },
+      Object {
+        "loc": "http://demo-prod.origin.arcpublishing.com/sitemap-2021-04-07.xml",
+      },
+      Object {
+        "loc": "http://demo-prod.origin.arcpublishing.com/sitemap-2021-04-06-1.xml",
+      },
+      Object {
+        "loc": "http://demo-prod.origin.arcpublishing.com/sitemap-2021-04-06-2.xml",
+      },
+      Object {
+        "loc": "http://demo-prod.origin.arcpublishing.com/sitemap-2021-04-05.xml",
+      },
+    ],
+  },
+}
+`;

--- a/blocks/sitemap-index-by-day-feature-block/features/sitemap-index/xml.js
+++ b/blocks/sitemap-index-by-day-feature-block/features/sitemap-index/xml.js
@@ -7,19 +7,19 @@ import URL from 'url'
 const sitemapIndexTemplate = ({
   maxDays,
   feedPath,
+  feedExtension,
   feedParam,
   feedDates2Split,
   section,
-  domain,
   buildIndexes,
 }) => ({
   sitemapindex: {
     '@xmlns': 'http://www.sitemaps.org/schemas/sitemap/0.9',
     sitemap: buildIndexes(
       maxDays,
-      domain,
       feedPath,
       section,
+      feedExtension,
       feedParam,
       feedDates2Split,
     ),
@@ -56,15 +56,16 @@ export function SitemapIndexByDay({
 
   const buildIndexes = (
     maxDays,
-    feedDomainUrl,
     feedPath,
     section,
+    feedExtension,
     feedParam,
     feedDates2Split,
   ) => {
     const arr = []
     const now = moment.utc(new Date())
     const parameters = feedParam ? `?${feedParam}` : ''
+    const extension = feedExtension || '/'
     const splitAllDates =
       feedDates2Split.all || feedDates2Split.All || feedDates2Split.ALL
     const feedPathKeys = Object.keys(feedPath).map((i) => parseInt(i))
@@ -76,12 +77,12 @@ export function SitemapIndexByDay({
       if (numSplits) {
         for (let splits = 1; splits <= numSplits; splits++) {
           arr.push({
-            loc: `${feedDomainURL}${pathValue}${section}${formattedDate}-${splits}/${parameters}`,
+            loc: `${feedDomainURL}${pathValue}${section}${formattedDate}-${splits}${extension}${parameters}`,
           })
         }
       } else {
         arr.push({
-          loc: `${feedDomainURL}${pathValue}${section}${formattedDate}/${parameters}`,
+          loc: `${feedDomainURL}${pathValue}${section}${formattedDate}${extension}${parameters}`,
         })
       }
       now.subtract(1, 'days')
@@ -93,7 +94,6 @@ export function SitemapIndexByDay({
   return sitemapIndexTemplate({
     ...customFields,
     section,
-    domain: feedDomainURL,
     maxDays,
     buildIndexes,
   })
@@ -124,6 +124,13 @@ SitemapIndexByDay.propTypes = {
       group: 'Format',
       description: 'Name of the sitemap-index feed in the URL',
       defaultValue: '/sitemap-index/',
+    }),
+    feedExtension: PropTypes.string.tag({
+      label: 'URL extention',
+      group: 'Format',
+      description:
+        'Optional file extention to append to URL. Set if sitemaps are redirected from root. For example .xml',
+      defaultValue: '',
     }),
     feedParam: PropTypes.string.tag({
       label: 'URL Parameters',

--- a/blocks/sitemap-index-by-day-feature-block/features/sitemap-index/xml.test.js
+++ b/blocks/sitemap-index-by-day-feature-block/features/sitemap-index/xml.test.js
@@ -103,3 +103,21 @@ it('returns template with empty values', () => {
   })
   expect(sitemapindex).toMatchSnapshot()
 })
+
+it('sitemaps at root', () => {
+  const sitemapindex = SitemapIndexByDay({
+    requestUri: '/sitemap-index/?outputType=xml',
+    arcSite: 'demo',
+    customFields: {
+      feedPath: {
+        0: '/sitemap-',
+      },
+      feedName: '/sitemap-index/',
+      feedExtension: '.xml',
+      feedParam: '',
+      numberOfDays: '5',
+      feedDates2Split: { '2021-04-06': 2 },
+    },
+  })
+  expect(sitemapindex).toMatchSnapshot()
+})

--- a/blocks/sitemap-section-index-feature-block/README.md
+++ b/blocks/sitemap-section-index-feature-block/README.md
@@ -7,9 +7,9 @@ This feed can be used to generate links to sitemaps like
 
 `http://wwww.example.com/arc/outboundfeeds/sitemap/category/{category}/`
 
-or it can be used to link directory to website sections like
+or it can be used to generate links to sitemaps at root like
 
-`http://wwww.example.com/{category}/`
+`http://wwww.example.com/sitemap-category-{category}.xml`
 
 Requires a Site Service Content Source like this one from themes
 "@wpmedia/site-hierarchy-content-block"
@@ -17,5 +17,7 @@ Requires a Site Service Content Source like this one from themes
 ## Custom Fields
 
 - feedPath - path to use to call feed used to display sitemap. default - /arc/outboundfeeds/sitemap/category
+- feedAtRoot - boolean should it replace / for -
+- feedExtension - add extention like .xml to end of url || /
 - feedParam - Additional params to add to sitemap request. default - outputType=xml
 - excludeSections - sections to exclude from results

--- a/blocks/sitemap-section-index-feature-block/features/sitemap-section-front-index/__snapshots__/xml.test.js.snap
+++ b/blocks/sitemap-section-index-feature-block/features/sitemap-section-front-index/__snapshots__/xml.test.js.snap
@@ -40,6 +40,46 @@ Object {
 }
 `;
 
+exports[`returns template with sitemap at root 1`] = `
+Object {
+  "sitemapindex": Object {
+    "@xmlns": "http://www.sitemaps.org/schemas/sitemap/0.9",
+    "sitemap": Array [
+      Object {
+        "loc": "http://demo-prod.origin.arcpublishing.com/sitemap-category-politics.xml",
+      },
+      Object {
+        "loc": "http://demo-prod.origin.arcpublishing.com/sitemap-category-opinion.xml",
+      },
+      Object {
+        "loc": "http://demo-prod.origin.arcpublishing.com/sitemap-category-economy.xml",
+      },
+      Object {
+        "loc": "http://demo-prod.origin.arcpublishing.com/sitemap-category-sports.xml",
+      },
+      Object {
+        "loc": "http://demo-prod.origin.arcpublishing.com/sitemap-category-sports-football.xml",
+      },
+      Object {
+        "loc": "http://demo-prod.origin.arcpublishing.com/sitemap-category-sports-baseball.xml",
+      },
+      Object {
+        "loc": "http://demo-prod.origin.arcpublishing.com/sitemap-category-sports-basketball.xml",
+      },
+      Object {
+        "loc": "http://demo-prod.origin.arcpublishing.com/sitemap-category-entertainment.xml",
+      },
+      Object {
+        "loc": "http://demo-prod.origin.arcpublishing.com/sitemap-category-entertainment-tv.xml",
+      },
+      Object {
+        "loc": "http://demo-prod.origin.arcpublishing.com/sitemap-category-entertainment-movies.xml",
+      },
+    ],
+  },
+}
+`;
+
 exports[`returns template with sitemap index by section links 1`] = `
 Object {
   "sitemapindex": Object {

--- a/blocks/sitemap-section-index-feature-block/features/sitemap-section-front-index/xml.js
+++ b/blocks/sitemap-section-index-feature-block/features/sitemap-section-front-index/xml.js
@@ -4,6 +4,8 @@ import getProperties from 'fusion:properties'
 
 const sitemapIndexTemplate = ({
   feedPath,
+  feedAtRoot,
+  feedExtension,
   feedParam,
   excludeSections,
   domain,
@@ -17,6 +19,8 @@ const sitemapIndexTemplate = ({
       excludeSections,
       domain,
       feedPath,
+      feedAtRoot,
+      feedExtension,
       feedParam,
     ),
   },
@@ -40,18 +44,24 @@ export function SitemapSectionFrontIndex({
     excludeSections,
     domain,
     feedPath,
+    feedAtRoot,
+    feedExtension,
     feedParam,
   ) => {
     const parameters = feedParam ? `?${feedParam}` : ''
+    const matchTerm = feedAtRoot ? /\//g : ''
+    const replaceTerm = feedAtRoot ? '-' : ''
     return sections.reduce((accum, section) => {
-      const sectionId = section._id || ''
+      const sectionId = (section._id || '').replace(matchTerm, replaceTerm)
       if (
         sectionId &&
         !excludeSections.includes(sectionId) &&
         !checkForLinks(section)
       ) {
         accum.push({
-          loc: `${domain}${feedPath}${sectionId}/${parameters}`,
+          loc: `${domain}${feedPath}${sectionId}${
+            feedExtension || '/'
+          }${parameters}`,
         })
         if (section.children?.length) {
           const subSections = buildSitemapIndexLinks(
@@ -59,6 +69,8 @@ export function SitemapSectionFrontIndex({
             excludeSections,
             domain,
             feedPath,
+            feedAtRoot,
+            feedExtension,
             feedParam,
           )
           accum.push(...subSections)
@@ -85,6 +97,20 @@ SitemapSectionFrontIndex.propTypes = {
       group: 'Format',
       description: 'Relative URL path used in the generated link',
       defaultValue: '/arc/outboundfeeds/sitemap/category',
+    }),
+    feedAtRoot: PropTypes.bool.tag({
+      label: 'Sitemap at root',
+      group: 'Format',
+      description:
+        'Set if sitemaps are redirected from root. This will replace slashes with dashes',
+      defaultValue: false,
+    }),
+    feedExtension: PropTypes.string.tag({
+      label: 'URL extention',
+      group: 'Format',
+      description:
+        'Optional file extention to append to URL. Set if sitemaps are redirected from root. For example .xml',
+      defaultValue: '',
     }),
     feedParam: PropTypes.string.tag({
       label: 'URL Parameters',

--- a/blocks/sitemap-section-index-feature-block/features/sitemap-section-front-index/xml.test.js
+++ b/blocks/sitemap-section-index-feature-block/features/sitemap-section-front-index/xml.test.js
@@ -63,3 +63,18 @@ it('returns template with links to sections without outputType', () => {
   })
   expect(sitemapsectionindex).toMatchSnapshot()
 })
+
+it('returns template with sitemap at root', () => {
+  const sitemapsectionindex = SitemapSectionFrontIndex({
+    arcSite: 'demo',
+    globalContent: siteService,
+    customFields: {
+      feedPath: '/sitemap-category',
+      feedAtRoot: true,
+      feedExtension: '.xml',
+      feedParam: '',
+      excludeSections: '',
+    },
+  })
+  expect(sitemapsectionindex).toMatchSnapshot()
+})


### PR DESCRIPTION
To support redirects for sitemaps at root we need allow them to use dashes instead of slashes and
add .xml to end of url with feedExtension
feedExtension - optional if set appends the value to the end of the url otherwise uses '/'
sitemapAtRoot - converts slashes to dashs for sitemap-section-index
In feeds-source-content-api-block
Sitemap-at-root - converts dashes back to slashes.  If they have sections with dashes in them,
those must be setup with their own resolvers.