### PR TITLE
refactor: shift component dependencies into resizer utils

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -13,16 +13,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node-version: [10.x, 12.x]
-
     steps:
-      - uses: actions/checkout@v2
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+      - uses: actions/checkout@v4
+      - name: Use Node.js 18.x
+        uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 18.x
           registry-url: https://npm.pkg.github.com
           scope: '@wpmedia'
       - run: npm install && npm run ci

--- a/.github/workflows/publish-develop.yml
+++ b/.github/workflows/publish-develop.yml
@@ -11,12 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@master
+        uses: actions/checkout@v4
 
-      - name: Setup Node.js 10.x
-        uses: actions/setup-node@master
+      - name: Setup Node.js 18.x
+        uses: actions/setup-node@v4
         with:
-          node-version: 10.x
+          node-version: 18.x
           registry-url: https://npm.pkg.github.com
           scope: '@wpmedia'
 

--- a/.github/workflows/publish-prod.yml
+++ b/.github/workflows/publish-prod.yml
@@ -11,12 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@master
+        uses: actions/checkout@v4
 
-      - name: Setup Node.js 10.x
-        uses: actions/setup-node@master
+      - name: Setup Node.js 18.x
+        uses: actions/setup-node@v4
         with:
-          node-version: 10.x
+          node-version: 18.x
           registry-url: https://npm.pkg.github.com
           scope: '@wpmedia'
 
@@ -28,7 +28,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create Release Pull Request or Publish to npm
-        uses: changesets/action@master
+        uses: changesets/action@v1
         with:
           #  this runs release:<branch name> which calls changeset publish --tag [beta|stable]
           publish: npm run release:prod

--- a/.github/workflows/publish-sandbox.yml
+++ b/.github/workflows/publish-sandbox.yml
@@ -11,12 +11,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@master
+        uses: actions/checkout@v4
 
-      - name: Setup Node.js 10.x
-        uses: actions/setup-node@master
+      - name: Setup Node.js 18.x
+        uses: actions/setup-node@v4
         with:
-          node-version: 10.x
+          node-version: 18.x
           registry-url: https://npm.pkg.github.com
           scope: '@wpmedia'
 

--- a/README.md
+++ b/README.md
@@ -22,3 +22,16 @@ There are a set of common utilities used in the blocks.  These are located in th
 
 If you would like to create a custom block, you can start with one of the existing OBF blocks or create something new.  More details can be found [here](https://redirector.arcpublishing.com/alc/arc-products/arcio/user-docs/ejecting-a-block/)
 
+## Local Development
+preconstruct is used to handle the dependency of packages depending on one another. It's set as postinstall and will likely run. If not follow the below:
+After `npm i`
+Run `npm run postinstall`
+```
+> postinstall
+> preconstruct dev
+
+🎁 info project is valid!
+🎁 success created links!
+```
+
+That should resolve any missing module/import errors from dependencies in the utils called in blocks.

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,3 +1,9 @@
 module.exports = {
-  presets: ['@babel/preset-env', '@babel/preset-react'],
+  presets: [    [
+    '@babel/preset-env',
+    {
+      targets: { esmodules: false, node: "current" }
+    },
+  ],
+  '@babel/preset-react'],
 }

--- a/blocks/ans-feature-block/features/ans/__snapshots__/json.test.js.snap
+++ b/blocks/ans-feature-block/features/ans/__snapshots__/json.test.js.snap
@@ -1,28 +1,28 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ANS undefined test 1`] = `
-Array [
-  Object {},
+[
+  {},
 ]
 `;
 
 exports[`returns ANS for story 1`] = `
-Array [
-  Object {
+[
+  {
     "_id": "ABCD1234",
-    "content_elements": Array [
-      Object {
+    "content_elements": [
+      {
         "content": "body goes here",
         "type": "text",
       },
-      Object {
+      {
         "content": "second paragraph goes here",
         "type": "text",
       },
     ],
     "last_updated_date": "2020-04-07T15:02:08.918Z",
-    "promo_items": Object {
-      "basic": Object {
+    "promo_items": {
+      "basic": {
         "title": "Hand Washing",
         "url": "hi/abcdefghijklmnopqrstuvwxyz=/arc-anglerfish-arc2-prod-demo.s3.amazonaws.com/public/JTWX7EUOLJE4FCHYGN2COQAERY.png",
       },
@@ -34,32 +34,32 @@ Array [
 `;
 
 exports[`returns ANS from navigation set 1`] = `
-Array [
-  Array [
-    Object {
+[
+  [
+    {
       "_id": "/channels",
       "_website": "demo",
-      "children": Array [
-        Object {
+      "children": [
+        {
           "_id": "/channels/ms-teams",
           "_website": "demo",
-          "children": Array [],
+          "children": [],
           "inactive": false,
           "name": "MS Teams",
           "node_type": "section",
         },
-        Object {
+        {
           "_id": "/channels/slack",
           "_website": "demo",
-          "children": Array [],
+          "children": [],
           "inactive": false,
           "name": "Slack",
           "node_type": "section",
         },
-        Object {
+        {
           "_id": "/channels/twitter",
           "_website": "demo",
-          "children": Array [],
+          "children": [],
           "inactive": false,
           "name": "Twitter",
           "node_type": "section",
@@ -74,12 +74,12 @@ Array [
 `;
 
 exports[`returns ANS from results set 1`] = `
-Array [
-  Array [
-    Object {
+[
+  [
+    {
       "last_updated_date": "2020-04-07T15:02:08.918Z",
-      "promo_items": Object {
-        "basic": Object {
+      "promo_items": {
+        "basic": {
           "title": "Hand Washing",
           "url": "hi/abcdefghijklmnopqrstuvwxyz=/arc-anglerfish-arc2-prod-demo.s3.amazonaws.com/public/JTWX7EUOLJE4FCHYGN2COQAERY.png",
         },
@@ -87,9 +87,9 @@ Array [
       "type": "story",
       "website_url": "/food/2020/04/07/tips-for-safe-hand-washing",
     },
-    Object {
-      "content_elements": Array [
-        Object {
+    {
+      "content_elements": [
+        {
           "type": "image",
           "url": "hi/abcdefghijklmnopqrstuvwxyz=/arc-anglerfish-arc2-prod-demo.s3.amazonaws.com/public/JTWX7EUOLJE4FCHYGN2COQAERY.png",
         },
@@ -98,14 +98,14 @@ Array [
       "type": "story",
       "website_url": "/food/2021/04/07/will-we-ever-stop-hand-washing",
     },
-    Object {
+    {
       "last_updated_date": "2021-04-03T13:02:08.918Z",
-      "promo_image": Object {
+      "promo_image": {
         "title": "No kneed recipes",
         "url": "hi/abcdefghijklmnopqrstuvwxyz=/arc-anglerfish-arc2-prod-demo.s3.amazonaws.com/public/JTWX7EUOLJE4FCHYGN2COQAERY.png",
       },
-      "promo_items": Object {
-        "basic": Object {
+      "promo_items": {
+        "basic": {
           "type": "video",
         },
       },

--- a/blocks/feeds-source-collections-block/sources/collections.js
+++ b/blocks/feeds-source-collections-block/sources/collections.js
@@ -7,9 +7,8 @@ import {
   resizerKey,
 } from 'fusion:environment'
 
-import { signImagesInANSObject } from '@wpmedia/feeds-resizer'
+import { signImagesInANSObject, resizerFetch } from '@wpmedia/feeds-resizer'
 import { defaultANSFields } from '@wpmedia/feeds-content-source-utils'
-import { fetch as resizerFetch } from '@wpmedia/signing-service-content-source-block'
 
 const sortStories = (idsResp, collectionResp, ids, site) => {
   idsResp.content_elements.forEach((item) => {

--- a/blocks/feeds-source-collections-block/sources/collections.js
+++ b/blocks/feeds-source-collections-block/sources/collections.js
@@ -7,7 +7,7 @@ import {
   resizerKey,
 } from 'fusion:environment'
 
-import signImagesInANSObject from '@wpmedia/arc-themes-components/src/utils/sign-images-in-ans-object'
+import { signImagesInANSObject } from '@wpmedia/feeds-resizer'
 import { defaultANSFields } from '@wpmedia/feeds-content-source-utils'
 import { fetch as resizerFetch } from '@wpmedia/signing-service-content-source-block'
 

--- a/blocks/feeds-source-content-api-block/sources/feeds-content-api.js
+++ b/blocks/feeds-source-content-api-block/sources/feeds-content-api.js
@@ -218,6 +218,7 @@ const fetch = (key, { cachedCall }) => {
         RESIZER_TOKEN_VERSION,
       )(result)
     })
+    .then(({data, ...rest}) => ({ ...rest, data: transform(data, key), }))
     .then(({ data }) => data)
     .catch((error) => console.log('== error ==', error))
 
@@ -227,7 +228,6 @@ const fetch = (key, { cachedCall }) => {
 export default {
   fetch,
   schemaName: 'feeds',
-  transform,
   params: {
     Section: 'text',
     Author: 'text',

--- a/blocks/feeds-source-content-api-block/sources/feeds-content-api.js
+++ b/blocks/feeds-source-content-api-block/sources/feeds-content-api.js
@@ -10,8 +10,7 @@ import {
   defaultANSFields,
   formatSections,
 } from '@wpmedia/feeds-content-source-utils'
-import { signImagesInANSObject } from '@wpmedia/feeds-resizer'
-import { fetch as resizerFetch } from '@wpmedia/signing-service-content-source-block'
+import { signImagesInANSObject, resizerFetch } from '@wpmedia/feeds-resizer'
 
 const generateDistributor = ({
   'Include-Distributor-Name': include_distributor_name,

--- a/blocks/feeds-source-content-api-block/sources/feeds-content-api.js
+++ b/blocks/feeds-source-content-api-block/sources/feeds-content-api.js
@@ -10,7 +10,7 @@ import {
   defaultANSFields,
   formatSections,
 } from '@wpmedia/feeds-content-source-utils'
-import signImagesInANSObject from '@wpmedia/arc-themes-components/src/utils/sign-images-in-ans-object'
+import { signImagesInANSObject } from '@wpmedia/feeds-resizer'
 import { fetch as resizerFetch } from '@wpmedia/signing-service-content-source-block'
 
 const generateDistributor = ({

--- a/blocks/feeds-source-content-api-block/sources/feeds-content-api.test.js
+++ b/blocks/feeds-source-content-api-block/sources/feeds-content-api.test.js
@@ -1,13 +1,22 @@
+import axios from 'axios';
 // eslint-disable-next-line no-unused-vars
 import Consumer from 'fusion:consumer'
-const resolver = require('./feeds-content-api')
+const source = require('./feeds-content-api')
+
+// Mock Axios
+jest.mock('axios');
+
+beforeEach(() => {
+  // Reset Axios mocks before each test
+  axios.mockClear();
+});
 
 it('validate schemaName', () => {
-  expect(resolver.default.schemaName).toBe('feeds')
+  expect(source.default.schemaName).toBe('feeds')
 })
 
 it('validate params', () => {
-  expect(resolver.default.params).toStrictEqual({
+  expect(source.default.params).toStrictEqual({
     Section: 'text',
     Author: 'text',
     Keywords: 'text',
@@ -29,8 +38,11 @@ it('validate params', () => {
   })
 })
 
-it('returns query with default values', () => {
-  const query = resolver.default.resolve({
+it('returns query with default values', async () => {
+  const mockData = { data: 'response' };
+  axios.mockResolvedValue(mockData);
+  
+  await source.default.fetch({
     Section: '',
     Author: '',
     Keywords: '',
@@ -46,14 +58,29 @@ it('returns query with default values', () => {
     'Source-Exclude': '',
     'Source-Include': '',
     'Sitemap-at-root': '',
-  })
-  expect(query).toBe(
+  }, { cachedCall: {} });
+  
+  expect(axios).toHaveBeenCalledTimes(1);
+  expect(axios).toHaveBeenCalledWith({
+    url: expect.stringContaining(`/content/v4/search/published`), // Check base URL
+    method: 'GET',
+    headers: expect.objectContaining({
+      'content-type': 'application/json',
+      Authorization: expect.stringContaining('Bearer '),
+    }),
+  });
+
+  const callUrl = axios.mock.calls[0][0].url;
+  expect(callUrl).toBe(
     'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22range%22:%7B%22last_updated_date%22:%7B%22gte%22:%22now-2d%22,%22lte%22:%22now%22%7D%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&sort=publish_date:desc&_sourceInclude=canonical_url,canonical_website,created_date,credits,description,display_date,duration,first_publish_date,headlines,last_updated_date,promo_image,promo_items,publish_date,streams,subheadlines,subtitles,subtype,taxonomy.primary_section,taxonomy.seo_keywords,taxonomy.tags,type,video_type,content_elements,websites.demo',
   )
 })
 
-it('returns query with parameter values', () => {
-  const query = resolver.default.resolve({
+it('returns query with parameter values', async () => {
+  const mockData = { data: 'response' };
+  axios.mockResolvedValue(mockData);
+  
+  await source.default.fetch({
     Section: '',
     Author: '',
     Keywords: '',
@@ -73,20 +100,26 @@ it('returns query with parameter values', () => {
     'Exclude-Distributor-Name': 'paid',
     'Include-Distributor-Category': 'promotions',
     'Exclude-Distributor-Category': 'wires',
-  })
-  expect(query).toContain('&size=25')
-  expect(query).toContain('&from=3')
-  expect(query).toContain('_sourceExclude=taxonomy&')
-  expect(query).toContain(',source,owner')
-  expect(query).not.toContain('content_elements')
-  expect(query).toContain('&include_distributor_name=AP')
-  expect(query).not.toContain('paid')
-  expect(query).not.toContain('promotions')
-  expect(query).not.toContain('wires')
+  }, { cachedCall: {} });
+  
+  const callUrl = axios.mock.calls[0][0].url;
+  const queryParams = new URLSearchParams(callUrl.split('?')[1]);
+  expect(queryParams.has('content_elements')).not.toBeTruthy();
+  expect(queryParams.has('paid')).not.toBeTruthy();
+  expect(queryParams.has('promotions')).not.toBeTruthy();
+  expect(queryParams.has('wires')).not.toBeTruthy();
+  expect(queryParams.get('size')).toBe('25'); 
+  expect(queryParams.get('from')).toBe('3'); 
+  expect(queryParams.get('_sourceExclude')).toBe('taxonomy'); 
+  expect(queryParams.get('_sourceInclude')).toBe('canonical_url,canonical_website,created_date,credits,description,display_date,duration,first_publish_date,headlines,last_updated_date,promo_image,promo_items,publish_date,streams,subheadlines,subtitles,subtype,taxonomy.primary_section,taxonomy.seo_keywords,taxonomy.tags,type,video_type,websites.demo,source,owner'); 
+  expect(queryParams.get('include_distributor_name')).toBe('AP'); 
 })
 
-it('returns query by section', () => {
-  const query = resolver.default.resolve({
+it('returns query by section', async () => {
+  const mockData = { data: 'response' };
+  axios.mockResolvedValue(mockData);
+  
+  await source.default.fetch({
     Section: 'sports/',
     Author: '',
     Keywords: '',
@@ -102,12 +135,17 @@ it('returns query by section', () => {
     'Source-Exclude': '',
     'Source-Include': '',
     'Sitemap-at-root': '',
-  })
-  expect(query).toContain('%22taxonomy.sections._id%22:%5B%22/sports%22')
+  }, { cachedCall: {} });
+  
+  const callUrl = axios.mock.calls[0][0].url;
+  expect(callUrl).toContain('%22taxonomy.sections._id%22:%5B%22/sports%22')
 })
 
-it('returns query by Exclude-Sections', () => {
-  const query = resolver.default.resolve({
+it('returns query by Exclude-Sections', async () => {
+  const mockData = { data: 'response' };
+  axios.mockResolvedValue(mockData);
+  
+  await source.default.fetch({
     Section: '',
     Author: '',
     Keywords: '',
@@ -123,107 +161,159 @@ it('returns query by Exclude-Sections', () => {
     'Source-Exclude': '',
     'Source-Include': '',
     'Sitemap-at-root': '',
-  })
-  expect(query).toBe(
+  }, { cachedCall: {} });
+  
+  const callUrl = axios.mock.calls[0][0].url;
+  expect(callUrl).toBe(
     'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22range%22:%7B%22last_updated_date%22:%7B%22gte%22:%22now-2d%22,%22lte%22:%22now%22%7D%7D%7D,%7B%22nested%22:%7B%22path%22:%22taxonomy.sections%22,%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22taxonomy.sections._website%22:%22demo%22%7D%7D%5D%7D%7D%7D%7D%5D,%22must_not%22:%5B%7B%22nested%22:%7B%22path%22:%22taxonomy.sections%22,%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22terms%22:%7B%22taxonomy.sections._id%22:%5B%22/food%22,%22/politics%22%5D%7D%7D%5D%7D%7D%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&sort=publish_date:desc&_sourceInclude=canonical_url,canonical_website,created_date,credits,description,display_date,duration,first_publish_date,headlines,last_updated_date,promo_image,promo_items,publish_date,streams,subheadlines,subtitles,subtype,taxonomy.primary_section,taxonomy.seo_keywords,taxonomy.tags,type,video_type,content_elements,websites.demo',
   )
 })
 
-it('returns query by section and Exclude-Sections', () => {
-  const query = resolver.default.resolve({
+it('returns query by section and Exclude-Sections', async () => {
+  const mockData = { data: 'response' };
+  axios.mockResolvedValue(mockData);
+  
+  await source.default.fetch({
     Section: '/sports/,/news/',
     'arc-site': 'demo',
     'Exclude-Sections': '/food,politics/',
     'Sitemap-at-root': 'false',
-  })
-  expect(query).toBe(
+  }, { cachedCall: {} });
+  
+  const callUrl = axios.mock.calls[0][0].url;
+  expect(callUrl).toBe(
     'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22range%22:%7B%22last_updated_date%22:%7B%22gte%22:%22now-2d%22,%22lte%22:%22now%22%7D%7D%7D,%7B%22nested%22:%7B%22path%22:%22taxonomy.sections%22,%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22taxonomy.sections._website%22:%22demo%22%7D%7D,%7B%22terms%22:%7B%22taxonomy.sections._id%22:%5B%22/sports%22,%22/news%22%5D%7D%7D%5D%7D%7D%7D%7D%5D,%22must_not%22:%5B%7B%22nested%22:%7B%22path%22:%22taxonomy.sections%22,%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22terms%22:%7B%22taxonomy.sections._id%22:%5B%22/food%22,%22/politics%22%5D%7D%7D%5D%7D%7D%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&sort=publish_date:desc&_sourceInclude=canonical_url,canonical_website,created_date,credits,description,display_date,duration,first_publish_date,headlines,last_updated_date,promo_image,promo_items,publish_date,streams,subheadlines,subtitles,subtype,taxonomy.primary_section,taxonomy.seo_keywords,taxonomy.tags,type,video_type,content_elements,websites.demo',
   )
 })
 
-it('returns query by author', () => {
-  const query = resolver.default.resolve({
+it('returns query by author', async () => {
+  const mockData = { data: 'response' };
+  axios.mockResolvedValue(mockData);
+  
+  await source.default.fetch({
     Author: 'John Smith',
     'arc-site': 'demo',
-  })
-  expect(query).toBe(
+  }, { cachedCall: {} });
+  
+  const callUrl = axios.mock.calls[0][0].url;
+  expect(callUrl).toBe(
     'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22range%22:%7B%22last_updated_date%22:%7B%22gte%22:%22now-2d%22,%22lte%22:%22now%22%7D%7D%7D,%7B%22term%22:%7B%22credits.by._id%22:%22John%20Smith%22%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&sort=publish_date:desc&_sourceInclude=canonical_url,canonical_website,created_date,credits,description,display_date,duration,first_publish_date,headlines,last_updated_date,promo_image,promo_items,publish_date,streams,subheadlines,subtitles,subtype,taxonomy.primary_section,taxonomy.seo_keywords,taxonomy.tags,type,video_type,content_elements,websites.demo',
   )
 })
 
-it('returns query by author with slash', () => {
-  const query = resolver.default.resolve({
+it('returns query by author with slash', async () => {
+  const mockData = { data: 'response' };
+  axios.mockResolvedValue(mockData);
+  
+  await source.default.fetch({
     Author: '/John /Smith/',
     'arc-site': 'demo',
-  })
-  expect(query).toBe(
+  }, { cachedCall: {} });
+  
+  const callUrl = axios.mock.calls[0][0].url;
+  expect(callUrl).toBe(
     'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22range%22:%7B%22last_updated_date%22:%7B%22gte%22:%22now-2d%22,%22lte%22:%22now%22%7D%7D%7D,%7B%22term%22:%7B%22credits.by._id%22:%22John%20Smith%22%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&sort=publish_date:desc&_sourceInclude=canonical_url,canonical_website,created_date,credits,description,display_date,duration,first_publish_date,headlines,last_updated_date,promo_image,promo_items,publish_date,streams,subheadlines,subtitles,subtype,taxonomy.primary_section,taxonomy.seo_keywords,taxonomy.tags,type,video_type,content_elements,websites.demo',
   )
 })
 
-it('returns query by keywords', () => {
-  const query = resolver.default.resolve({
+it('returns query by keywords', async () => {
+  const mockData = { data: 'response' };
+  axios.mockResolvedValue(mockData);
+  
+  await source.default.fetch({
     Keywords: 'washington football,sports',
     'arc-site': 'demo',
-  })
-  expect(query).toBe(
+  }, { cachedCall: {} });
+  
+  const callUrl = axios.mock.calls[0][0].url;
+  expect(callUrl).toBe(
     'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22range%22:%7B%22last_updated_date%22:%7B%22gte%22:%22now-2d%22,%22lte%22:%22now%22%7D%7D%7D,%7B%22simple_query_string%22:%7B%22query%22:%22%5C%22washington%20football%5C%22%20%7C%20%5C%22sports%5C%22%22,%22fields%22:%5B%22taxonomy.seo_keywords%22%5D%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&sort=publish_date:desc&_sourceInclude=canonical_url,canonical_website,created_date,credits,description,display_date,duration,first_publish_date,headlines,last_updated_date,promo_image,promo_items,publish_date,streams,subheadlines,subtitles,subtype,taxonomy.primary_section,taxonomy.seo_keywords,taxonomy.tags,type,video_type,content_elements,websites.demo',
   )
 })
 
-it('returns query by tags text', () => {
-  const query = resolver.default.resolve({
+it('returns query by tags text', async () => {
+  const mockData = { data: 'response' };
+  axios.mockResolvedValue(mockData);
+  
+  await source.default.fetch({
     'Tags-Text': 'football,sports',
     'arc-site': 'demo',
-  })
-  expect(query).toBe(
+  }, { cachedCall: {} });
+  
+  const callUrl = axios.mock.calls[0][0].url;
+  expect(callUrl).toBe(
     'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22range%22:%7B%22last_updated_date%22:%7B%22gte%22:%22now-2d%22,%22lte%22:%22now%22%7D%7D%7D,%7B%22terms%22:%7B%22taxonomy.tags.text.raw%22:%5B%22football%22,%22sports%22%5D%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&sort=publish_date:desc&_sourceInclude=canonical_url,canonical_website,created_date,credits,description,display_date,duration,first_publish_date,headlines,last_updated_date,promo_image,promo_items,publish_date,streams,subheadlines,subtitles,subtype,taxonomy.primary_section,taxonomy.seo_keywords,taxonomy.tags,type,video_type,content_elements,websites.demo',
   )
 })
 
-it('returns query by tags slug', () => {
-  const query = resolver.default.resolve({
+it('returns query by tags slug', async () => {
+  const mockData = { data: 'response' };
+  axios.mockResolvedValue(mockData);
+  
+  await source.default.fetch({
     'Tags-Slug': '/football,/sports/',
     'arc-site': 'demo',
-  })
-  expect(query).toBe(
+  }, { cachedCall: {} });
+  
+  const callUrl = axios.mock.calls[0][0].url;
+  expect(callUrl).toBe(
     'undefined/content/v4/search/published?body=%7B%22query%22:%7B%22bool%22:%7B%22must%22:%5B%7B%22term%22:%7B%22type%22:%22story%22%7D%7D,%7B%22range%22:%7B%22last_updated_date%22:%7B%22gte%22:%22now-2d%22,%22lte%22:%22now%22%7D%7D%7D,%7B%22terms%22:%7B%22taxonomy.tags.slug%22:%5B%22football%22,%22sports%22%5D%7D%7D%5D%7D%7D%7D&website=demo&size=100&from=0&sort=publish_date:desc&_sourceInclude=canonical_url,canonical_website,created_date,credits,description,display_date,duration,first_publish_date,headlines,last_updated_date,promo_image,promo_items,publish_date,streams,subheadlines,subtitles,subtype,taxonomy.primary_section,taxonomy.seo_keywords,taxonomy.tags,type,video_type,content_elements,websites.demo',
   )
 })
 
-it('returns query by Include-Terms', () => {
-  const query = resolver.default.resolve({
+it('returns query by Include-Terms', async () => {
+  const mockData = { data: 'response' };
+  axios.mockResolvedValue(mockData);
+  
+  await source.default.fetch({
     'Include-Terms': '[{"term":{"type":"video"}}]',
     'arc-site': 'demo',
-  })
-  expect(query).not.toContain('%22term%22:%7B%22type%22:%22story%22')
-  expect(query).toContain('%22term%22:%7B%22type%22:%22video%22')
+  }, { cachedCall: {} });
+  
+  const callUrl = axios.mock.calls[0][0].url;
+  expect(callUrl).not.toContain('%22term%22:%7B%22type%22:%22story%22')
+  expect(callUrl).toContain('%22term%22:%7B%22type%22:%22video%22')
 })
 
-it('returns query by Exclude-Terms', () => {
-  const query = resolver.default.resolve({
+it('returns query by Exclude-Terms', async () => {
+  const mockData = { data: 'response' };
+  axios.mockResolvedValue(mockData);
+  
+  await source.default.fetch({
     'arc-site': 'demo',
     'Exclude-Terms': '[{"term":{"subtype":"premium"}}]',
-  })
-  expect(query).toContain('%22term%22:%7B%22type%22:%22story%22')
-  expect(query).toContain('%22term%22:%7B%22subtype%22:%22premium%22')
+  }, { cachedCall: {} });
+  
+  const callUrl = axios.mock.calls[0][0].url;
+  expect(callUrl).toContain('%22term%22:%7B%22type%22:%22story%22')
+  expect(callUrl).toContain('%22term%22:%7B%22subtype%22:%22premium%22')
 })
 
-it('returns query by Exclude-Terms', () => {
-  const query = resolver.default.resolve({
+it('returns query by Exclude-Terms', async () => {
+  const mockData = { data: 'response' };
+  axios.mockResolvedValue(mockData);
+  
+  await source.default.fetch({
     'Include-Distributor-Name': 'AP',
-  })
-  expect(query).toContain('include_distributor_name=AP')
-  expect(query).not.toContain('exclude_distributor_name=AP')
+  }, { cachedCall: {} });
+  
+  const callUrl = axios.mock.calls[0][0].url;
+  expect(callUrl).toContain('include_distributor_name=AP')
+  expect(callUrl).not.toContain('exclude_distributor_name=AP')
 })
 
-it('Sitemap at Root replace the slashes', () => {
-  const query = resolver.default.resolve({
+it('Sitemap at Root replace the slashes', async () => {
+  const mockData = { data: 'response' };
+  axios.mockResolvedValue(mockData);
+  
+  await source.default.fetch({
     Section: 'sports-football,news',
     'arc-site': 'demo',
     'Exclude-Sections': 'ffg-homepage',
     'Sitemap-at-root': 'X',
-  })
-  expect(query).toContain(encodeURI('["/sports/football","/news"]'))
-  expect(query).toContain(encodeURI('["/ffg-homepage"]'))
+  }, { cachedCall: {} });
+  
+  const callUrl = axios.mock.calls[0][0].url;
+  expect(callUrl).toContain(encodeURI('["/sports/football","/news"]'))
+  expect(callUrl).toContain(encodeURI('["/ffg-homepage"]'))
 })

--- a/blocks/feeds-source-content-api-by-day-block/sources/feeds-content-api-by-day.js
+++ b/blocks/feeds-source-content-api-by-day-block/sources/feeds-content-api-by-day.js
@@ -9,7 +9,7 @@ import {
 } from 'fusion:environment'
 import getProperties from 'fusion:properties'
 
-import signImagesInANSObject from '@wpmedia/arc-themes-components/src/utils/sign-images-in-ans-object'
+import { signImagesInANSObject } from '@wpmedia/feeds-resizer'
 import {
   defaultANSFields,
   formatSections,

--- a/blocks/feeds-source-content-api-by-day-block/sources/feeds-content-api-by-day.js
+++ b/blocks/feeds-source-content-api-by-day-block/sources/feeds-content-api-by-day.js
@@ -201,6 +201,7 @@ const fetch = async (key, { cachedCall }) => {
           RESIZER_TOKEN_VERSION,
         )(result)
       })
+      .then(({data, ...rest}) => ({ ...rest, data: transform(data, key), }))
       .then(({ data }) => data)
       .catch((error) => console.log('== error ==', error))
 
@@ -219,7 +220,6 @@ const fetch = async (key, { cachedCall }) => {
 export default {
   fetch,
   schemaName: 'feeds',
-  transform,
   params: [
     {
       name: 'dateField',

--- a/blocks/feeds-source-content-api-by-day-block/sources/feeds-content-api-by-day.js
+++ b/blocks/feeds-source-content-api-by-day-block/sources/feeds-content-api-by-day.js
@@ -9,7 +9,7 @@ import {
 } from 'fusion:environment'
 import getProperties from 'fusion:properties'
 
-import { signImagesInANSObject } from '@wpmedia/feeds-resizer'
+import { signImagesInANSObject, resizerFetch } from '@wpmedia/feeds-resizer'
 import {
   defaultANSFields,
   formatSections,
@@ -17,7 +17,6 @@ import {
   transform,
   validANSDates,
 } from '@wpmedia/feeds-content-source-utils'
-import { fetch as resizerFetch } from '@wpmedia/signing-service-content-source-block'
 
 const options = {
   headers: {

--- a/blocks/feeds-source-content-api-by-day2-block/sources/feeds-content-api-by-day2.js
+++ b/blocks/feeds-source-content-api-by-day2-block/sources/feeds-content-api-by-day2.js
@@ -9,7 +9,7 @@ import {
 } from 'fusion:environment'
 import getProperties from 'fusion:properties'
 
-import signImagesInANSObject from '@wpmedia/arc-themes-components/src/utils/sign-images-in-ans-object'
+import { signImagesInANSObject } from '@wpmedia/feeds-resizer'
 import {
   defaultANSFields,
   formatSections,

--- a/blocks/feeds-source-content-api-by-day2-block/sources/feeds-content-api-by-day2.js
+++ b/blocks/feeds-source-content-api-by-day2-block/sources/feeds-content-api-by-day2.js
@@ -201,6 +201,7 @@ const fetch = async (key, { cachedCall }) => {
           RESIZER_TOKEN_VERSION,
         )(result)
       })
+      .then(({data, ...rest}) => ({ ...rest, data: transform(data, key), }))
       .then(({ data }) => data)
       .catch((error) => console.log('== error ==', error))
 
@@ -219,7 +220,6 @@ const fetch = async (key, { cachedCall }) => {
 export default {
   fetch,
   schemaName: 'feeds',
-  transform,
   params: [
     {
       name: 'dateField',

--- a/blocks/feeds-source-content-api-by-day2-block/sources/feeds-content-api-by-day2.js
+++ b/blocks/feeds-source-content-api-by-day2-block/sources/feeds-content-api-by-day2.js
@@ -9,7 +9,7 @@ import {
 } from 'fusion:environment'
 import getProperties from 'fusion:properties'
 
-import { signImagesInANSObject } from '@wpmedia/feeds-resizer'
+import { signImagesInANSObject, resizerFetch } from '@wpmedia/feeds-resizer'
 import {
   defaultANSFields,
   formatSections,
@@ -17,7 +17,6 @@ import {
   transform,
   validANSDates,
 } from '@wpmedia/feeds-content-source-utils'
-import { fetch as resizerFetch } from '@wpmedia/signing-service-content-source-block'
 
 const options = {
   headers: {

--- a/blocks/feeds-source-content-api-by-day3-block/sources/feeds-content-api-by-day3.js
+++ b/blocks/feeds-source-content-api-by-day3-block/sources/feeds-content-api-by-day3.js
@@ -9,7 +9,7 @@ import {
 } from 'fusion:environment'
 import getProperties from 'fusion:properties'
 
-import signImagesInANSObject from '@wpmedia/arc-themes-components/src/utils/sign-images-in-ans-object'
+import { signImagesInANSObject } from '@wpmedia/feeds-resizer'
 import {
   defaultANSFields,
   formatSections,

--- a/blocks/feeds-source-content-api-by-day3-block/sources/feeds-content-api-by-day3.js
+++ b/blocks/feeds-source-content-api-by-day3-block/sources/feeds-content-api-by-day3.js
@@ -201,6 +201,7 @@ const fetch = async (key, { cachedCall }) => {
           RESIZER_TOKEN_VERSION,
         )(result)
       })
+      .then(({data, ...rest}) => ({ ...rest, data: transform(data, key), }))
       .then(({ data }) => data)
       .catch((error) => console.log('== error ==', error))
 
@@ -219,7 +220,6 @@ const fetch = async (key, { cachedCall }) => {
 export default {
   fetch,
   schemaName: 'feeds',
-  transform,
   params: [
     {
       name: 'dateField',

--- a/blocks/feeds-source-content-api-by-day3-block/sources/feeds-content-api-by-day3.js
+++ b/blocks/feeds-source-content-api-by-day3-block/sources/feeds-content-api-by-day3.js
@@ -9,7 +9,7 @@ import {
 } from 'fusion:environment'
 import getProperties from 'fusion:properties'
 
-import { signImagesInANSObject } from '@wpmedia/feeds-resizer'
+import { signImagesInANSObject, resizerFetch } from '@wpmedia/feeds-resizer'
 import {
   defaultANSFields,
   formatSections,
@@ -17,7 +17,6 @@ import {
   transform,
   validANSDates,
 } from '@wpmedia/feeds-content-source-utils'
-import { fetch as resizerFetch } from '@wpmedia/signing-service-content-source-block'
 
 const options = {
   headers: {

--- a/blocks/feeds-source-single-content-block/sources/single-content.js
+++ b/blocks/feeds-source-single-content-block/sources/single-content.js
@@ -7,8 +7,7 @@ import {
   resizerKey,
 } from 'fusion:environment'
 
-import { signImagesInANSObject } from '@wpmedia/feeds-resizer'
-import { fetch as resizerFetch } from '@wpmedia/signing-service-content-source-block'
+import { signImagesInANSObject, resizerFetch } from '@wpmedia/feeds-resizer'
 
 const params = {
   _id: 'text',

--- a/blocks/feeds-source-single-content-block/sources/single-content.js
+++ b/blocks/feeds-source-single-content-block/sources/single-content.js
@@ -7,7 +7,7 @@ import {
   resizerKey,
 } from 'fusion:environment'
 
-import signImagesInANSObject from '@wpmedia/arc-themes-components/src/utils/sign-images-in-ans-object'
+import { signImagesInANSObject } from '@wpmedia/feeds-resizer'
 import { fetch as resizerFetch } from '@wpmedia/signing-service-content-source-block'
 
 const params = {

--- a/blocks/feeds-source-video-api-block/sources/feeds-video-api.js
+++ b/blocks/feeds-source-video-api-block/sources/feeds-video-api.js
@@ -10,7 +10,7 @@ import {
   resizerKey,
 } from 'fusion:environment'
 
-import signImagesInANSObject from '@wpmedia/arc-themes-components/src/utils/sign-images-in-ans-object'
+import { signImagesInANSObject } from '@wpmedia/feeds-resizer'
 import { fetch as resizerFetch } from '@wpmedia/signing-service-content-source-block'
 
 const params = {

--- a/blocks/feeds-source-video-api-block/sources/feeds-video-api.js
+++ b/blocks/feeds-source-video-api-block/sources/feeds-video-api.js
@@ -10,8 +10,7 @@ import {
   resizerKey,
 } from 'fusion:environment'
 
-import { signImagesInANSObject } from '@wpmedia/feeds-resizer'
-import { fetch as resizerFetch } from '@wpmedia/signing-service-content-source-block'
+import { signImagesInANSObject, resizerFetch } from '@wpmedia/feeds-resizer'
 
 const params = {
   Uuids: 'text',

--- a/blocks/feeds-source-video-api-block/sources/feeds-video-api.test.js
+++ b/blocks/feeds-source-video-api-block/sources/feeds-video-api.test.js
@@ -1,26 +1,56 @@
+import axios from 'axios';
 // eslint-disable-next-line no-unused-vars
 import Consumer from 'fusion:consumer'
-const resolver = require('./feeds-video-api')
+const source = require('./feeds-video-api')
+
+// Mock Axios
+jest.mock('axios');
+
+beforeEach(() => {
+  // Reset Axios mocks before each test
+  axios.mockClear();
+});
+
 it('validate schemaName', () => {
-  expect(resolver.default.schemaName).toBe('feeds')
+  expect(source.default.schemaName).toBe('feeds')
 })
 
-it('returns query with default values', () => {
-  const query1 = resolver.default.resolve({
+it('returns query with default values', async () => {
+  const mockData = { data: 'response' };
+  axios.mockResolvedValue(mockData);
+  
+  await source.default.fetch({
     Uuids:
       'db9862d6-be50-11e7-9294-705f80164f6e,4594b2c0-6cc1-11e7-abbc-a53480672286',
-  })
-  expect(query1).toBe(
+  }, { cachedCall: {} });
+  
+  expect(axios).toHaveBeenCalledTimes(1);
+  expect(axios).toHaveBeenCalledWith({
+    url: expect.stringContaining(`/api/v1/ansvideos/findByUuids`), // Check base URL
+    method: 'GET',
+    headers: expect.objectContaining({
+      'content-type': 'application/json',
+      Authorization: expect.stringContaining('Bearer '),
+    }),
+  });
+
+  const callUrl = axios.mock.calls[0][0].url;
+  expect(callUrl).toBe(
     'undefined/api/v1/ansvideos/findByUuids?uuids=db9862d6-be50-11e7-9294-705f80164f6e&uuids=4594b2c0-6cc1-11e7-abbc-a53480672286',
   )
 })
 
-it('returns query with default values', () => {
-  const query2 = resolver.default.resolve({
+it('returns query with default values', async () => {
+  const mockData = { data: 'response' };
+  axios.mockResolvedValue(mockData);
+  
+  await source.default.fetch({
     Playlist: 'playlist5',
     Count: '10',
-  })
-  expect(query2).toBe(
+  }, { cachedCall: {} });
+  
+  const callUrl = axios.mock.calls[0][0].url;
+  expect(callUrl).toBe(
     'undefined/api/v1/ans/playlists/findByPlaylist?name=playlist5&count=10',
   )
 })

--- a/blocks/mrss-feature-block/features/mrss/__snapshots__/xml.test.js.snap
+++ b/blocks/mrss-feature-block/features/mrss/__snapshots__/xml.test.js.snap
@@ -1,23 +1,23 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`returns MRSS template with default values 1`] = `
-Object {
-  "rss": Object {
+{
+  "rss": {
     "@version": "2.0",
     "@xmlns:atom": "http://www.w3.org/2005/Atom",
     "@xmlns:media": "http://search.yahoo.com/mrss/",
-    "channel": Object {
-      "atom:link": Object {
+    "channel": {
+      "atom:link": {
         "@href": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/mrss/",
         "@rel": "self",
         "@type": "application/rss+xml",
       },
       "description": "google news",
-      "item": Array [
-        Object {
-          "#": Array [
-            Object {
-              "media:content": Object {
+      "item": [
+        {
+          "#": [
+            {
+              "media:content": {
                 "@bitrate": 2000,
                 "@duration": 789,
                 "@fileSize": 3368020,
@@ -28,26 +28,26 @@ Object {
                 "@width": 1280,
                 "media:category": "Video",
                 "media:keywords": "sample,demo",
-                "media:thumbnail": Object {
+                "media:thumbnail": {
                   "@url": "hi/abcdefghijklmnopqrstuvwxyz=/dv8csq7v0ltdn.cloudfront.net/04-16-2020/t_95d8de29ea3b41caac132f0462c5c71a_name_file_1920x1080_5400_v4_.jpg",
                 },
-                "media:title": Object {
+                "media:title": {
                   "$": "Inexact Odyssey, A Volcom Snowboarding Film",
                 },
               },
             },
           ],
-          "description": Object {
+          "description": {
             "$": "",
           },
-          "guid": Object {
+          "guid": {
             "#": "http://demo-prod.origin.arcpublishing.com/video/2020/04/16/inexact-odyssey-a-volcom-snowboarding-film/",
             "@isPermaLink": false,
           },
           "link": "http://demo-prod.origin.arcpublishing.com/video/2020/04/16/inexact-odyssey-a-volcom-snowboarding-film/",
           "pubDate": "Thu, 16 Apr 2020 19:55:25 +0000",
           "referenceid": undefined,
-          "title": Object {
+          "title": {
             "$": "Inexact Odyssey, A Volcom Snowboarding Film",
           },
         },
@@ -62,23 +62,23 @@ Object {
 `;
 
 exports[`returns MRSS template without values 1`] = `
-Object {
-  "rss": Object {
+{
+  "rss": {
     "@version": "2.0",
     "@xmlns:atom": "http://www.w3.org/2005/Atom",
     "@xmlns:media": "http://search.yahoo.com/mrss/",
-    "channel": Object {
-      "atom:link": Object {
+    "channel": {
+      "atom:link": {
         "@href": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/mrss/",
         "@rel": "self",
         "@type": "application/rss+xml",
       },
       "description": "google news",
-      "item": Array [
-        Object {
-          "#": Array [
-            Object {
-              "media:content": Object {
+      "item": [
+        {
+          "#": [
+            {
+              "media:content": {
                 "@bitrate": 2000,
                 "@duration": 789,
                 "@fileSize": 3368020,
@@ -89,16 +89,16 @@ Object {
                 "@width": 1280,
                 "media:category": "Video",
                 "media:keywords": "sample,demo",
-                "media:thumbnail": Object {
+                "media:thumbnail": {
                   "@url": "hi/abcdefghijklmnopqrstuvwxyz=/dv8csq7v0ltdn.cloudfront.net/04-16-2020/t_95d8de29ea3b41caac132f0462c5c71a_name_file_1920x1080_5400_v4_.jpg",
                 },
-                "media:title": Object {
+                "media:title": {
                   "$": "Inexact Odyssey, A Volcom Snowboarding Film",
                 },
               },
             },
           ],
-          "guid": Object {
+          "guid": {
             "#": "http://demo-prod.origin.arcpublishing.com/video/2020/04/16/inexact-odyssey-a-volcom-snowboarding-film/",
             "@isPermaLink": false,
           },

--- a/blocks/rss-alexa-feature-block/features/rss/__snapshots__/xml.test.js.snap
+++ b/blocks/rss-alexa-feature-block/features/rss/__snapshots__/xml.test.js.snap
@@ -1,23 +1,23 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`returns Alexa template with custom values 1`] = `
-Object {
-  "rss": Object {
+{
+  "rss": {
     "@version": "2.0",
-    "channel": Object {
+    "channel": {
       "category": "news",
       "copyright": "2020 The Washington Post LLC",
       "description": "All the news that's fit to print",
-      "image": Object {
+      "image": {
         "link": "http://demo-prod.origin.arcpublishing.com",
         "title": "The Daily Prophet",
         "url": "hi/abcdefghijklmnopqrstuvwxyz=/arc-anglerfish-arc2-prod-demo.s3.amazonaws.com/public/JTWX7EUOLJE4FCHYGN2COQAERY.png",
       },
-      "item": Array [
-        Object {
+      "item": [
+        {
           "category": "coronvirus",
           "description": "try singing the happy birthday songbe sure to wash your thumbs",
-          "enclosure": Object {
+          "enclosure": {
             "@type": "audio/mp3",
             "@url": "https://clark.com/wp-content/uploads/2021/01/Ask-Clark_GameStop_2021.mp3?_=4",
           },
@@ -26,7 +26,7 @@ Object {
           "pubDate": "2020-04-07T15:02:08.918Z",
           "title": "Tips for Safe Hand washing",
         },
-        Object {
+        {
           "description": "",
           "guid": "ABCD",
           "link": "http://demo-prod.origin.arcpublishing.com",
@@ -45,14 +45,14 @@ Object {
 `;
 
 exports[`returns Alexa template with default values 1`] = `
-Object {
-  "rss": Object {
+{
+  "rss": {
     "@version": "2.0",
-    "channel": Object {
-      "item": Array [
-        Object {
+    "channel": {
+      "item": [
+        {
           "description": "",
-          "enclosure": Object {
+          "enclosure": {
             "@type": "audio/mp3",
             "@url": "https://clark.com/wp-content/uploads/2021/01/Ask-Clark_GameStop_2021.mp3?_=4",
           },
@@ -61,7 +61,7 @@ Object {
           "pubDate": "2020-04-07T15:02:08.918Z",
           "title": "Tips for Safe Hand washing",
         },
-        Object {
+        {
           "description": "",
           "guid": "ABCD",
           "link": "http://demo-prod.origin.arcpublishing.com",
@@ -79,18 +79,18 @@ Object {
 `;
 
 exports[`returns Alexa template with empty values 1`] = `
-Object {
-  "rss": Object {
+{
+  "rss": {
     "@version": "2.0",
-    "channel": Object {
-      "item": Array [
-        Object {
+    "channel": {
+      "item": [
+        {
           "description": "try singing the happy birthday songbe sure to wash your thumbs",
           "guid": undefined,
           "link": "http://demo-prod.origin.arcpublishing.com/food/2020/04/07/tips-for-safe-hand-washing",
           "pubDate": "2020-04-07T15:02:08.918Z",
         },
-        Object {
+        {
           "description": "",
           "guid": "ABCD",
           "link": "http://demo-prod.origin.arcpublishing.com",

--- a/blocks/rss-fbia-feature-block/features/rss/__snapshots__/xml.test.js.snap
+++ b/blocks/rss-fbia-feature-block/features/rss/__snapshots__/xml.test.js.snap
@@ -1,87 +1,87 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`returns FB-IA template with custom values 1`] = `
-Object {
-  "rss": Object {
+{
+  "rss": {
     "@version": "2.0",
     "@xmlns:atom": "http://www.w3.org/2005/Atom",
     "@xmlns:content": "http://purl.org/rss/1.0/modules/content/",
     "@xmlns:dc": "http://purl.org/dc/elements/1.1/",
     "@xmlns:media": "http://search.yahoo.com/mrss/",
     "@xmlns:sy": "http://purl.org/rss/1.0/modules/syndication/",
-    "channel": Object {
-      "atom:link": Object {
+    "channel": {
+      "atom:link": {
         "@href": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/fb-ia/",
         "@rel": "self",
         "@type": "application/rss+xml",
       },
       "category": "News",
       "copyright": "Copyright 2021",
-      "description": Object {
+      "description": {
         "$": "Only the best for FB",
       },
-      "image": Object {
+      "image": {
         "link": "http://demo-prod.origin.arcpublishing.com",
         "title": "Facebook Instant Articles Feed",
         "url": "hi/abcdefghijklmnopqrstuvwxyz=/example.com/logo.png",
       },
-      "item": Array [
-        Object {
-          "#": Array [
-            Object {
-              "media:content": Object {
+      "item": [
+        {
+          "#": [
+            {
+              "media:content": {
                 "@type": "image/png",
                 "@url": "hi/abcdefghijklmnopqrstuvwxyz=/arc-anglerfish-arc2-prod-demo.s3.amazonaws.com/public/JTWX7EUOLJE4FCHYGN2COQAERY.png",
-                "media:credit": Object {
+                "media:credit": {
                   "#": "Harold Hands",
                   "@role": "author",
                   "@scheme": "urn:ebu",
                 },
-                "media:description": Object {
+                "media:description": {
                   "$": "Hand washing can be fun if you make it a song",
                   "@type": "plain",
                 },
-                "media:title": Object {
+                "media:title": {
                   "$": "Hand Washing",
                 },
               },
             },
           ],
-          "content:encoded": Object {
-            "$": "<!doctype html><html lang=\\"en\\"><head><link rel=\\"canonical\\" href=\\"http://demo-prod.origin.arcpublishing.com/food/2020/04/07/tips-for-safe-hand-washing\\"/><title>Tips for Safe Hand washing</title><meta property=\\"og:title\\" content=\\"Tips for Safe Hand washing\\"/><meta property=\\"og:url\\" content=\\"http://demo-prod.origin.arcpublishing.com/food/2020/04/07/tips-for-safe-hand-washing\\"/><meta property=\\"og:description\\" content=\\"This is from the subheadlines\\"/><meta property=\\"fb:use_automatic_ad_placement\\" content=\\"enable=true ad_density=low\\"/><meta property=\\"op:markup_version\\" content=\\"v1.0\\"/><meta property=\\"fb:article_style\\" content=\\"times-bold\\"/><meta property=\\"og:image\\" content=\\"hi/abcdefghijklmnopqrstuvwxyz=/arc-anglerfish-arc2-prod-demo.s3.amazonaws.com/public/JTWX7EUOLJE4FCHYGN2COQAERY.png\\"/><meta property=\\"fb:likes_and_comments\\" content=\\"enable\\"/><meta property=\\"something\\" content=\\"other thing\\"/></head><body><article><header><section class=\\"op-ad-template\\"><script>myscript()</script></section><h1>Tips for Safe Hand washing</h1><h2>This is from the subheadlines</h2><time datetime=\\"2020-04-08T10:34:41.432Z\\" class=\\"op-modified\\">2020-04-08T10:34:41.432Z</time><time datetime=\\"2020-04-08T10:34:41.432Z\\" class=\\"op-published\\">2020-04-08T10:34:41.432Z</time><address><a>JOHN-SMITH</a><a>JANE-DOE</a></address><figure class=\\"fb-feed-cover\\"><img src=\\"hi/abcdefghijklmnopqrstuvwxyz=/arc-anglerfish-arc2-prod-demo.s3.amazonaws.com/public/JTWX7EUOLJE4FCHYGN2COQAERY.png\\"/><figcaption class=\\"op-vertical-below op-small\\">Hand washing can be fun if you make it a song<cite class=\\"op-small\\">Harold Hands</cite></figcaption></figure><h2 class=\\"op-kicker\\">coronvirus</h2></header><p id=\\"AAAAA\\">try singing the happy birthday song<br></p><p id=\\"BBBBB\\">be sure to <i>wash</i> your thumbs</p><figure class=\\"op-interactive\\"><iframe width=\\"560\\"><div style=\\"background:#ffffff; color: #333; margin:100px 0 1rem 0; line-height:28px; font-family: 'Merriweather', serif;\\"><img style=\\"height:120px; width: 120px; float: left; margin-right: 20px;\\" src=\\"https://www.example.com.mx/graficos/img/novedad-180321.jpg\\" class=\\"img-responsive\\" alt=\\"logo\\" /><img style=\\"height:120px; width: 120px; float: right; \\" src=\\"https://example.com.mx/graficos/interior-nota/abcd_novedad.png\\" class=\\"img-responsive\\" alt=\\"logo\\" /><span style=\\"font-size: 1.1rem; font-weight: 700;\\"> Concertos for Oboe, Clarinet and Orchestra </span><hr style=\\"border: 0;  height: 1px;   background-image: -webkit-linear-gradient(left, #666666, #ffffff);  background-image: -moz-linear-gradient(left, #666666, #ffffff);  background-image: -ms-linear-gradient(left, #666666, #ffffff);  background-image: -o-linear-gradient(left,  #666666, #ffffff); padding: 0; margin: 0;\\"/><span style=\\"font-size: .9rem\\">ARTISTA: Camerata de las Américas, dirigida por Ludwig Carrasco </span><br><span style=\\"font-size: .9rem\\">SELLO:   Urtext </span><br><span style=\\"font-size: .9rem\\">PRECIO:   $168n </span></div></iframe></figure><figure class=\\"op-interactive\\"><iframe width=\\"560\\"><blockquote class=\\"twitter-tweet\\"><p lang=\\"fr\\" dir=\\"ltr\\">21. Je déploie le robot pour reconnaitre OSCAR3.<br>Retour en images sur l’exercice de recherche appliquée organisé les 30 et 31 mars par l’EMIA et le centre de recherche. Robotisation du champ de bataille : sensibiliser les élèves aux enjeux de demain. <a href=\\"https://twitter.com/hashtag/CapaciTERRE?src=hash&amp;ref_src=twsrc%5Etfw\\">#CapaciTERRE</a> <a href=\\"https://twitter.com/hashtag/Robots?src=hash&amp;ref_src=twsrc%5Etfw\\">#Robots</a> <a href=\\"https://t.co/HiZ2BFOZPY\\">pic.twitter.com/HiZ2BFOZPY</a></p>&mdash; Saint-Cyr Coëtquidan (@SaintCyrCoet) <a href=\\"https://twitter.com/SaintCyrCoet/status/1379457690020294665?ref_src=twsrc%5Etfw\\">April 6, 2021</a></blockquote>
-<script async src=\\"https://platform.twitter.com/widgets.js\\" charset=\\"utf-8\\"></script>
-</iframe></figure><figure><table><thead><tr><th>Description</th><th>Amount</th></tr></thead><tbody><tr><td>apples</td><td>$0.25</td></tr><tr><td>pears</td><td>$0.50</td></tr><tr><td>oranges</td><td>$0.70</td></tr></tbody></table></figure><figure class=\\"op-tracker\\"><iframe><script>alert(\\"hi\\");</script></iframe></figure><footer><aside>John is a journalist</aside><small>Copyright 2021</small></footer></article></body></html>",
+          "content:encoded": {
+            "$": "<!doctype html><html lang="en"><head><link rel="canonical" href="http://demo-prod.origin.arcpublishing.com/food/2020/04/07/tips-for-safe-hand-washing"/><title>Tips for Safe Hand washing</title><meta property="og:title" content="Tips for Safe Hand washing"/><meta property="og:url" content="http://demo-prod.origin.arcpublishing.com/food/2020/04/07/tips-for-safe-hand-washing"/><meta property="og:description" content="This is from the subheadlines"/><meta property="fb:use_automatic_ad_placement" content="enable=true ad_density=low"/><meta property="op:markup_version" content="v1.0"/><meta property="fb:article_style" content="times-bold"/><meta property="og:image" content="hi/abcdefghijklmnopqrstuvwxyz=/arc-anglerfish-arc2-prod-demo.s3.amazonaws.com/public/JTWX7EUOLJE4FCHYGN2COQAERY.png"/><meta property="fb:likes_and_comments" content="enable"/><meta property="something" content="other thing"/></head><body><article><header><section class="op-ad-template"><script>myscript()</script></section><h1>Tips for Safe Hand washing</h1><h2>This is from the subheadlines</h2><time datetime="2020-04-08T10:34:41.432Z" class="op-modified">2020-04-08T10:34:41.432Z</time><time datetime="2020-04-08T10:34:41.432Z" class="op-published">2020-04-08T10:34:41.432Z</time><address><a>JOHN-SMITH</a><a>JANE-DOE</a></address><figure class="fb-feed-cover"><img src="hi/abcdefghijklmnopqrstuvwxyz=/arc-anglerfish-arc2-prod-demo.s3.amazonaws.com/public/JTWX7EUOLJE4FCHYGN2COQAERY.png"/><figcaption class="op-vertical-below op-small">Hand washing can be fun if you make it a song<cite class="op-small">Harold Hands</cite></figcaption></figure><h2 class="op-kicker">coronvirus</h2></header><p id="AAAAA">try singing the happy birthday song<br></p><p id="BBBBB">be sure to <i>wash</i> your thumbs</p><figure class="op-interactive"><iframe width="560"><div style="background:#ffffff; color: #333; margin:100px 0 1rem 0; line-height:28px; font-family: 'Merriweather', serif;"><img style="height:120px; width: 120px; float: left; margin-right: 20px;" src="https://www.example.com.mx/graficos/img/novedad-180321.jpg" class="img-responsive" alt="logo" /><img style="height:120px; width: 120px; float: right; " src="https://example.com.mx/graficos/interior-nota/abcd_novedad.png" class="img-responsive" alt="logo" /><span style="font-size: 1.1rem; font-weight: 700;"> Concertos for Oboe, Clarinet and Orchestra </span><hr style="border: 0;  height: 1px;   background-image: -webkit-linear-gradient(left, #666666, #ffffff);  background-image: -moz-linear-gradient(left, #666666, #ffffff);  background-image: -ms-linear-gradient(left, #666666, #ffffff);  background-image: -o-linear-gradient(left,  #666666, #ffffff); padding: 0; margin: 0;"/><span style="font-size: .9rem">ARTISTA: Camerata de las Américas, dirigida por Ludwig Carrasco </span><br><span style="font-size: .9rem">SELLO:   Urtext </span><br><span style="font-size: .9rem">PRECIO:   $168n </span></div></iframe></figure><figure class="op-interactive"><iframe width="560"><blockquote class="twitter-tweet"><p lang="fr" dir="ltr">21. Je déploie le robot pour reconnaitre OSCAR3.<br>Retour en images sur l’exercice de recherche appliquée organisé les 30 et 31 mars par l’EMIA et le centre de recherche. Robotisation du champ de bataille : sensibiliser les élèves aux enjeux de demain. <a href="https://twitter.com/hashtag/CapaciTERRE?src=hash&amp;ref_src=twsrc%5Etfw">#CapaciTERRE</a> <a href="https://twitter.com/hashtag/Robots?src=hash&amp;ref_src=twsrc%5Etfw">#Robots</a> <a href="https://t.co/HiZ2BFOZPY">pic.twitter.com/HiZ2BFOZPY</a></p>&mdash; Saint-Cyr Coëtquidan (@SaintCyrCoet) <a href="https://twitter.com/SaintCyrCoet/status/1379457690020294665?ref_src=twsrc%5Etfw">April 6, 2021</a></blockquote>
+<script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+</iframe></figure><figure><table><thead><tr><th>Description</th><th>Amount</th></tr></thead><tbody><tr><td>apples</td><td>$0.25</td></tr><tr><td>pears</td><td>$0.50</td></tr><tr><td>oranges</td><td>$0.70</td></tr></tbody></table></figure><figure class="op-tracker"><iframe><script>alert("hi");</script></iframe></figure><footer><aside>John is a journalist</aside><small>Copyright 2021</small></footer></article></body></html>",
           },
-          "dc:creator": Object {
+          "dc:creator": {
             "$": "john-smith, jane-doe",
           },
-          "description": Object {
+          "description": {
             "$": "This is from the subheadlines",
           },
-          "guid": Object {
+          "guid": {
             "#": "http://demo-prod.origin.arcpublishing.com/food/2020/04/07/tips-for-safe-hand-washing",
             "@isPermaLink": true,
           },
           "link": "http://demo-prod.origin.arcpublishing.com/food/2020/04/07/tips-for-safe-hand-washing",
           "pubDate": "Wed, 08 Apr 2020 10:34:41 +0000",
-          "title": Object {
+          "title": {
             "$": "Tips for Safe Hand washing",
           },
         },
-        Object {
-          "content:encoded": Object {
-            "$": "<!doctype html><html lang=\\"en\\"><head><link rel=\\"canonical\\" href=\\"http://demo-prod.origin.arcpublishing.com/food/empty-recipe\\"/><title>I'm out of ideas</title><meta property=\\"og:title\\" content=\\"I'm out of ideas\\"/><meta property=\\"og:url\\" content=\\"http://demo-prod.origin.arcpublishing.com/food/empty-recipe\\"/><meta property=\\"og:description\\" content=\\"\\"/><meta property=\\"fb:use_automatic_ad_placement\\" content=\\"enable=true ad_density=low\\"/><meta property=\\"op:markup_version\\" content=\\"v1.0\\"/><meta property=\\"fb:article_style\\" content=\\"times-bold\\"/><meta property=\\"og:image\\" content=\\"\\"/><meta property=\\"fb:likes_and_comments\\" content=\\"enable\\"/><meta property=\\"something\\" content=\\"other thing\\"/></head><body><article><header><section class=\\"op-ad-template\\"><script>myscript()</script></section><h1>I'm out of ideas</h1><time datetime=\\"2021-04-08T10:34:41.432Z\\" class=\\"op-modified\\">2021-04-08T10:34:41.432Z</time><time datetime=\\"2021-04-08T10:34:41.432Z\\" class=\\"op-published\\">2021-04-08T10:34:41.432Z</time></header><figure class=\\"op-tracker\\"><iframe><script>alert(\\"hi\\");</script></iframe></figure><footer><small>Copyright 2021</small></footer></article></body></html>",
+        {
+          "content:encoded": {
+            "$": "<!doctype html><html lang="en"><head><link rel="canonical" href="http://demo-prod.origin.arcpublishing.com/food/empty-recipe"/><title>I'm out of ideas</title><meta property="og:title" content="I'm out of ideas"/><meta property="og:url" content="http://demo-prod.origin.arcpublishing.com/food/empty-recipe"/><meta property="og:description" content=""/><meta property="fb:use_automatic_ad_placement" content="enable=true ad_density=low"/><meta property="op:markup_version" content="v1.0"/><meta property="fb:article_style" content="times-bold"/><meta property="og:image" content=""/><meta property="fb:likes_and_comments" content="enable"/><meta property="something" content="other thing"/></head><body><article><header><section class="op-ad-template"><script>myscript()</script></section><h1>I'm out of ideas</h1><time datetime="2021-04-08T10:34:41.432Z" class="op-modified">2021-04-08T10:34:41.432Z</time><time datetime="2021-04-08T10:34:41.432Z" class="op-published">2021-04-08T10:34:41.432Z</time></header><figure class="op-tracker"><iframe><script>alert("hi");</script></iframe></figure><footer><small>Copyright 2021</small></footer></article></body></html>",
           },
-          "description": Object {
+          "description": {
             "$": "",
           },
-          "guid": Object {
+          "guid": {
             "#": "http://demo-prod.origin.arcpublishing.com/food/empty-recipe",
             "@isPermaLink": true,
           },
           "link": "http://demo-prod.origin.arcpublishing.com/food/empty-recipe",
           "pubDate": "Thu, 08 Apr 2021 10:34:41 +0000",
-          "title": Object {
+          "title": {
             "$": "I'm out of ideas",
           },
         },
@@ -91,7 +91,7 @@ Object {
       "link": "http://demo-prod.origin.arcpublishing.com",
       "sy:updateFrequency": "4",
       "sy:updatePeriod": "weekly",
-      "title": Object {
+      "title": {
         "$": "Facebook Instant Articles Feed",
       },
       "ttl": "5",
@@ -101,80 +101,80 @@ Object {
 `;
 
 exports[`returns FB-IA template with default values 1`] = `
-Object {
-  "rss": Object {
+{
+  "rss": {
     "@version": "2.0",
     "@xmlns:atom": "http://www.w3.org/2005/Atom",
     "@xmlns:content": "http://purl.org/rss/1.0/modules/content/",
     "@xmlns:dc": "http://purl.org/dc/elements/1.1/",
     "@xmlns:media": "http://search.yahoo.com/mrss/",
     "@xmlns:sy": "http://purl.org/rss/1.0/modules/syndication/",
-    "channel": Object {
-      "atom:link": Object {
+    "channel": {
+      "atom:link": {
         "@href": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/fb-ia/",
         "@rel": "self",
         "@type": "application/rss+xml",
       },
-      "description": Object {
+      "description": {
         "$": "google news News Feed",
       },
-      "item": Array [
-        Object {
-          "#": Array [
-            Object {
-              "media:content": Object {
+      "item": [
+        {
+          "#": [
+            {
+              "media:content": {
                 "@type": "image/png",
                 "@url": "hi/abcdefghijklmnopqrstuvwxyz=/arc-anglerfish-arc2-prod-demo.s3.amazonaws.com/public/JTWX7EUOLJE4FCHYGN2COQAERY.png",
-                "media:credit": Object {
+                "media:credit": {
                   "#": "Harold Hands",
                   "@role": "author",
                   "@scheme": "urn:ebu",
                 },
-                "media:description": Object {
+                "media:description": {
                   "$": "Hand washing can be fun if you make it a song",
                   "@type": "plain",
                 },
-                "media:title": Object {
+                "media:title": {
                   "$": "Hand Washing",
                 },
               },
             },
           ],
-          "content:encoded": Object {
-            "$": "<!doctype html><html lang=\\"en\\"><head><link rel=\\"canonical\\" href=\\"http://demo-prod.origin.arcpublishing.com/food/2020/04/07/tips-for-safe-hand-washing\\"/><title>Tips for Safe Hand washing</title><meta property=\\"og:title\\" content=\\"Tips for Safe Hand washing\\"/><meta property=\\"og:url\\" content=\\"http://demo-prod.origin.arcpublishing.com/food/2020/04/07/tips-for-safe-hand-washing\\"/><meta property=\\"og:description\\" content=\\"Tips to keep you wash for 20 seconds\\"/><meta property=\\"fb:use_automatic_ad_placement\\" content=\\"enable=false\\"/><meta property=\\"op:markup_version\\" content=\\"v1.0\\"/><meta property=\\"fb:article_style\\" content=\\"default\\"/><meta property=\\"og:image\\" content=\\"hi/abcdefghijklmnopqrstuvwxyz=/arc-anglerfish-arc2-prod-demo.s3.amazonaws.com/public/JTWX7EUOLJE4FCHYGN2COQAERY.png\\"/><meta property=\\"fb:likes_and_comments\\" content=\\"disable\\"/></head><body><article><header><h1>Tips for Safe Hand washing</h1><h2>Tips to keep you wash for 20 seconds</h2><time datetime=\\"2020-04-08T10:34:41.432Z\\" class=\\"op-modified\\">2020-04-08T10:34:41.432Z</time><time datetime=\\"2020-04-07T15:02:08.918Z\\" class=\\"op-published\\">2020-04-07T15:02:08.918Z</time><address><a>JOHN SMITH</a><a>JANE DOE</a></address><figure class=\\"fb-feed-cover\\"><img src=\\"hi/abcdefghijklmnopqrstuvwxyz=/arc-anglerfish-arc2-prod-demo.s3.amazonaws.com/public/JTWX7EUOLJE4FCHYGN2COQAERY.png\\"/><figcaption class=\\"op-vertical-below op-small\\">Hand washing can be fun if you make it a song<cite class=\\"op-small\\">Harold Hands</cite></figcaption></figure><h2 class=\\"op-kicker\\">coronvirus</h2></header><p id=\\"AAAAA\\">try singing the happy birthday song<br></p><p id=\\"BBBBB\\">be sure to <i>wash</i> your thumbs</p><figure class=\\"op-interactive\\"><iframe><blockquote class=\\"twitter-tweet\\"><p lang=\\"fr\\" dir=\\"ltr\\">21. Je déploie le robot pour reconnaitre OSCAR3.<br>Retour en images sur l’exercice de recherche appliquée organisé les 30 et 31 mars par l’EMIA et le centre de recherche. Robotisation du champ de bataille : sensibiliser les élèves aux enjeux de demain. <a href=\\"https://twitter.com/hashtag/CapaciTERRE?src=hash&amp;ref_src=twsrc%5Etfw\\">#CapaciTERRE</a> <a href=\\"https://twitter.com/hashtag/Robots?src=hash&amp;ref_src=twsrc%5Etfw\\">#Robots</a> <a href=\\"https://t.co/HiZ2BFOZPY\\">pic.twitter.com/HiZ2BFOZPY</a></p>&mdash; Saint-Cyr Coëtquidan (@SaintCyrCoet) <a href=\\"https://twitter.com/SaintCyrCoet/status/1379457690020294665?ref_src=twsrc%5Etfw\\">April 6, 2021</a></blockquote>
-<script async src=\\"https://platform.twitter.com/widgets.js\\" charset=\\"utf-8\\"></script>
+          "content:encoded": {
+            "$": "<!doctype html><html lang="en"><head><link rel="canonical" href="http://demo-prod.origin.arcpublishing.com/food/2020/04/07/tips-for-safe-hand-washing"/><title>Tips for Safe Hand washing</title><meta property="og:title" content="Tips for Safe Hand washing"/><meta property="og:url" content="http://demo-prod.origin.arcpublishing.com/food/2020/04/07/tips-for-safe-hand-washing"/><meta property="og:description" content="Tips to keep you wash for 20 seconds"/><meta property="fb:use_automatic_ad_placement" content="enable=false"/><meta property="op:markup_version" content="v1.0"/><meta property="fb:article_style" content="default"/><meta property="og:image" content="hi/abcdefghijklmnopqrstuvwxyz=/arc-anglerfish-arc2-prod-demo.s3.amazonaws.com/public/JTWX7EUOLJE4FCHYGN2COQAERY.png"/><meta property="fb:likes_and_comments" content="disable"/></head><body><article><header><h1>Tips for Safe Hand washing</h1><h2>Tips to keep you wash for 20 seconds</h2><time datetime="2020-04-08T10:34:41.432Z" class="op-modified">2020-04-08T10:34:41.432Z</time><time datetime="2020-04-07T15:02:08.918Z" class="op-published">2020-04-07T15:02:08.918Z</time><address><a>JOHN SMITH</a><a>JANE DOE</a></address><figure class="fb-feed-cover"><img src="hi/abcdefghijklmnopqrstuvwxyz=/arc-anglerfish-arc2-prod-demo.s3.amazonaws.com/public/JTWX7EUOLJE4FCHYGN2COQAERY.png"/><figcaption class="op-vertical-below op-small">Hand washing can be fun if you make it a song<cite class="op-small">Harold Hands</cite></figcaption></figure><h2 class="op-kicker">coronvirus</h2></header><p id="AAAAA">try singing the happy birthday song<br></p><p id="BBBBB">be sure to <i>wash</i> your thumbs</p><figure class="op-interactive"><iframe><blockquote class="twitter-tweet"><p lang="fr" dir="ltr">21. Je déploie le robot pour reconnaitre OSCAR3.<br>Retour en images sur l’exercice de recherche appliquée organisé les 30 et 31 mars par l’EMIA et le centre de recherche. Robotisation du champ de bataille : sensibiliser les élèves aux enjeux de demain. <a href="https://twitter.com/hashtag/CapaciTERRE?src=hash&amp;ref_src=twsrc%5Etfw">#CapaciTERRE</a> <a href="https://twitter.com/hashtag/Robots?src=hash&amp;ref_src=twsrc%5Etfw">#Robots</a> <a href="https://t.co/HiZ2BFOZPY">pic.twitter.com/HiZ2BFOZPY</a></p>&mdash; Saint-Cyr Coëtquidan (@SaintCyrCoet) <a href="https://twitter.com/SaintCyrCoet/status/1379457690020294665?ref_src=twsrc%5Etfw">April 6, 2021</a></blockquote>
+<script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
 </iframe></figure><figure><table><thead><tr><th>Description</th><th>Amount</th></tr></thead><tbody><tr><td>apples</td><td>$0.25</td></tr><tr><td>pears</td><td>$0.50</td></tr><tr><td>oranges</td><td>$0.70</td></tr></tbody></table></figure><footer><aside>John is a journalist</aside><small>© 2024 google news</small></footer></article></body></html>",
           },
-          "dc:creator": Object {
+          "dc:creator": {
             "$": "John Smith, Jane Doe",
           },
-          "description": Object {
+          "description": {
             "$": "Tips to keep you wash for 20 seconds",
           },
-          "guid": Object {
+          "guid": {
             "#": "http://demo-prod.origin.arcpublishing.com/food/2020/04/07/tips-for-safe-hand-washing",
             "@isPermaLink": true,
           },
           "link": "http://demo-prod.origin.arcpublishing.com/food/2020/04/07/tips-for-safe-hand-washing",
           "pubDate": "Tue, 07 Apr 2020 15:02:08 +0000",
-          "title": Object {
+          "title": {
             "$": "Tips for Safe Hand washing",
           },
         },
-        Object {
-          "content:encoded": Object {
-            "$": "<!doctype html><html lang=\\"en\\"><head><link rel=\\"canonical\\" href=\\"http://demo-prod.origin.arcpublishing.com/food/empty-recipe\\"/><title>I'm out of ideas</title><meta property=\\"og:title\\" content=\\"I'm out of ideas\\"/><meta property=\\"og:url\\" content=\\"http://demo-prod.origin.arcpublishing.com/food/empty-recipe\\"/><meta property=\\"og:description\\" content=\\"\\"/><meta property=\\"fb:use_automatic_ad_placement\\" content=\\"enable=false\\"/><meta property=\\"op:markup_version\\" content=\\"v1.0\\"/><meta property=\\"fb:article_style\\" content=\\"default\\"/><meta property=\\"og:image\\" content=\\"\\"/><meta property=\\"fb:likes_and_comments\\" content=\\"disable\\"/></head><body><article><header><h1>I'm out of ideas</h1><time datetime=\\"2021-04-08T10:34:41.432Z\\" class=\\"op-modified\\">2021-04-08T10:34:41.432Z</time><time datetime=\\"2021-04-07T15:02:08.918Z\\" class=\\"op-published\\">2021-04-07T15:02:08.918Z</time></header><footer><small>© 2024 google news</small></footer></article></body></html>",
+        {
+          "content:encoded": {
+            "$": "<!doctype html><html lang="en"><head><link rel="canonical" href="http://demo-prod.origin.arcpublishing.com/food/empty-recipe"/><title>I'm out of ideas</title><meta property="og:title" content="I'm out of ideas"/><meta property="og:url" content="http://demo-prod.origin.arcpublishing.com/food/empty-recipe"/><meta property="og:description" content=""/><meta property="fb:use_automatic_ad_placement" content="enable=false"/><meta property="op:markup_version" content="v1.0"/><meta property="fb:article_style" content="default"/><meta property="og:image" content=""/><meta property="fb:likes_and_comments" content="disable"/></head><body><article><header><h1>I'm out of ideas</h1><time datetime="2021-04-08T10:34:41.432Z" class="op-modified">2021-04-08T10:34:41.432Z</time><time datetime="2021-04-07T15:02:08.918Z" class="op-published">2021-04-07T15:02:08.918Z</time></header><footer><small>© 2024 google news</small></footer></article></body></html>",
           },
-          "description": Object {
+          "description": {
             "$": "",
           },
-          "guid": Object {
+          "guid": {
             "#": "http://demo-prod.origin.arcpublishing.com/food/empty-recipe",
             "@isPermaLink": true,
           },
           "link": "http://demo-prod.origin.arcpublishing.com/food/empty-recipe",
           "pubDate": "Wed, 07 Apr 2021 15:02:08 +0000",
-          "title": Object {
+          "title": {
             "$": "I'm out of ideas",
           },
         },
@@ -184,7 +184,7 @@ Object {
       "link": "http://demo-prod.origin.arcpublishing.com",
       "sy:updateFrequency": "1",
       "sy:updatePeriod": "hourly",
-      "title": Object {
+      "title": {
         "$": "google news",
       },
       "ttl": "1",
@@ -194,38 +194,38 @@ Object {
 `;
 
 exports[`returns FB-IA template with empty values 1`] = `
-Object {
-  "rss": Object {
+{
+  "rss": {
     "@version": "2.0",
     "@xmlns:atom": "http://www.w3.org/2005/Atom",
     "@xmlns:content": "http://purl.org/rss/1.0/modules/content/",
     "@xmlns:media": "http://search.yahoo.com/mrss/",
-    "channel": Object {
-      "atom:link": Object {
+    "channel": {
+      "atom:link": {
         "@href": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/fb-ia/",
         "@rel": "self",
         "@type": "application/rss+xml",
       },
-      "description": Object {
+      "description": {
         "$": "google news News Feed",
       },
-      "item": Array [
-        Object {
-          "content:encoded": Object {
-            "$": "<!doctype html><html lang=\\"en\\"><head><link rel=\\"canonical\\" href=\\"http://demo-prod.origin.arcpublishing.com/food/2020/04/07/tips-for-safe-hand-washing\\"/><title/><meta property=\\"og:title\\" content=\\"\\"/><meta property=\\"og:url\\" content=\\"http://demo-prod.origin.arcpublishing.com/food/2020/04/07/tips-for-safe-hand-washing\\"/><meta property=\\"og:description\\" content=\\"\\"/><meta property=\\"fb:use_automatic_ad_placement\\" content=\\"enable=false\\"/><meta property=\\"op:markup_version\\" content=\\"v1.0\\"/><meta property=\\"fb:article_style\\" content=\\"default\\"/><meta property=\\"og:image\\" content=\\"hi/abcdefghijklmnopqrstuvwxyz=/arc-anglerfish-arc2-prod-demo.s3.amazonaws.com/public/JTWX7EUOLJE4FCHYGN2COQAERY.png\\"/><meta property=\\"fb:likes_and_comments\\" content=\\"disable\\"/></head><body><article><header><h1/><time datetime=\\"2020-04-08T10:34:41.432Z\\" class=\\"op-modified\\">2020-04-08T10:34:41.432Z</time><time datetime=\\"2020-04-08T10:34:41.432Z\\" class=\\"op-published\\">2020-04-08T10:34:41.432Z</time><figure class=\\"fb-feed-cover\\"><img src=\\"hi/abcdefghijklmnopqrstuvwxyz=/arc-anglerfish-arc2-prod-demo.s3.amazonaws.com/public/JTWX7EUOLJE4FCHYGN2COQAERY.png\\"/></figure><h2 class=\\"op-kicker\\">coronvirus</h2></header><footer><aside>John is a journalist</aside><small>© 2024 google news</small></footer></article></body></html>",
+      "item": [
+        {
+          "content:encoded": {
+            "$": "<!doctype html><html lang="en"><head><link rel="canonical" href="http://demo-prod.origin.arcpublishing.com/food/2020/04/07/tips-for-safe-hand-washing"/><title/><meta property="og:title" content=""/><meta property="og:url" content="http://demo-prod.origin.arcpublishing.com/food/2020/04/07/tips-for-safe-hand-washing"/><meta property="og:description" content=""/><meta property="fb:use_automatic_ad_placement" content="enable=false"/><meta property="op:markup_version" content="v1.0"/><meta property="fb:article_style" content="default"/><meta property="og:image" content="hi/abcdefghijklmnopqrstuvwxyz=/arc-anglerfish-arc2-prod-demo.s3.amazonaws.com/public/JTWX7EUOLJE4FCHYGN2COQAERY.png"/><meta property="fb:likes_and_comments" content="disable"/></head><body><article><header><h1/><time datetime="2020-04-08T10:34:41.432Z" class="op-modified">2020-04-08T10:34:41.432Z</time><time datetime="2020-04-08T10:34:41.432Z" class="op-published">2020-04-08T10:34:41.432Z</time><figure class="fb-feed-cover"><img src="hi/abcdefghijklmnopqrstuvwxyz=/arc-anglerfish-arc2-prod-demo.s3.amazonaws.com/public/JTWX7EUOLJE4FCHYGN2COQAERY.png"/></figure><h2 class="op-kicker">coronvirus</h2></header><footer><aside>John is a journalist</aside><small>© 2024 google news</small></footer></article></body></html>",
           },
-          "guid": Object {
+          "guid": {
             "#": "http://demo-prod.origin.arcpublishing.com/food/2020/04/07/tips-for-safe-hand-washing",
             "@isPermaLink": true,
           },
           "link": "http://demo-prod.origin.arcpublishing.com/food/2020/04/07/tips-for-safe-hand-washing",
           "pubDate": "Wed, 08 Apr 2020 10:34:41 +0000",
         },
-        Object {
-          "content:encoded": Object {
-            "$": "<!doctype html><html lang=\\"en\\"><head><link rel=\\"canonical\\" href=\\"http://demo-prod.origin.arcpublishing.com/food/empty-recipe\\"/><title/><meta property=\\"og:title\\" content=\\"\\"/><meta property=\\"og:url\\" content=\\"http://demo-prod.origin.arcpublishing.com/food/empty-recipe\\"/><meta property=\\"og:description\\" content=\\"\\"/><meta property=\\"fb:use_automatic_ad_placement\\" content=\\"enable=false\\"/><meta property=\\"op:markup_version\\" content=\\"v1.0\\"/><meta property=\\"fb:article_style\\" content=\\"default\\"/><meta property=\\"og:image\\" content=\\"\\"/><meta property=\\"fb:likes_and_comments\\" content=\\"disable\\"/></head><body><article><header><h1/><time datetime=\\"2021-04-08T10:34:41.432Z\\" class=\\"op-modified\\">2021-04-08T10:34:41.432Z</time><time datetime=\\"2021-04-08T10:34:41.432Z\\" class=\\"op-published\\">2021-04-08T10:34:41.432Z</time></header><footer><small>© 2024 google news</small></footer></article></body></html>",
+        {
+          "content:encoded": {
+            "$": "<!doctype html><html lang="en"><head><link rel="canonical" href="http://demo-prod.origin.arcpublishing.com/food/empty-recipe"/><title/><meta property="og:title" content=""/><meta property="og:url" content="http://demo-prod.origin.arcpublishing.com/food/empty-recipe"/><meta property="og:description" content=""/><meta property="fb:use_automatic_ad_placement" content="enable=false"/><meta property="op:markup_version" content="v1.0"/><meta property="fb:article_style" content="default"/><meta property="og:image" content=""/><meta property="fb:likes_and_comments" content="disable"/></head><body><article><header><h1/><time datetime="2021-04-08T10:34:41.432Z" class="op-modified">2021-04-08T10:34:41.432Z</time><time datetime="2021-04-08T10:34:41.432Z" class="op-published">2021-04-08T10:34:41.432Z</time></header><footer><small>© 2024 google news</small></footer></article></body></html>",
           },
-          "guid": Object {
+          "guid": {
             "#": "http://demo-prod.origin.arcpublishing.com/food/empty-recipe",
             "@isPermaLink": true,
           },
@@ -235,7 +235,7 @@ Object {
       ],
       "lastBuildDate": StringMatching /\\\\w\\+, \\\\d\\+ \\\\w\\+ \\\\d\\{4\\} \\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\} \\\\\\+0000/,
       "link": "http://demo-prod.origin.arcpublishing.com",
-      "title": Object {
+      "title": {
         "$": "google news",
       },
     },
@@ -244,87 +244,87 @@ Object {
 `;
 
 exports[`returns FB-IA template with include value 1`] = `
-Object {
-  "rss": Object {
+{
+  "rss": {
     "@version": "2.0",
     "@xmlns:atom": "http://www.w3.org/2005/Atom",
     "@xmlns:content": "http://purl.org/rss/1.0/modules/content/",
     "@xmlns:dc": "http://purl.org/dc/elements/1.1/",
     "@xmlns:media": "http://search.yahoo.com/mrss/",
     "@xmlns:sy": "http://purl.org/rss/1.0/modules/syndication/",
-    "channel": Object {
-      "atom:link": Object {
+    "channel": {
+      "atom:link": {
         "@href": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/fb-ia/",
         "@rel": "self",
         "@type": "application/rss+xml",
       },
       "category": "News",
       "copyright": "Copyright 2021",
-      "description": Object {
+      "description": {
         "$": "Only the best for FB",
       },
-      "image": Object {
+      "image": {
         "link": "http://demo-prod.origin.arcpublishing.com",
         "title": "Facebook Instant Articles Feed",
         "url": "hi/abcdefghijklmnopqrstuvwxyz=/example.com/logo.png",
       },
-      "item": Array [
-        Object {
-          "#": Array [
-            Object {
-              "media:content": Object {
+      "item": [
+        {
+          "#": [
+            {
+              "media:content": {
                 "@type": "image/png",
                 "@url": "hi/abcdefghijklmnopqrstuvwxyz=/arc-anglerfish-arc2-prod-demo.s3.amazonaws.com/public/JTWX7EUOLJE4FCHYGN2COQAERY.png",
-                "media:credit": Object {
+                "media:credit": {
                   "#": "Harold Hands",
                   "@role": "author",
                   "@scheme": "urn:ebu",
                 },
-                "media:description": Object {
+                "media:description": {
                   "$": "Hand washing can be fun if you make it a song",
                   "@type": "plain",
                 },
-                "media:title": Object {
+                "media:title": {
                   "$": "Hand Washing",
                 },
               },
             },
           ],
-          "content:encoded": Object {
-            "$": "<!doctype html><html lang=\\"en\\"><head><link rel=\\"canonical\\" href=\\"http://demo-prod.origin.arcpublishing.com/food/2020/04/07/tips-for-safe-hand-washing\\"/><title>Tips for Safe Hand washing</title><meta property=\\"og:title\\" content=\\"Tips for Safe Hand washing\\"/><meta property=\\"og:url\\" content=\\"http://demo-prod.origin.arcpublishing.com/food/2020/04/07/tips-for-safe-hand-washing\\"/><meta property=\\"og:description\\" content=\\"This is from the subheadlines\\"/><meta property=\\"fb:use_automatic_ad_placement\\" content=\\"enable=true ad_density=low\\"/><meta property=\\"op:markup_version\\" content=\\"v1.0\\"/><meta property=\\"fb:article_style\\" content=\\"times-bold\\"/><meta property=\\"og:image\\" content=\\"hi/abcdefghijklmnopqrstuvwxyz=/arc-anglerfish-arc2-prod-demo.s3.amazonaws.com/public/JTWX7EUOLJE4FCHYGN2COQAERY.png\\"/><meta property=\\"fb:likes_and_comments\\" content=\\"enable\\"/><meta property=\\"something\\" content=\\"other thing\\"/></head><body><article><header><section class=\\"op-ad-template\\"><script>myscript()</script></section><h1>Tips for Safe Hand washing</h1><h2>This is from the subheadlines</h2><time datetime=\\"2020-04-08T10:34:41.432Z\\" class=\\"op-modified\\">2020-04-08T10:34:41.432Z</time><time datetime=\\"2020-04-08T10:34:41.432Z\\" class=\\"op-published\\">2020-04-08T10:34:41.432Z</time><address><a>JOHN-SMITH</a><a>JANE-DOE</a></address><figure class=\\"fb-feed-cover\\"><img src=\\"hi/abcdefghijklmnopqrstuvwxyz=/arc-anglerfish-arc2-prod-demo.s3.amazonaws.com/public/JTWX7EUOLJE4FCHYGN2COQAERY.png\\"/><figcaption class=\\"op-vertical-below op-small\\">Hand washing can be fun if you make it a song<cite class=\\"op-small\\">Harold Hands</cite></figcaption></figure><h2 class=\\"op-kicker\\">coronvirus</h2></header><p id=\\"AAAAA\\">try singing the happy birthday song<br></p><p id=\\"BBBBB\\">be sure to <i>wash</i> your thumbs</p><div style=\\"background:#ffffff; color: #333; margin:100px 0 1rem 0; line-height:28px; font-family: 'Merriweather', serif;\\"><img style=\\"height:120px; width: 120px; float: left; margin-right: 20px;\\" src=\\"https://www.example.com.mx/graficos/img/novedad-180321.jpg\\" class=\\"img-responsive\\" alt=\\"logo\\" /><img style=\\"height:120px; width: 120px; float: right; \\" src=\\"https://example.com.mx/graficos/interior-nota/abcd_novedad.png\\" class=\\"img-responsive\\" alt=\\"logo\\" /><span style=\\"font-size: 1.1rem; font-weight: 700;\\"> Concertos for Oboe, Clarinet and Orchestra </span><hr style=\\"border: 0;  height: 1px;   background-image: -webkit-linear-gradient(left, #666666, #ffffff);  background-image: -moz-linear-gradient(left, #666666, #ffffff);  background-image: -ms-linear-gradient(left, #666666, #ffffff);  background-image: -o-linear-gradient(left,  #666666, #ffffff); padding: 0; margin: 0;\\"/><span style=\\"font-size: .9rem\\">ARTISTA: Camerata de las Américas, dirigida por Ludwig Carrasco </span><br><span style=\\"font-size: .9rem\\">SELLO:   Urtext </span><br><span style=\\"font-size: .9rem\\">PRECIO:   $168n </span></div><figure class=\\"op-interactive\\"><iframe width=\\"560\\"><blockquote class=\\"twitter-tweet\\"><p lang=\\"fr\\" dir=\\"ltr\\">21. Je déploie le robot pour reconnaitre OSCAR3.<br>Retour en images sur l’exercice de recherche appliquée organisé les 30 et 31 mars par l’EMIA et le centre de recherche. Robotisation du champ de bataille : sensibiliser les élèves aux enjeux de demain. <a href=\\"https://twitter.com/hashtag/CapaciTERRE?src=hash&amp;ref_src=twsrc%5Etfw\\">#CapaciTERRE</a> <a href=\\"https://twitter.com/hashtag/Robots?src=hash&amp;ref_src=twsrc%5Etfw\\">#Robots</a> <a href=\\"https://t.co/HiZ2BFOZPY\\">pic.twitter.com/HiZ2BFOZPY</a></p>&mdash; Saint-Cyr Coëtquidan (@SaintCyrCoet) <a href=\\"https://twitter.com/SaintCyrCoet/status/1379457690020294665?ref_src=twsrc%5Etfw\\">April 6, 2021</a></blockquote>
-<script async src=\\"https://platform.twitter.com/widgets.js\\" charset=\\"utf-8\\"></script>
-</iframe></figure><figure><table><thead><tr><th>Description</th><th>Amount</th></tr></thead><tbody><tr><td>apples</td><td>$0.25</td></tr><tr><td>pears</td><td>$0.50</td></tr><tr><td>oranges</td><td>$0.70</td></tr></tbody></table></figure><figure class=\\"op-tracker\\"><iframe><script>alert(\\"\\",\\"Tips for Safe Hand washing\\",\\"\\");</script></iframe></figure><footer><aside>John is a journalist</aside><small>Copyright 2021</small></footer></article></body></html>",
+          "content:encoded": {
+            "$": "<!doctype html><html lang="en"><head><link rel="canonical" href="http://demo-prod.origin.arcpublishing.com/food/2020/04/07/tips-for-safe-hand-washing"/><title>Tips for Safe Hand washing</title><meta property="og:title" content="Tips for Safe Hand washing"/><meta property="og:url" content="http://demo-prod.origin.arcpublishing.com/food/2020/04/07/tips-for-safe-hand-washing"/><meta property="og:description" content="This is from the subheadlines"/><meta property="fb:use_automatic_ad_placement" content="enable=true ad_density=low"/><meta property="op:markup_version" content="v1.0"/><meta property="fb:article_style" content="times-bold"/><meta property="og:image" content="hi/abcdefghijklmnopqrstuvwxyz=/arc-anglerfish-arc2-prod-demo.s3.amazonaws.com/public/JTWX7EUOLJE4FCHYGN2COQAERY.png"/><meta property="fb:likes_and_comments" content="enable"/><meta property="something" content="other thing"/></head><body><article><header><section class="op-ad-template"><script>myscript()</script></section><h1>Tips for Safe Hand washing</h1><h2>This is from the subheadlines</h2><time datetime="2020-04-08T10:34:41.432Z" class="op-modified">2020-04-08T10:34:41.432Z</time><time datetime="2020-04-08T10:34:41.432Z" class="op-published">2020-04-08T10:34:41.432Z</time><address><a>JOHN-SMITH</a><a>JANE-DOE</a></address><figure class="fb-feed-cover"><img src="hi/abcdefghijklmnopqrstuvwxyz=/arc-anglerfish-arc2-prod-demo.s3.amazonaws.com/public/JTWX7EUOLJE4FCHYGN2COQAERY.png"/><figcaption class="op-vertical-below op-small">Hand washing can be fun if you make it a song<cite class="op-small">Harold Hands</cite></figcaption></figure><h2 class="op-kicker">coronvirus</h2></header><p id="AAAAA">try singing the happy birthday song<br></p><p id="BBBBB">be sure to <i>wash</i> your thumbs</p><div style="background:#ffffff; color: #333; margin:100px 0 1rem 0; line-height:28px; font-family: 'Merriweather', serif;"><img style="height:120px; width: 120px; float: left; margin-right: 20px;" src="https://www.example.com.mx/graficos/img/novedad-180321.jpg" class="img-responsive" alt="logo" /><img style="height:120px; width: 120px; float: right; " src="https://example.com.mx/graficos/interior-nota/abcd_novedad.png" class="img-responsive" alt="logo" /><span style="font-size: 1.1rem; font-weight: 700;"> Concertos for Oboe, Clarinet and Orchestra </span><hr style="border: 0;  height: 1px;   background-image: -webkit-linear-gradient(left, #666666, #ffffff);  background-image: -moz-linear-gradient(left, #666666, #ffffff);  background-image: -ms-linear-gradient(left, #666666, #ffffff);  background-image: -o-linear-gradient(left,  #666666, #ffffff); padding: 0; margin: 0;"/><span style="font-size: .9rem">ARTISTA: Camerata de las Américas, dirigida por Ludwig Carrasco </span><br><span style="font-size: .9rem">SELLO:   Urtext </span><br><span style="font-size: .9rem">PRECIO:   $168n </span></div><figure class="op-interactive"><iframe width="560"><blockquote class="twitter-tweet"><p lang="fr" dir="ltr">21. Je déploie le robot pour reconnaitre OSCAR3.<br>Retour en images sur l’exercice de recherche appliquée organisé les 30 et 31 mars par l’EMIA et le centre de recherche. Robotisation du champ de bataille : sensibiliser les élèves aux enjeux de demain. <a href="https://twitter.com/hashtag/CapaciTERRE?src=hash&amp;ref_src=twsrc%5Etfw">#CapaciTERRE</a> <a href="https://twitter.com/hashtag/Robots?src=hash&amp;ref_src=twsrc%5Etfw">#Robots</a> <a href="https://t.co/HiZ2BFOZPY">pic.twitter.com/HiZ2BFOZPY</a></p>&mdash; Saint-Cyr Coëtquidan (@SaintCyrCoet) <a href="https://twitter.com/SaintCyrCoet/status/1379457690020294665?ref_src=twsrc%5Etfw">April 6, 2021</a></blockquote>
+<script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+</iframe></figure><figure><table><thead><tr><th>Description</th><th>Amount</th></tr></thead><tbody><tr><td>apples</td><td>$0.25</td></tr><tr><td>pears</td><td>$0.50</td></tr><tr><td>oranges</td><td>$0.70</td></tr></tbody></table></figure><figure class="op-tracker"><iframe><script>alert("","Tips for Safe Hand washing","");</script></iframe></figure><footer><aside>John is a journalist</aside><small>Copyright 2021</small></footer></article></body></html>",
           },
-          "dc:creator": Object {
+          "dc:creator": {
             "$": "john-smith, jane-doe",
           },
-          "description": Object {
+          "description": {
             "$": "This is from the subheadlines",
           },
-          "guid": Object {
+          "guid": {
             "#": "http://demo-prod.origin.arcpublishing.com/food/2020/04/07/tips-for-safe-hand-washing",
             "@isPermaLink": true,
           },
           "link": "http://demo-prod.origin.arcpublishing.com/food/2020/04/07/tips-for-safe-hand-washing",
           "pubDate": "Wed, 08 Apr 2020 10:34:41 +0000",
-          "title": Object {
+          "title": {
             "$": "Tips for Safe Hand washing",
           },
         },
-        Object {
-          "content:encoded": Object {
-            "$": "<!doctype html><html lang=\\"en\\"><head><link rel=\\"canonical\\" href=\\"http://demo-prod.origin.arcpublishing.com/food/empty-recipe\\"/><title>I'm out of ideas</title><meta property=\\"og:title\\" content=\\"I'm out of ideas\\"/><meta property=\\"og:url\\" content=\\"http://demo-prod.origin.arcpublishing.com/food/empty-recipe\\"/><meta property=\\"og:description\\" content=\\"\\"/><meta property=\\"fb:use_automatic_ad_placement\\" content=\\"enable=true ad_density=low\\"/><meta property=\\"op:markup_version\\" content=\\"v1.0\\"/><meta property=\\"fb:article_style\\" content=\\"times-bold\\"/><meta property=\\"og:image\\" content=\\"\\"/><meta property=\\"fb:likes_and_comments\\" content=\\"enable\\"/><meta property=\\"something\\" content=\\"other thing\\"/></head><body><article><header><section class=\\"op-ad-template\\"><script>myscript()</script></section><h1>I'm out of ideas</h1><time datetime=\\"2021-04-08T10:34:41.432Z\\" class=\\"op-modified\\">2021-04-08T10:34:41.432Z</time><time datetime=\\"2021-04-08T10:34:41.432Z\\" class=\\"op-published\\">2021-04-08T10:34:41.432Z</time></header><figure class=\\"op-tracker\\"><iframe><script>alert(\\"\\",\\"I'm out of ideas\\",\\"\\");</script></iframe></figure><footer><small>Copyright 2021</small></footer></article></body></html>",
+        {
+          "content:encoded": {
+            "$": "<!doctype html><html lang="en"><head><link rel="canonical" href="http://demo-prod.origin.arcpublishing.com/food/empty-recipe"/><title>I'm out of ideas</title><meta property="og:title" content="I'm out of ideas"/><meta property="og:url" content="http://demo-prod.origin.arcpublishing.com/food/empty-recipe"/><meta property="og:description" content=""/><meta property="fb:use_automatic_ad_placement" content="enable=true ad_density=low"/><meta property="op:markup_version" content="v1.0"/><meta property="fb:article_style" content="times-bold"/><meta property="og:image" content=""/><meta property="fb:likes_and_comments" content="enable"/><meta property="something" content="other thing"/></head><body><article><header><section class="op-ad-template"><script>myscript()</script></section><h1>I'm out of ideas</h1><time datetime="2021-04-08T10:34:41.432Z" class="op-modified">2021-04-08T10:34:41.432Z</time><time datetime="2021-04-08T10:34:41.432Z" class="op-published">2021-04-08T10:34:41.432Z</time></header><figure class="op-tracker"><iframe><script>alert("","I'm out of ideas","");</script></iframe></figure><footer><small>Copyright 2021</small></footer></article></body></html>",
           },
-          "description": Object {
+          "description": {
             "$": "",
           },
-          "guid": Object {
+          "guid": {
             "#": "http://demo-prod.origin.arcpublishing.com/food/empty-recipe",
             "@isPermaLink": true,
           },
           "link": "http://demo-prod.origin.arcpublishing.com/food/empty-recipe",
           "pubDate": "Thu, 08 Apr 2021 10:34:41 +0000",
-          "title": Object {
+          "title": {
             "$": "I'm out of ideas",
           },
         },
@@ -334,7 +334,7 @@ Object {
       "link": "http://demo-prod.origin.arcpublishing.com",
       "sy:updateFrequency": "4",
       "sy:updatePeriod": "weekly",
-      "title": Object {
+      "title": {
         "$": "Facebook Instant Articles Feed",
       },
       "ttl": "5",

--- a/blocks/rss-feature-block/features/rss/__snapshots__/xml.test.js.snap
+++ b/blocks/rss-feature-block/features/rss/__snapshots__/xml.test.js.snap
@@ -1,83 +1,83 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`returns RSS template with custom values 1`] = `
-Object {
-  "rss": Object {
+{
+  "rss": {
     "@version": "2.0",
     "@xmlns:atom": "http://www.w3.org/2005/Atom",
     "@xmlns:content": "http://purl.org/rss/1.0/modules/content/",
     "@xmlns:dc": "http://purl.org/dc/elements/1.1/",
     "@xmlns:media": "http://search.yahoo.com/mrss/",
     "@xmlns:sy": "http://purl.org/rss/1.0/modules/syndication/",
-    "channel": Object {
-      "atom:link": Object {
+    "channel": {
+      "atom:link": {
         "@href": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/rss/",
         "@rel": "self",
         "@type": "application/rss+xml",
       },
       "category": "news",
       "copyright": "2020 The Washington Post LLC",
-      "description": Object {
+      "description": {
         "$": "All the news that's fit to print",
       },
-      "image": Object {
+      "image": {
         "link": "http://demo-prod.origin.arcpublishing.com",
         "title": "The Daily Prophet",
         "url": "hi/abcdefghijklmnopqrstuvwxyz=/arc-anglerfish-arc2-prod-demo.s3.amazonaws.com/public/JTWX7EUOLJE4FCHYGN2COQAERY.png",
       },
-      "item": Array [
-        Object {
-          "#": Array [
-            Object {
-              "media:content": Object {
+      "item": [
+        {
+          "#": [
+            {
+              "media:content": {
                 "@type": "image/png",
                 "@url": "hi/abcdefghijklmnopqrstuvwxyz=/arc-anglerfish-arc2-prod-demo.s3.amazonaws.com/public/JTWX7EUOLJE4FCHYGN2COQAERY.png",
-                "media:credit": Object {
+                "media:credit": {
                   "#": "Harold Hands",
                   "@role": "author",
                   "@scheme": "urn:ebu",
                 },
-                "media:description": Object {
+                "media:description": {
                   "$": "Hand washing can be fun if you make it a song",
                   "@type": "plain",
                 },
-                "media:title": Object {
+                "media:title": {
                   "$": "Hand Washing",
                 },
               },
             },
           ],
           "category": "coronvirus",
-          "content:encoded": Object {
+          "content:encoded": {
             "$": "<p>try singing the happy birthday song</p><p>be sure to wash your thumbs</p>",
           },
-          "dc:creator": Object {
+          "dc:creator": {
             "$": "john-smith, jane-doe",
           },
-          "description": Object {
+          "description": {
             "$": "This is from the subheadlines",
           },
-          "guid": Object {
+          "guid": {
             "#": "http://demo-prod.origin.arcpublishing.com/food/2020/04/07/tips-for-safe-hand-washing",
             "@isPermaLink": true,
           },
           "link": "http://demo-prod.origin.arcpublishing.com/food/2020/04/07/tips-for-safe-hand-washing",
           "pubDate": "Tue, 07 Apr 2020 15:02:08 +0000",
-          "title": Object {
+          "title": {
             "$": "Tips for Safe Hand washing",
           },
         },
-        Object {
-          "description": Object {
+        {
+          "description": {
             "$": "",
           },
-          "guid": Object {
+          "guid": {
             "#": "http://demo-prod.origin.arcpublishing.com",
             "@isPermaLink": true,
           },
           "link": "http://demo-prod.origin.arcpublishing.com",
           "pubDate": "Tue, 07 Apr 2020 15:02:08 +0000",
-          "title": Object {
+          "title": {
             "$": "",
           },
         },
@@ -87,7 +87,7 @@ Object {
       "link": "http://demo-prod.origin.arcpublishing.com",
       "sy:updateFrequency": "1",
       "sy:updatePeriod": "weekly",
-      "title": Object {
+      "title": {
         "$": "The Daily Prophet",
       },
       "ttl": "60",
@@ -97,72 +97,72 @@ Object {
 `;
 
 exports[`returns RSS template with default values 1`] = `
-Object {
-  "rss": Object {
+{
+  "rss": {
     "@version": "2.0",
     "@xmlns:atom": "http://www.w3.org/2005/Atom",
     "@xmlns:content": "http://purl.org/rss/1.0/modules/content/",
     "@xmlns:dc": "http://purl.org/dc/elements/1.1/",
     "@xmlns:media": "http://search.yahoo.com/mrss/",
     "@xmlns:sy": "http://purl.org/rss/1.0/modules/syndication/",
-    "channel": Object {
-      "atom:link": Object {
+    "channel": {
+      "atom:link": {
         "@href": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/rss/",
         "@rel": "self",
         "@type": "application/rss+xml",
       },
-      "description": Object {
+      "description": {
         "$": "google news News Feed",
       },
-      "item": Array [
-        Object {
-          "#": Array [
-            Object {
-              "media:content": Object {
+      "item": [
+        {
+          "#": [
+            {
+              "media:content": {
                 "@type": "image/png",
                 "@url": "hi/abcdefghijklmnopqrstuvwxyz=/arc-anglerfish-arc2-prod-demo.s3.amazonaws.com/public/JTWX7EUOLJE4FCHYGN2COQAERY.png",
-                "media:credit": Object {
+                "media:credit": {
                   "#": "Harold Hands",
                   "@role": "author",
                   "@scheme": "urn:ebu",
                 },
-                "media:description": Object {
+                "media:description": {
                   "$": "Hand washing can be fun if you make it a song",
                   "@type": "plain",
                 },
-                "media:title": Object {
+                "media:title": {
                   "$": "Hand Washing",
                 },
               },
             },
           ],
-          "dc:creator": Object {
+          "dc:creator": {
             "$": "John Smith, Jane Doe",
           },
-          "description": Object {
+          "description": {
             "$": "Tips to keep you wash for 20 seconds",
           },
-          "guid": Object {
+          "guid": {
             "#": "http://demo-prod.origin.arcpublishing.com/food/2020/04/07/tips-for-safe-hand-washing",
             "@isPermaLink": true,
           },
           "link": "http://demo-prod.origin.arcpublishing.com/food/2020/04/07/tips-for-safe-hand-washing",
           "pubDate": "Tue, 07 Apr 2020 15:02:08 +0000",
-          "title": Object {
+          "title": {
             "$": "Tips for Safe Hand washing",
           },
         },
-        Object {
-          "description": Object {
+        {
+          "description": {
             "$": "",
           },
-          "guid": Object {
+          "guid": {
             "#": "http://demo-prod.origin.arcpublishing.com",
             "@isPermaLink": true,
           },
           "link": "http://demo-prod.origin.arcpublishing.com",
           "pubDate": "Tue, 07 Apr 2020 15:02:08 +0000",
-          "title": Object {
+          "title": {
             "$": "",
           },
         },
@@ -172,7 +172,7 @@ Object {
       "link": "http://demo-prod.origin.arcpublishing.com",
       "sy:updateFrequency": "1",
       "sy:updatePeriod": "hourly",
-      "title": Object {
+      "title": {
         "$": "google news",
       },
       "ttl": "1",
@@ -182,32 +182,32 @@ Object {
 `;
 
 exports[`returns RSS template with empty values 1`] = `
-Object {
-  "rss": Object {
+{
+  "rss": {
     "@version": "2.0",
     "@xmlns:atom": "http://www.w3.org/2005/Atom",
     "@xmlns:content": "http://purl.org/rss/1.0/modules/content/",
     "@xmlns:media": "http://search.yahoo.com/mrss/",
-    "channel": Object {
-      "atom:link": Object {
+    "channel": {
+      "atom:link": {
         "@href": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/rss/",
         "@rel": "self",
         "@type": "application/rss+xml",
       },
-      "description": Object {
+      "description": {
         "$": "google news News Feed",
       },
-      "item": Array [
-        Object {
-          "guid": Object {
+      "item": [
+        {
+          "guid": {
             "#": "http://demo-prod.origin.arcpublishing.com/food/2020/04/07/tips-for-safe-hand-washing",
             "@isPermaLink": true,
           },
           "link": "http://demo-prod.origin.arcpublishing.com/food/2020/04/07/tips-for-safe-hand-washing",
           "pubDate": "Tue, 07 Apr 2020 15:02:08 +0000",
         },
-        Object {
-          "guid": Object {
+        {
+          "guid": {
             "#": "http://demo-prod.origin.arcpublishing.com",
             "@isPermaLink": true,
           },
@@ -217,7 +217,7 @@ Object {
       ],
       "lastBuildDate": StringMatching /\\\\w\\+, \\\\d\\+ \\\\w\\+ \\\\d\\{4\\} \\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\} \\\\\\+0000/,
       "link": "http://demo-prod.origin.arcpublishing.com",
-      "title": Object {
+      "title": {
         "$": "google news",
       },
     },

--- a/blocks/rss-flipboard-feature-block/features/rss-flipboard/__snapshots__/xml.test.js.snap
+++ b/blocks/rss-flipboard-feature-block/features/rss-flipboard/__snapshots__/xml.test.js.snap
@@ -1,66 +1,66 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`returns Flipboard template with custom values 1`] = `
-Object {
-  "rss": Object {
+{
+  "rss": {
     "@version": "2.0",
     "@xmlns:atom": "http://www.w3.org/2005/Atom",
     "@xmlns:content": "http://purl.org/rss/1.0/modules/content/",
     "@xmlns:dc": "http://purl.org/dc/elements/1.1/",
     "@xmlns:media": "http://search.yahoo.com/mrss/",
     "@xmlns:sy": "http://purl.org/rss/1.0/modules/syndication/",
-    "channel": Object {
-      "atom:link": Object {
+    "channel": {
+      "atom:link": {
         "@href": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/flipboard/",
         "@rel": "self",
         "@type": "application/rss+xml",
       },
       "category": "news",
       "copyright": "2020 The Washington Post LLC",
-      "description": Object {
+      "description": {
         "$": "All the news that's fit to print",
       },
-      "image": Object {
+      "image": {
         "link": "http://demo-prod.origin.arcpublishing.com",
         "title": "The Daily Prophet",
         "url": "hi/abcdefghijklmnopqrstuvwxyz=/arc-anglerfish-arc2-prod-demo.s3.amazonaws.com/public/JTWX7EUOLJE4FCHYGN2COQAERY.png",
       },
-      "item": Array [
-        Object {
-          "#": Array [
-            Object {
-              "media:content": Object {
+      "item": [
+        {
+          "#": [
+            {
+              "media:content": {
                 "@type": "image/png",
                 "@url": "hi/abcdefghijklmnopqrstuvwxyz=/arc-anglerfish-arc2-prod-demo.s3.amazonaws.com/public/JTWX7EUOLJE4FCHYGN2COQAERY.png",
-                "media:credit": Object {
+                "media:credit": {
                   "#": "Harold Hands",
                   "@role": "author",
                   "@scheme": "urn:ebu",
                 },
-                "media:description": Object {
+                "media:description": {
                   "$": "Hand washing can be fun if you make it a song",
                   "@type": "plain",
                 },
-                "media:title": Object {
+                "media:title": {
                   "$": "Hand Washing",
                 },
               },
             },
           ],
           "category": "coronvirus",
-          "content:encoded": Object {
-            "$": "<p>try singing the happy birthday song</p><p>be sure to wash your thumbs</p><figure><img alt=\\"test caption\\" src=\\"hi/abcdefghijklmnopqrstuvwxyz=/arc-anglerfish-arc2-prod-demo.s3.amazonaws.com/QHOCF6YFIZCUFIXBVEAXENGFFM.jpg\\"/><figcaption>test caption</figcaption></figure>",
+          "content:encoded": {
+            "$": "<p>try singing the happy birthday song</p><p>be sure to wash your thumbs</p><figure><img alt="test caption" src="hi/abcdefghijklmnopqrstuvwxyz=/arc-anglerfish-arc2-prod-demo.s3.amazonaws.com/QHOCF6YFIZCUFIXBVEAXENGFFM.jpg"/><figcaption>test caption</figcaption></figure>",
           },
-          "description": Object {
+          "description": {
             "$": "This is from the subheadlines",
           },
-          "guid": Object {
+          "guid": {
             "#": "http://demo-prod.origin.arcpublishing.com/food/2020/04/07/tips-for-safe-hand-washing",
             "@isPermaLink": true,
           },
           "link": "http://demo-prod.origin.arcpublishing.com/food/2020/04/07/tips-for-safe-hand-washing",
           "pubDate": "Tue, 07 Apr 2020 15:02:08 +0000",
-          "title": Object {
+          "title": {
             "$": "Tips for Safe Hand washing",
           },
         },
@@ -70,7 +70,7 @@ Object {
       "link": "http://demo-prod.origin.arcpublishing.com",
       "sy:updateFrequency": "1",
       "sy:updatePeriod": "weekly",
-      "title": Object {
+      "title": {
         "$": "The Daily Prophet",
       },
       "ttl": "60",
@@ -80,58 +80,58 @@ Object {
 `;
 
 exports[`returns Flipboard template with default values 1`] = `
-Object {
-  "rss": Object {
+{
+  "rss": {
     "@version": "2.0",
     "@xmlns:atom": "http://www.w3.org/2005/Atom",
     "@xmlns:content": "http://purl.org/rss/1.0/modules/content/",
     "@xmlns:dc": "http://purl.org/dc/elements/1.1/",
     "@xmlns:media": "http://search.yahoo.com/mrss/",
     "@xmlns:sy": "http://purl.org/rss/1.0/modules/syndication/",
-    "channel": Object {
-      "atom:link": Object {
+    "channel": {
+      "atom:link": {
         "@href": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/flipboard/",
         "@rel": "self",
         "@type": "application/rss+xml",
       },
-      "description": Object {
+      "description": {
         "$": "google news News Feed",
       },
-      "item": Array [
-        Object {
-          "#": Array [
-            Object {
-              "media:content": Object {
+      "item": [
+        {
+          "#": [
+            {
+              "media:content": {
                 "@type": "image/png",
                 "@url": "hi/abcdefghijklmnopqrstuvwxyz=/arc-anglerfish-arc2-prod-demo.s3.amazonaws.com/public/JTWX7EUOLJE4FCHYGN2COQAERY.png",
-                "media:credit": Object {
+                "media:credit": {
                   "#": "Harold Hands",
                   "@role": "author",
                   "@scheme": "urn:ebu",
                 },
-                "media:description": Object {
+                "media:description": {
                   "$": "Hand washing can be fun if you make it a song",
                   "@type": "plain",
                 },
-                "media:title": Object {
+                "media:title": {
                   "$": "Hand Washing",
                 },
               },
             },
           ],
-          "dc:creator": Object {
+          "dc:creator": {
             "$": "John Smith, Jane Doe",
           },
-          "description": Object {
+          "description": {
             "$": "Tips to keep you wash for 20 seconds",
           },
-          "guid": Object {
+          "guid": {
             "#": "http://demo-prod.origin.arcpublishing.com/food/2020/04/07/tips-for-safe-hand-washing",
             "@isPermaLink": true,
           },
           "link": "http://demo-prod.origin.arcpublishing.com/food/2020/04/07/tips-for-safe-hand-washing",
           "pubDate": "Tue, 07 Apr 2020 15:02:08 +0000",
-          "title": Object {
+          "title": {
             "$": "Tips for Safe Hand washing",
           },
         },
@@ -141,7 +141,7 @@ Object {
       "link": "http://demo-prod.origin.arcpublishing.com",
       "sy:updateFrequency": "1",
       "sy:updatePeriod": "hourly",
-      "title": Object {
+      "title": {
         "$": "google news",
       },
       "ttl": "1",
@@ -151,24 +151,24 @@ Object {
 `;
 
 exports[`returns Flipboard template with empty values 1`] = `
-Object {
-  "rss": Object {
+{
+  "rss": {
     "@version": "2.0",
     "@xmlns:atom": "http://www.w3.org/2005/Atom",
     "@xmlns:content": "http://purl.org/rss/1.0/modules/content/",
     "@xmlns:media": "http://search.yahoo.com/mrss/",
-    "channel": Object {
-      "atom:link": Object {
+    "channel": {
+      "atom:link": {
         "@href": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/flipboard/",
         "@rel": "self",
         "@type": "application/rss+xml",
       },
-      "description": Object {
+      "description": {
         "$": "google news News Feed",
       },
-      "item": Array [
-        Object {
-          "guid": Object {
+      "item": [
+        {
+          "guid": {
             "#": "http://demo-prod.origin.arcpublishing.com/food/2020/04/07/tips-for-safe-hand-washing",
             "@isPermaLink": true,
           },
@@ -178,7 +178,7 @@ Object {
       ],
       "lastBuildDate": StringMatching /\\\\w\\+, \\\\d\\+ \\\\w\\+ \\\\d\\{4\\} \\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\} \\\\\\+0000/,
       "link": "http://demo-prod.origin.arcpublishing.com",
-      "title": Object {
+      "title": {
         "$": "google news",
       },
     },

--- a/blocks/rss-google-news-feature-block/features/google-news-rss/__snapshots__/xml.test.js.snap
+++ b/blocks/rss-google-news-feature-block/features/google-news-rss/__snapshots__/xml.test.js.snap
@@ -1,66 +1,66 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`returns Google News template with custom values 1`] = `
-Object {
-  "rss": Object {
+{
+  "rss": {
     "@version": "2.0",
     "@xmlns:atom": "http://www.w3.org/2005/Atom",
     "@xmlns:content": "http://purl.org/rss/1.0/modules/content/",
     "@xmlns:dc": "http://purl.org/dc/elements/1.1/",
     "@xmlns:media": "http://search.yahoo.com/mrss/",
     "@xmlns:sy": "http://purl.org/rss/1.0/modules/syndication/",
-    "channel": Object {
-      "atom:link": Object {
+    "channel": {
+      "atom:link": {
         "@href": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/google-news-feed/",
         "@rel": "self",
         "@type": "application/rss+xml",
       },
       "category": "news",
       "copyright": "2020 The Washington Post LLC",
-      "description": Object {
+      "description": {
         "$": "All the news that's fit to print",
       },
-      "image": Object {
+      "image": {
         "link": "http://demo-prod.origin.arcpublishing.com",
         "title": "The Daily Prophet",
         "url": "hi/abcdefghijklmnopqrstuvwxyz=/arc-anglerfish-arc2-prod-demo.s3.amazonaws.com/public/JTWX7EUOLJE4FCHYGN2COQAERY.png",
       },
-      "item": Array [
-        Object {
-          "#": Array [
-            Object {
-              "media:content": Object {
+      "item": [
+        {
+          "#": [
+            {
+              "media:content": {
                 "@type": "image/png",
                 "@url": "hi/abcdefghijklmnopqrstuvwxyz=/arc-anglerfish-arc2-prod-demo.s3.amazonaws.com/public/JTWX7EUOLJE4FCHYGN2COQAERY.png",
-                "media:credit": Object {
+                "media:credit": {
                   "#": "Harold Hands",
                   "@role": "author",
                   "@scheme": "urn:ebu",
                 },
-                "media:description": Object {
+                "media:description": {
                   "$": "Hand washing can be fun if you make it a song",
                   "@type": "plain",
                 },
-                "media:title": Object {
+                "media:title": {
                   "$": "Hand Washing",
                 },
               },
             },
           ],
           "category": "coronvirus",
-          "content:encoded": Object {
-            "$": "<p>try singing the happy birthday song</p><p>be sure to wash your thumbs</p><figure><img src=\\"hi/abcdefghijklmnopqrstuvwxyz=/arc-anglerfish-arc2-prod-demo.s3.amazonaws.com/QHOCF6YFIZCUFIXBVEAXENGFFM.jpg\\" alt=\\"test caption\\"/><figcaption>test caption</figcaption></figure>",
+          "content:encoded": {
+            "$": "<p>try singing the happy birthday song</p><p>be sure to wash your thumbs</p><figure><img src="hi/abcdefghijklmnopqrstuvwxyz=/arc-anglerfish-arc2-prod-demo.s3.amazonaws.com/QHOCF6YFIZCUFIXBVEAXENGFFM.jpg" alt="test caption"/><figcaption>test caption</figcaption></figure>",
           },
-          "description": Object {
+          "description": {
             "$": "This is from the subheadlines",
           },
-          "guid": Object {
+          "guid": {
             "#": "http://demo-prod.origin.arcpublishing.com/food/2020/04/07/tips-for-safe-hand-washing",
             "@isPermaLink": true,
           },
           "link": "http://demo-prod.origin.arcpublishing.com/food/2020/04/07/tips-for-safe-hand-washing",
           "pubDate": "Tue, 07 Apr 2020 15:02:08 +0000",
-          "title": Object {
+          "title": {
             "$": "Tips for Safe Hand washing",
           },
         },
@@ -70,7 +70,7 @@ Object {
       "link": "http://demo-prod.origin.arcpublishing.com",
       "sy:updateFrequency": "1",
       "sy:updatePeriod": "weekly",
-      "title": Object {
+      "title": {
         "$": "The Daily Prophet",
       },
       "ttl": "60",
@@ -80,58 +80,58 @@ Object {
 `;
 
 exports[`returns Google News template with default values 1`] = `
-Object {
-  "rss": Object {
+{
+  "rss": {
     "@version": "2.0",
     "@xmlns:atom": "http://www.w3.org/2005/Atom",
     "@xmlns:content": "http://purl.org/rss/1.0/modules/content/",
     "@xmlns:dc": "http://purl.org/dc/elements/1.1/",
     "@xmlns:media": "http://search.yahoo.com/mrss/",
     "@xmlns:sy": "http://purl.org/rss/1.0/modules/syndication/",
-    "channel": Object {
-      "atom:link": Object {
+    "channel": {
+      "atom:link": {
         "@href": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/google-news-feed/",
         "@rel": "self",
         "@type": "application/rss+xml",
       },
-      "description": Object {
+      "description": {
         "$": "google news News Feed",
       },
-      "item": Array [
-        Object {
-          "#": Array [
-            Object {
-              "media:content": Object {
+      "item": [
+        {
+          "#": [
+            {
+              "media:content": {
                 "@type": "image/png",
                 "@url": "hi/abcdefghijklmnopqrstuvwxyz=/arc-anglerfish-arc2-prod-demo.s3.amazonaws.com/public/JTWX7EUOLJE4FCHYGN2COQAERY.png",
-                "media:credit": Object {
+                "media:credit": {
                   "#": "Harold Hands",
                   "@role": "author",
                   "@scheme": "urn:ebu",
                 },
-                "media:description": Object {
+                "media:description": {
                   "$": "Hand washing can be fun if you make it a song",
                   "@type": "plain",
                 },
-                "media:title": Object {
+                "media:title": {
                   "$": "Hand Washing",
                 },
               },
             },
           ],
-          "dc:creator": Object {
+          "dc:creator": {
             "$": "John Smith, Jane Doe",
           },
-          "description": Object {
+          "description": {
             "$": "Tips to keep you wash for 20 seconds",
           },
-          "guid": Object {
+          "guid": {
             "#": "http://demo-prod.origin.arcpublishing.com/food/2020/04/07/tips-for-safe-hand-washing",
             "@isPermaLink": true,
           },
           "link": "http://demo-prod.origin.arcpublishing.com/food/2020/04/07/tips-for-safe-hand-washing",
           "pubDate": "Tue, 07 Apr 2020 15:02:08 +0000",
-          "title": Object {
+          "title": {
             "$": "Tips for Safe Hand washing",
           },
         },
@@ -141,7 +141,7 @@ Object {
       "link": "http://demo-prod.origin.arcpublishing.com",
       "sy:updateFrequency": "1",
       "sy:updatePeriod": "hourly",
-      "title": Object {
+      "title": {
         "$": "google news",
       },
       "ttl": "1",
@@ -151,24 +151,24 @@ Object {
 `;
 
 exports[`returns Google News template with empty values 1`] = `
-Object {
-  "rss": Object {
+{
+  "rss": {
     "@version": "2.0",
     "@xmlns:atom": "http://www.w3.org/2005/Atom",
     "@xmlns:content": "http://purl.org/rss/1.0/modules/content/",
     "@xmlns:media": "http://search.yahoo.com/mrss/",
-    "channel": Object {
-      "atom:link": Object {
+    "channel": {
+      "atom:link": {
         "@href": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/google-news-feed/",
         "@rel": "self",
         "@type": "application/rss+xml",
       },
-      "description": Object {
+      "description": {
         "$": "google news News Feed",
       },
-      "item": Array [
-        Object {
-          "guid": Object {
+      "item": [
+        {
+          "guid": {
             "#": "http://demo-prod.origin.arcpublishing.com/food/2020/04/07/tips-for-safe-hand-washing",
             "@isPermaLink": true,
           },
@@ -178,7 +178,7 @@ Object {
       ],
       "lastBuildDate": StringMatching /\\\\w\\+, \\\\d\\+ \\\\w\\+ \\\\d\\{4\\} \\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\} \\\\\\+0000/,
       "link": "http://demo-prod.origin.arcpublishing.com",
-      "title": Object {
+      "title": {
         "$": "google news",
       },
     },

--- a/blocks/rss-msn-feature-block/features/msn-rss/__snapshots__/xml.test.js.snap
+++ b/blocks/rss-msn-feature-block/features/msn-rss/__snapshots__/xml.test.js.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`returns MSN template with custom values 1`] = `
-Object {
-  "rss": Object {
+{
+  "rss": {
     "@version": "2.0",
     "@xmlns:atom": "http://www.w3.org/2005/Atom",
     "@xmlns:content": "http://purl.org/rss/1.0/modules/content/",
@@ -10,60 +10,60 @@ Object {
     "@xmlns:dcterms": "https://purl.org/dc/terms/",
     "@xmlns:media": "http://search.yahoo.com/mrss/",
     "@xmlns:sy": "http://purl.org/rss/1.0/modules/syndication/",
-    "channel": Object {
-      "atom:link": Object {
+    "channel": {
+      "atom:link": {
         "@href": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/msn/",
         "@rel": "self",
         "@type": "application/rss+xml",
       },
       "category": "news",
       "copyright": "2020 The Washington Post LLC",
-      "description": Object {
+      "description": {
         "$": "All the news that's fit to print",
       },
-      "image": Object {
+      "image": {
         "link": "http://demo-prod.origin.arcpublishing.com",
         "title": "The Daily Prophet",
         "url": "hi/abcdefghijklmnopqrstuvwxyz=/arc-anglerfish-arc2-prod-demo.s3.amazonaws.com/public/JTWX7EUOLJE4FCHYGN2COQAERY.png",
       },
-      "item": Array [
-        Object {
-          "#": Array [
-            Object {
-              "media:content": Object {
+      "item": [
+        {
+          "#": [
+            {
+              "media:content": {
                 "@type": "image/png",
                 "@url": "hi/abcdefghijklmnopqrstuvwxyz=/arc-anglerfish-arc2-prod-demo.s3.amazonaws.com/public/JTWX7EUOLJE4FCHYGN2COQAERY.png",
-                "media:credit": Object {
+                "media:credit": {
                   "#": "Harold Hands",
                   "@role": "author",
                   "@scheme": "urn:ebu",
                 },
-                "media:description": Object {
+                "media:description": {
                   "$": "Hand washing can be fun if you make it a song",
                   "@type": "plain",
                 },
                 "media:text": "The Daily Prophet",
-                "media:title": Object {
+                "media:title": {
                   "$": "Hand Washing",
                 },
               },
             },
           ],
           "category": "coronvirus",
-          "content:encoded": Object {
-            "$": "<p>try singing the happy birthday song</p><p>be sure to wash your thumbs</p><figure><img src=\\"hi/abcdefghijklmnopqrstuvwxyz=/arc-anglerfish-arc2-prod-demo.s3.amazonaws.com/QHOCF6YFIZCUFIXBVEAXENGFFM.jpg\\" alt=\\"test caption\\"/><figcaption>test caption</figcaption></figure>",
+          "content:encoded": {
+            "$": "<p>try singing the happy birthday song</p><p>be sure to wash your thumbs</p><figure><img src="hi/abcdefghijklmnopqrstuvwxyz=/arc-anglerfish-arc2-prod-demo.s3.amazonaws.com/QHOCF6YFIZCUFIXBVEAXENGFFM.jpg" alt="test caption"/><figcaption>test caption</figcaption></figure>",
           },
           "dcterms:modified": undefined,
-          "description": Object {
+          "description": {
             "$": "This is from the subheadlines",
           },
-          "guid": Object {
+          "guid": {
             "#": undefined,
             "@isPermaLink": false,
           },
           "link": "http://demo-prod.origin.arcpublishing.com/food/2020/04/07/tips-for-safe-hand-washing",
           "pubDate": "Tue, 07 Apr 2020 15:02:08 +0000",
-          "title": Object {
+          "title": {
             "$": "Tips for Safe Hand washing",
           },
         },
@@ -73,7 +73,7 @@ Object {
       "link": "http://demo-prod.origin.arcpublishing.com",
       "sy:updateFrequency": "1",
       "sy:updatePeriod": "weekly",
-      "title": Object {
+      "title": {
         "$": "The Daily Prophet",
       },
       "ttl": "60",
@@ -83,8 +83,8 @@ Object {
 `;
 
 exports[`returns MSN template with default values 1`] = `
-Object {
-  "rss": Object {
+{
+  "rss": {
     "@version": "2.0",
     "@xmlns:atom": "http://www.w3.org/2005/Atom",
     "@xmlns:content": "http://purl.org/rss/1.0/modules/content/",
@@ -92,52 +92,52 @@ Object {
     "@xmlns:dcterms": "https://purl.org/dc/terms/",
     "@xmlns:media": "http://search.yahoo.com/mrss/",
     "@xmlns:sy": "http://purl.org/rss/1.0/modules/syndication/",
-    "channel": Object {
-      "atom:link": Object {
+    "channel": {
+      "atom:link": {
         "@href": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/msn/",
         "@rel": "self",
         "@type": "application/rss+xml",
       },
-      "description": Object {
+      "description": {
         "$": "google news News Feed",
       },
-      "item": Array [
-        Object {
-          "#": Array [
-            Object {
-              "media:content": Object {
+      "item": [
+        {
+          "#": [
+            {
+              "media:content": {
                 "@type": "image/png",
                 "@url": "hi/abcdefghijklmnopqrstuvwxyz=/arc-anglerfish-arc2-prod-demo.s3.amazonaws.com/public/JTWX7EUOLJE4FCHYGN2COQAERY.png",
-                "media:credit": Object {
+                "media:credit": {
                   "#": "Harold Hands",
                   "@role": "author",
                   "@scheme": "urn:ebu",
                 },
-                "media:description": Object {
+                "media:description": {
                   "$": "Hand washing can be fun if you make it a song",
                   "@type": "plain",
                 },
                 "media:text": "google news",
-                "media:title": Object {
+                "media:title": {
                   "$": "Hand Washing",
                 },
               },
             },
           ],
-          "dc:creator": Object {
+          "dc:creator": {
             "$": "John Smith, Jane Doe",
           },
           "dcterms:modified": undefined,
-          "description": Object {
+          "description": {
             "$": "Tips to keep you wash for 20 seconds",
           },
-          "guid": Object {
+          "guid": {
             "#": undefined,
             "@isPermaLink": false,
           },
           "link": "http://demo-prod.origin.arcpublishing.com/food/2020/04/07/tips-for-safe-hand-washing",
           "pubDate": "Tue, 07 Apr 2020 15:02:08 +0000",
-          "title": Object {
+          "title": {
             "$": "Tips for Safe Hand washing",
           },
         },
@@ -147,7 +147,7 @@ Object {
       "link": "http://demo-prod.origin.arcpublishing.com",
       "sy:updateFrequency": "1",
       "sy:updatePeriod": "hourly",
-      "title": Object {
+      "title": {
         "$": "google news",
       },
       "ttl": "1",
@@ -157,26 +157,26 @@ Object {
 `;
 
 exports[`returns MSN template with empty values 1`] = `
-Object {
-  "rss": Object {
+{
+  "rss": {
     "@version": "2.0",
     "@xmlns:atom": "http://www.w3.org/2005/Atom",
     "@xmlns:content": "http://purl.org/rss/1.0/modules/content/",
     "@xmlns:dcterms": "https://purl.org/dc/terms/",
     "@xmlns:media": "http://search.yahoo.com/mrss/",
-    "channel": Object {
-      "atom:link": Object {
+    "channel": {
+      "atom:link": {
         "@href": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/msn/",
         "@rel": "self",
         "@type": "application/rss+xml",
       },
-      "description": Object {
+      "description": {
         "$": "google news News Feed",
       },
-      "item": Array [
-        Object {
+      "item": [
+        {
           "dcterms:modified": undefined,
-          "guid": Object {
+          "guid": {
             "#": undefined,
             "@isPermaLink": false,
           },
@@ -186,7 +186,7 @@ Object {
       ],
       "lastBuildDate": StringMatching /\\\\w\\+, \\\\d\\+ \\\\w\\+ \\\\d\\{4\\} \\\\d\\{2\\}:\\\\d\\{2\\}:\\\\d\\{2\\} \\\\\\+0000/,
       "link": "http://demo-prod.origin.arcpublishing.com",
-      "title": Object {
+      "title": {
         "$": "google news",
       },
     },

--- a/blocks/sitemap-feature-block/features/sitemap/__snapshots__/xml.test.js.snap
+++ b/blocks/sitemap-feature-block/features/sitemap/__snapshots__/xml.test.js.snap
@@ -1,27 +1,27 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`returns template with default values 1`] = `
-Object {
-  "urlset": Object {
+{
+  "urlset": {
     "@xmlns": "http://www.sitemaps.org/schemas/sitemap/0.9",
     "@xmlns:image": "http://www.google.com/schemas/sitemap-image/1.1",
-    "url": Array [
-      Object {
+    "url": [
+      {
         "changefreq": "always",
         "lastmod": "2020-04-07T15:02:08.918Z",
         "loc": "http://demo-prod.origin.arcpublishing.com/food/2020/04/07/tips-for-safe-hand-washing",
         "priority": "0.5",
       },
-      Object {
+      {
         "changefreq": "always",
         "lastmod": "2021-04-07T17:02:08.918Z",
         "loc": "http://demo-prod.origin.arcpublishing.com/food/2021/04/07/will-we-ever-stop-hand-washing",
         "priority": "0.5",
       },
-      Object {
-        "#": Array [
-          Object {
-            "image:image": Object {
+      {
+        "#": [
+          {
+            "image:image": {
               "image:loc": "hi/abcdefghijklmnopqrstuvwxyz=/arc-anglerfish-arc2-prod-demo.s3.amazonaws.com/public/VIDEO_ONE_IMAGE.png",
             },
           },
@@ -37,24 +37,24 @@ Object {
 `;
 
 exports[`returns template with empty values 1`] = `
-Object {
-  "urlset": Object {
+{
+  "urlset": {
     "@xmlns": "http://www.sitemaps.org/schemas/sitemap/0.9",
     "@xmlns:image": "http://www.google.com/schemas/sitemap-image/1.1",
-    "url": Array [
-      Object {
+    "url": [
+      {
         "changefreq": "",
         "lastmod": undefined,
         "loc": "http://demo-prod.origin.arcpublishing.com/food/2020/04/07/tips-for-safe-hand-washing",
         "priority": "",
       },
-      Object {
+      {
         "changefreq": "",
         "lastmod": undefined,
         "loc": "http://demo-prod.origin.arcpublishing.com/food/2021/04/07/will-we-ever-stop-hand-washing",
         "priority": "",
       },
-      Object {
+      {
         "changefreq": "",
         "lastmod": undefined,
         "loc": "http://demo-prod.origin.arcpublishing.com/food/2021/04/03/best-sourdough-recipes",

--- a/blocks/sitemap-index-by-day-feature-block/features/sitemap-index/__snapshots__/xml.test.js.snap
+++ b/blocks/sitemap-index-by-day-feature-block/features/sitemap-index/__snapshots__/xml.test.js.snap
@@ -1,14 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`invalid date format, should return 2 1`] = `
-Object {
-  "sitemapindex": Object {
+{
+  "sitemapindex": {
     "@xmlns": "http://www.sitemaps.org/schemas/sitemap/0.9",
-    "sitemap": Array [
-      Object {
+    "sitemap": [
+      {
         "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap-news/latest/?outputType=xml",
       },
-      Object {
+      {
         "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap-news/2021-04-08/?outputType=xml",
       },
     ],
@@ -17,14 +17,14 @@ Object {
 `;
 
 exports[`invalid date, should return 2 1`] = `
-Object {
-  "sitemapindex": Object {
+{
+  "sitemapindex": {
     "@xmlns": "http://www.sitemaps.org/schemas/sitemap/0.9",
-    "sitemap": Array [
-      Object {
+    "sitemap": [
+      {
         "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap-news/latest/?outputType=xml",
       },
-      Object {
+      {
         "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap-news/2021-04-08/?outputType=xml",
       },
     ],
@@ -33,14 +33,14 @@ Object {
 `;
 
 exports[`returns template with default values 1`] = `
-Object {
-  "sitemapindex": Object {
+{
+  "sitemapindex": {
     "@xmlns": "http://www.sitemaps.org/schemas/sitemap/0.9",
-    "sitemap": Array [
-      Object {
+    "sitemap": [
+      {
         "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap/latest/?outputType=xml",
       },
-      Object {
+      {
         "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap/2021-04-08/?outputType=xml",
       },
     ],
@@ -49,14 +49,14 @@ Object {
 `;
 
 exports[`returns template with empty values 1`] = `
-Object {
-  "sitemapindex": Object {
+{
+  "sitemapindex": {
     "@xmlns": "http://www.sitemaps.org/schemas/sitemap/0.9",
-    "sitemap": Array [
-      Object {
+    "sitemap": [
+      {
         "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap/latest/",
       },
-      Object {
+      {
         "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap/2021-04-08/",
       },
     ],
@@ -65,44 +65,44 @@ Object {
 `;
 
 exports[`returns template with set end date 2021-04-01 1`] = `
-Object {
-  "sitemapindex": Object {
+{
+  "sitemapindex": {
     "@xmlns": "http://www.sitemaps.org/schemas/sitemap/0.9",
-    "sitemap": Array [
-      Object {
+    "sitemap": [
+      {
         "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap/latest/?outputType=xml",
       },
-      Object {
+      {
         "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap/2021-04-08/?outputType=xml",
       },
-      Object {
+      {
         "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap2/2021-04-07/?outputType=xml",
       },
-      Object {
+      {
         "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap2/2021-04-06-1/?outputType=xml",
       },
-      Object {
+      {
         "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap2/2021-04-06-2/?outputType=xml",
       },
-      Object {
+      {
         "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap2/2021-04-06-3/?outputType=xml",
       },
-      Object {
+      {
         "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap2/2021-04-06-4/?outputType=xml",
       },
-      Object {
+      {
         "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap2/2021-04-05/?outputType=xml",
       },
-      Object {
+      {
         "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap2/2021-04-04/?outputType=xml",
       },
-      Object {
+      {
         "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap2/2021-04-03/?outputType=xml",
       },
-      Object {
+      {
         "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap3/2021-04-02/?outputType=xml",
       },
-      Object {
+      {
         "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap3/2021-04-01/?outputType=xml",
       },
     ],
@@ -111,14 +111,14 @@ Object {
 `;
 
 exports[`returns template without outputType 1`] = `
-Object {
-  "sitemapindex": Object {
+{
+  "sitemapindex": {
     "@xmlns": "http://www.sitemaps.org/schemas/sitemap/0.9",
-    "sitemap": Array [
-      Object {
+    "sitemap": [
+      {
         "loc": "http://demo-prod.origin.arcpublishing.com/sitemap/latest/",
       },
-      Object {
+      {
         "loc": "http://demo-prod.origin.arcpublishing.com/sitemap/2021-04-08/",
       },
     ],
@@ -127,26 +127,26 @@ Object {
 `;
 
 exports[`sitemaps at root 1`] = `
-Object {
-  "sitemapindex": Object {
+{
+  "sitemapindex": {
     "@xmlns": "http://www.sitemaps.org/schemas/sitemap/0.9",
-    "sitemap": Array [
-      Object {
+    "sitemap": [
+      {
         "loc": "http://demo-prod.origin.arcpublishing.com/sitemap-latest.xml",
       },
-      Object {
+      {
         "loc": "http://demo-prod.origin.arcpublishing.com/sitemap-2021-04-08.xml",
       },
-      Object {
+      {
         "loc": "http://demo-prod.origin.arcpublishing.com/sitemap-2021-04-07.xml",
       },
-      Object {
+      {
         "loc": "http://demo-prod.origin.arcpublishing.com/sitemap-2021-04-06-1.xml",
       },
-      Object {
+      {
         "loc": "http://demo-prod.origin.arcpublishing.com/sitemap-2021-04-06-2.xml",
       },
-      Object {
+      {
         "loc": "http://demo-prod.origin.arcpublishing.com/sitemap-2021-04-05.xml",
       },
     ],

--- a/blocks/sitemap-index-feature-block/features/sitemap-index/__snapshots__/xml.test.js.snap
+++ b/blocks/sitemap-index-feature-block/features/sitemap-index/__snapshots__/xml.test.js.snap
@@ -1,27 +1,27 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`returns template with category in url 1`] = `
-Object {
-  "sitemapindex": Object {
+{
+  "sitemapindex": {
     "@xmlns": "http://www.sitemaps.org/schemas/sitemap/0.9",
-    "sitemap": Array [
-      Object {
+    "sitemap": [
+      {
         "lastmod": "2020-04-07T15:02:08.918Z",
         "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap/category/sports/?outputType=xml",
       },
-      Object {
+      {
         "lastmod": "2020-04-07T15:02:08.918Z",
         "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap/category/sports/?outputType=xml&from=100",
       },
-      Object {
+      {
         "lastmod": "2020-04-07T15:02:08.918Z",
         "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap/category/sports/?outputType=xml&from=200",
       },
-      Object {
+      {
         "lastmod": "2020-04-07T15:02:08.918Z",
         "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap/category/sports/?outputType=xml&from=300",
       },
-      Object {
+      {
         "lastmod": "2020-04-07T15:02:08.918Z",
         "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap/category/sports/?outputType=xml&from=400",
       },
@@ -31,27 +31,27 @@ Object {
 `;
 
 exports[`returns template with default values 1`] = `
-Object {
-  "sitemapindex": Object {
+{
+  "sitemapindex": {
     "@xmlns": "http://www.sitemaps.org/schemas/sitemap/0.9",
-    "sitemap": Array [
-      Object {
+    "sitemap": [
+      {
         "lastmod": "2020-04-07T15:02:08.918Z",
         "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap/?outputType=xml",
       },
-      Object {
+      {
         "lastmod": "2020-04-07T15:02:08.918Z",
         "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap/?outputType=xml&from=100",
       },
-      Object {
+      {
         "lastmod": "2020-04-07T15:02:08.918Z",
         "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap/?outputType=xml&from=200",
       },
-      Object {
+      {
         "lastmod": "2020-04-07T15:02:08.918Z",
         "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap/?outputType=xml&from=300",
       },
-      Object {
+      {
         "lastmod": "2020-04-07T15:02:08.918Z",
         "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap/?outputType=xml&from=400",
       },
@@ -61,23 +61,23 @@ Object {
 `;
 
 exports[`returns template with empty values 1`] = `
-Object {
-  "sitemapindex": Object {
+{
+  "sitemapindex": {
     "@xmlns": "http://www.sitemaps.org/schemas/sitemap/0.9",
-    "sitemap": Array [
-      Object {
+    "sitemap": [
+      {
         "loc": "http://demo-prod.origin.arcpublishing.com",
       },
-      Object {
+      {
         "loc": "http://demo-prod.origin.arcpublishing.com?from=100",
       },
-      Object {
+      {
         "loc": "http://demo-prod.origin.arcpublishing.com?from=200",
       },
-      Object {
+      {
         "loc": "http://demo-prod.origin.arcpublishing.com?from=300",
       },
-      Object {
+      {
         "loc": "http://demo-prod.origin.arcpublishing.com?from=400",
       },
     ],
@@ -86,10 +86,10 @@ Object {
 `;
 
 exports[`returns template with no content 1`] = `
-Object {
-  "sitemapindex": Object {
+{
+  "sitemapindex": {
     "@xmlns": "http://www.sitemaps.org/schemas/sitemap/0.9",
-    "sitemap": Array [],
+    "sitemap": [],
   },
 }
 `;

--- a/blocks/sitemap-news-feature-block/features/news-sitemap/__snapshots__/xml.test.js.snap
+++ b/blocks/sitemap-news-feature-block/features/news-sitemap/__snapshots__/xml.test.js.snap
@@ -1,18 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`returns template with default values 1`] = `
-Object {
-  "urlset": Object {
+{
+  "urlset": {
     "@xmlns": "http://www.sitemaps.org/schemas/sitemap/0.9",
     "@xmlns:image": "http://www.google.com/schemas/sitemap-image/1.1",
     "@xmlns:news": "http://www.google.com/schemas/sitemap-news/0.9",
-    "url": Array [
-      Object {
-        "#": Array [
-          Object {
-            "image:image": Object {
+    "url": [
+      {
+        "#": [
+          {
+            "image:image": {
               "image:loc": "hi/abcdefghijklmnopqrstuvwxyz=/arc-anglerfish-arc2-prod-demo.s3.amazonaws.com/public/STORY_ONE_IMAGE.png",
-              "image:title": Object {
+              "image:title": {
                 "$": "Hand Washing",
               },
             },
@@ -21,35 +21,35 @@ Object {
         "changefreq": "always",
         "lastmod": "2018-10-05T14:28:25.674Z",
         "loc": "http://demo-prod.origin.arcpublishing.com/food/2020/04/07/tips-for-safe-hand-washing",
-        "news:news": Object {
-          "news:keywords": Object {
+        "news:news": {
+          "news:keywords": {
             "$": "animal videos",
           },
-          "news:publication": Object {
+          "news:publication": {
             "news:language": "en",
             "news:name": "google news",
           },
           "news:publication_date": "2018-10-05T14:28:25.674Z",
-          "news:title": Object {
+          "news:title": {
             "$": "dog running outside enjoying the sunny day",
           },
         },
         "priority": "0.5",
       },
-      Object {
+      {
         "changefreq": "always",
         "lastmod": "2021-11-15T12:18:25.674Z",
         "loc": "http://demo-prod.origin.arcpublishing.com/food/2021/04/07/best-sourdough-recipes",
-        "news:news": Object {
-          "news:keywords": Object {
+        "news:news": {
+          "news:keywords": {
             "$": "food videos",
           },
-          "news:publication": Object {
+          "news:publication": {
             "news:language": "en",
             "news:name": "google news",
           },
           "news:publication_date": "2021-11-15T12:18:25.674Z",
-          "news:title": Object {
+          "news:title": {
             "$": "Best Sourdough you have ever made",
           },
         },
@@ -61,18 +61,18 @@ Object {
 `;
 
 exports[`returns template with empty values 1`] = `
-Object {
-  "urlset": Object {
+{
+  "urlset": {
     "@xmlns": "http://www.sitemaps.org/schemas/sitemap/0.9",
     "@xmlns:image": "http://www.google.com/schemas/sitemap-image/1.1",
     "@xmlns:news": "http://www.google.com/schemas/sitemap-news/0.9",
-    "url": Array [
-      Object {
+    "url": [
+      {
         "changefreq": "",
         "lastmod": undefined,
         "loc": "http://demo-prod.origin.arcpublishing.com/food/2020/04/07/tips-for-safe-hand-washing",
-        "news:news": Object {
-          "news:publication": Object {
+        "news:news": {
+          "news:publication": {
             "news:language": "en",
             "news:name": "google news",
           },
@@ -80,12 +80,12 @@ Object {
         },
         "priority": "",
       },
-      Object {
+      {
         "changefreq": "",
         "lastmod": undefined,
         "loc": "http://demo-prod.origin.arcpublishing.com/food/2021/04/07/best-sourdough-recipes",
-        "news:news": Object {
-          "news:publication": Object {
+        "news:news": {
+          "news:publication": {
             "news:language": "en",
             "news:name": "google news",
           },
@@ -99,17 +99,17 @@ Object {
 `;
 
 exports[`returns template with langauge 1`] = `
-Object {
-  "urlset": Object {
+{
+  "urlset": {
     "@xmlns": "http://www.sitemaps.org/schemas/sitemap/0.9",
     "@xmlns:news": "http://www.google.com/schemas/sitemap-news/0.9",
-    "url": Array [
-      Object {
+    "url": [
+      {
         "changefreq": undefined,
         "lastmod": undefined,
         "loc": "http://demo-prod.origin.arcpublishing.com/food/2020/04/07/tips-for-safe-hand-washing",
-        "news:news": Object {
-          "news:publication": Object {
+        "news:news": {
+          "news:publication": {
             "news:language": "es",
             "news:name": "google news",
           },
@@ -117,12 +117,12 @@ Object {
         },
         "priority": undefined,
       },
-      Object {
+      {
         "changefreq": undefined,
         "lastmod": undefined,
         "loc": "http://demo-prod.origin.arcpublishing.com/food/2021/04/07/best-sourdough-recipes",
-        "news:news": Object {
-          "news:publication": Object {
+        "news:news": {
+          "news:publication": {
             "news:language": "es",
             "news:name": "google news",
           },

--- a/blocks/sitemap-section-feature-block/features/sitemap-section/__snapshots__/xml.test.js.snap
+++ b/blocks/sitemap-section-feature-block/features/sitemap-section/__snapshots__/xml.test.js.snap
@@ -1,56 +1,56 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`returns template with links to sections without outputType 1`] = `
-Object {
-  "urlset": Object {
+{
+  "urlset": {
     "@xmlns": "http://www.sitemaps.org/schemas/sitemap/0.9",
-    "url": Array [
-      Object {
+    "url": [
+      {
         "changefreq": "",
         "loc": "http://demo-prod.origin.arcpublishing.com/politics/",
         "priority": "",
       },
-      Object {
+      {
         "changefreq": "",
         "loc": "http://demo-prod.origin.arcpublishing.com/opinion/",
         "priority": "",
       },
-      Object {
+      {
         "changefreq": "",
         "loc": "http://demo-prod.origin.arcpublishing.com/economy/",
         "priority": "",
       },
-      Object {
+      {
         "changefreq": "",
         "loc": "http://demo-prod.origin.arcpublishing.com/sports/",
         "priority": "",
       },
-      Object {
+      {
         "changefreq": "",
         "loc": "http://demo-prod.origin.arcpublishing.com/sports/football/",
         "priority": "",
       },
-      Object {
+      {
         "changefreq": "",
         "loc": "http://demo-prod.origin.arcpublishing.com/sports/baseball/",
         "priority": "",
       },
-      Object {
+      {
         "changefreq": "",
         "loc": "http://demo-prod.origin.arcpublishing.com/sports/basketball/",
         "priority": "",
       },
-      Object {
+      {
         "changefreq": "",
         "loc": "http://demo-prod.origin.arcpublishing.com/entertainment/",
         "priority": "",
       },
-      Object {
+      {
         "changefreq": "",
         "loc": "http://demo-prod.origin.arcpublishing.com/entertainment/tv/",
         "priority": "",
       },
-      Object {
+      {
         "changefreq": "",
         "loc": "http://demo-prod.origin.arcpublishing.com/entertainment/movies/",
         "priority": "",
@@ -61,56 +61,56 @@ Object {
 `;
 
 exports[`returns template with sitemap by section links 1`] = `
-Object {
-  "urlset": Object {
+{
+  "urlset": {
     "@xmlns": "http://www.sitemaps.org/schemas/sitemap/0.9",
-    "url": Array [
-      Object {
+    "url": [
+      {
         "changefreq": "always",
         "loc": "http://demo-prod.origin.arcpublishing.com/politics/",
         "priority": "0.5",
       },
-      Object {
+      {
         "changefreq": "always",
         "loc": "http://demo-prod.origin.arcpublishing.com/opinion/",
         "priority": "0.5",
       },
-      Object {
+      {
         "changefreq": "always",
         "loc": "http://demo-prod.origin.arcpublishing.com/economy/",
         "priority": "0.5",
       },
-      Object {
+      {
         "changefreq": "always",
         "loc": "http://demo-prod.origin.arcpublishing.com/sports/",
         "priority": "0.5",
       },
-      Object {
+      {
         "changefreq": "always",
         "loc": "http://demo-prod.origin.arcpublishing.com/sports/football/",
         "priority": "0.5",
       },
-      Object {
+      {
         "changefreq": "always",
         "loc": "http://demo-prod.origin.arcpublishing.com/sports/baseball/",
         "priority": "0.5",
       },
-      Object {
+      {
         "changefreq": "always",
         "loc": "http://demo-prod.origin.arcpublishing.com/sports/basketball/",
         "priority": "0.5",
       },
-      Object {
+      {
         "changefreq": "always",
         "loc": "http://demo-prod.origin.arcpublishing.com/entertainment/",
         "priority": "0.5",
       },
-      Object {
+      {
         "changefreq": "always",
         "loc": "http://demo-prod.origin.arcpublishing.com/entertainment/tv/",
         "priority": "0.5",
       },
-      Object {
+      {
         "changefreq": "always",
         "loc": "http://demo-prod.origin.arcpublishing.com/entertainment/movies/",
         "priority": "0.5",
@@ -121,46 +121,46 @@ Object {
 `;
 
 exports[`returns template with sitemap by section links with excluded links 1`] = `
-Object {
-  "urlset": Object {
+{
+  "urlset": {
     "@xmlns": "http://www.sitemaps.org/schemas/sitemap/0.9",
-    "url": Array [
-      Object {
+    "url": [
+      {
         "changefreq": "always",
         "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap/category/opinion/?outputType=xml",
         "priority": "0.5",
       },
-      Object {
+      {
         "changefreq": "always",
         "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap/category/economy/?outputType=xml",
         "priority": "0.5",
       },
-      Object {
+      {
         "changefreq": "always",
         "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap/category/sports/?outputType=xml",
         "priority": "0.5",
       },
-      Object {
+      {
         "changefreq": "always",
         "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap/category/sports/football/?outputType=xml",
         "priority": "0.5",
       },
-      Object {
+      {
         "changefreq": "always",
         "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap/category/sports/baseball/?outputType=xml",
         "priority": "0.5",
       },
-      Object {
+      {
         "changefreq": "always",
         "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap/category/sports/basketball/?outputType=xml",
         "priority": "0.5",
       },
-      Object {
+      {
         "changefreq": "always",
         "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap/category/entertainment/?outputType=xml",
         "priority": "0.5",
       },
-      Object {
+      {
         "changefreq": "always",
         "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap/category/entertainment/movies/?outputType=xml",
         "priority": "0.5",
@@ -171,38 +171,38 @@ Object {
 `;
 
 exports[`returns template without priority or change frequency 1`] = `
-Object {
-  "urlset": Object {
+{
+  "urlset": {
     "@xmlns": "http://www.sitemaps.org/schemas/sitemap/0.9",
-    "url": Array [
-      Object {
+    "url": [
+      {
         "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap/category/politics/?outputType=xml",
       },
-      Object {
+      {
         "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap/category/opinion/?outputType=xml",
       },
-      Object {
+      {
         "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap/category/economy/?outputType=xml",
       },
-      Object {
+      {
         "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap/category/sports/?outputType=xml",
       },
-      Object {
+      {
         "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap/category/sports/football/?outputType=xml",
       },
-      Object {
+      {
         "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap/category/sports/baseball/?outputType=xml",
       },
-      Object {
+      {
         "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap/category/sports/basketball/?outputType=xml",
       },
-      Object {
+      {
         "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap/category/entertainment/?outputType=xml",
       },
-      Object {
+      {
         "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap/category/entertainment/tv/?outputType=xml",
       },
-      Object {
+      {
         "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap/category/entertainment/movies/?outputType=xml",
       },
     ],

--- a/blocks/sitemap-section-index-feature-block/features/sitemap-section-front-index/__snapshots__/xml.test.js.snap
+++ b/blocks/sitemap-section-index-feature-block/features/sitemap-section-front-index/__snapshots__/xml.test.js.snap
@@ -1,38 +1,38 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`returns template with links to sections without outputType 1`] = `
-Object {
-  "sitemapindex": Object {
+{
+  "sitemapindex": {
     "@xmlns": "http://www.sitemaps.org/schemas/sitemap/0.9",
-    "sitemap": Array [
-      Object {
+    "sitemap": [
+      {
         "loc": "http://demo-prod.origin.arcpublishing.com/politics/",
       },
-      Object {
+      {
         "loc": "http://demo-prod.origin.arcpublishing.com/opinion/",
       },
-      Object {
+      {
         "loc": "http://demo-prod.origin.arcpublishing.com/economy/",
       },
-      Object {
+      {
         "loc": "http://demo-prod.origin.arcpublishing.com/sports/",
       },
-      Object {
+      {
         "loc": "http://demo-prod.origin.arcpublishing.com/sports/football/",
       },
-      Object {
+      {
         "loc": "http://demo-prod.origin.arcpublishing.com/sports/baseball/",
       },
-      Object {
+      {
         "loc": "http://demo-prod.origin.arcpublishing.com/sports/basketball/",
       },
-      Object {
+      {
         "loc": "http://demo-prod.origin.arcpublishing.com/entertainment/",
       },
-      Object {
+      {
         "loc": "http://demo-prod.origin.arcpublishing.com/entertainment/tv/",
       },
-      Object {
+      {
         "loc": "http://demo-prod.origin.arcpublishing.com/entertainment/movies/",
       },
     ],
@@ -41,38 +41,38 @@ Object {
 `;
 
 exports[`returns template with sitemap at root 1`] = `
-Object {
-  "sitemapindex": Object {
+{
+  "sitemapindex": {
     "@xmlns": "http://www.sitemaps.org/schemas/sitemap/0.9",
-    "sitemap": Array [
-      Object {
+    "sitemap": [
+      {
         "loc": "http://demo-prod.origin.arcpublishing.com/sitemap-category-politics.xml",
       },
-      Object {
+      {
         "loc": "http://demo-prod.origin.arcpublishing.com/sitemap-category-opinion.xml",
       },
-      Object {
+      {
         "loc": "http://demo-prod.origin.arcpublishing.com/sitemap-category-economy.xml",
       },
-      Object {
+      {
         "loc": "http://demo-prod.origin.arcpublishing.com/sitemap-category-sports.xml",
       },
-      Object {
+      {
         "loc": "http://demo-prod.origin.arcpublishing.com/sitemap-category-sports-football.xml",
       },
-      Object {
+      {
         "loc": "http://demo-prod.origin.arcpublishing.com/sitemap-category-sports-baseball.xml",
       },
-      Object {
+      {
         "loc": "http://demo-prod.origin.arcpublishing.com/sitemap-category-sports-basketball.xml",
       },
-      Object {
+      {
         "loc": "http://demo-prod.origin.arcpublishing.com/sitemap-category-entertainment.xml",
       },
-      Object {
+      {
         "loc": "http://demo-prod.origin.arcpublishing.com/sitemap-category-entertainment-tv.xml",
       },
-      Object {
+      {
         "loc": "http://demo-prod.origin.arcpublishing.com/sitemap-category-entertainment-movies.xml",
       },
     ],
@@ -81,38 +81,38 @@ Object {
 `;
 
 exports[`returns template with sitemap index by section links 1`] = `
-Object {
-  "sitemapindex": Object {
+{
+  "sitemapindex": {
     "@xmlns": "http://www.sitemaps.org/schemas/sitemap/0.9",
-    "sitemap": Array [
-      Object {
+    "sitemap": [
+      {
         "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap/category/politics/",
       },
-      Object {
+      {
         "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap/category/opinion/",
       },
-      Object {
+      {
         "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap/category/economy/",
       },
-      Object {
+      {
         "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap/category/sports/",
       },
-      Object {
+      {
         "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap/category/sports/football/",
       },
-      Object {
+      {
         "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap/category/sports/baseball/",
       },
-      Object {
+      {
         "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap/category/sports/basketball/",
       },
-      Object {
+      {
         "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap/category/entertainment/",
       },
-      Object {
+      {
         "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap/category/entertainment/tv/",
       },
-      Object {
+      {
         "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap/category/entertainment/movies/",
       },
     ],
@@ -121,32 +121,32 @@ Object {
 `;
 
 exports[`returns template with sitemap index by section links with excluded links 1`] = `
-Object {
-  "sitemapindex": Object {
+{
+  "sitemapindex": {
     "@xmlns": "http://www.sitemaps.org/schemas/sitemap/0.9",
-    "sitemap": Array [
-      Object {
+    "sitemap": [
+      {
         "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap/category/opinion/?outputType=xml",
       },
-      Object {
+      {
         "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap/category/economy/?outputType=xml",
       },
-      Object {
+      {
         "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap/category/sports/?outputType=xml",
       },
-      Object {
+      {
         "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap/category/sports/football/?outputType=xml",
       },
-      Object {
+      {
         "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap/category/sports/baseball/?outputType=xml",
       },
-      Object {
+      {
         "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap/category/sports/basketball/?outputType=xml",
       },
-      Object {
+      {
         "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap/category/entertainment/?outputType=xml",
       },
-      Object {
+      {
         "loc": "http://demo-prod.origin.arcpublishing.com/arc/outboundfeeds/sitemap/category/entertainment/movies/?outputType=xml",
       },
     ],

--- a/blocks/sitemap-video-feature-block/features/video-sitemap/__snapshots__/xml.test.js.snap
+++ b/blocks/sitemap-video-feature-block/features/video-sitemap/__snapshots__/xml.test.js.snap
@@ -1,38 +1,38 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`returns template with default values 1`] = `
-Object {
-  "urlset": Object {
+{
+  "urlset": {
     "@xmlns": "http://www.sitemaps.org/schemas/sitemap/0.9",
     "@xmlns:video": "http://www.google.com/schemas/sitemap-video/1.1",
-    "url": Array [
-      Object {
+    "url": [
+      {
         "lastmod": "2020-04-16T19:55:14Z",
         "loc": "http://demo-prod.origin.arcpublishing.com/video/2020/04/16/inexact-odyssey-a-volcom-snowboarding-film/",
-        "video:video": Object {
+        "video:video": {
           "video:category": "Video",
           "video:content_loc": "https://d3ujdjwa458jgt.cloudfront.net/out/v1/87998c783fb94bf0b965847d5c8b4392/index.m3u8",
-          "video:description": Object {
+          "video:description": {
             "$": "Video Description",
           },
           "video:duration": 789,
           "video:thumbnail_loc": "hi/abcdefghijklmnopqrstuvwxyz=/dv8csq7v0ltdn.cloudfront.net/04-16-2020/t_95d8de29ea3b41caac132f0462c5c71a_name_file_1920x1080_5400_v4_.jpg",
-          "video:title": Object {
+          "video:title": {
             "$": "Inexact Odyssey, A Volcom Snowboarding Film",
           },
         },
       },
-      Object {
+      {
         "lastmod": "2021-04-16T19:55:14Z",
         "loc": "http://demo-prod.origin.arcpublishing.com/video/2020/04/16/inexact-odyssey-a-volcom-snowboarding-film/",
-        "video:video": Object {
+        "video:video": {
           "video:category": "Video",
           "video:content_loc": "https://d3ujdjwa458jgt.cloudfront.net/out/v1/87998c783fb94bf0b965847d5c8b4392/index.m3u8",
-          "video:description": Object {
+          "video:description": {
             "$": "Video Description",
           },
           "video:duration": 789,
-          "video:title": Object {
+          "video:title": {
             "$": "Inexact Odyssey, A Volcom Snowboarding Film",
           },
         },
@@ -43,24 +43,24 @@ Object {
 `;
 
 exports[`returns template with empty values 1`] = `
-Object {
-  "urlset": Object {
+{
+  "urlset": {
     "@xmlns": "http://www.sitemaps.org/schemas/sitemap/0.9",
     "@xmlns:video": "http://www.google.com/schemas/sitemap-video/1.1",
-    "url": Array [
-      Object {
+    "url": [
+      {
         "lastmod": undefined,
         "loc": "http://demo-prod.origin.arcpublishing.com/video/2020/04/16/inexact-odyssey-a-volcom-snowboarding-film/",
-        "video:video": Object {
+        "video:video": {
           "video:category": "Video",
           "video:content_loc": "https://d3ujdjwa458jgt.cloudfront.net/out/v1/87998c783fb94bf0b965847d5c8b4392/index.m3u8",
           "video:duration": 789,
         },
       },
-      Object {
+      {
         "lastmod": undefined,
         "loc": "http://demo-prod.origin.arcpublishing.com/video/2020/04/16/inexact-odyssey-a-volcom-snowboarding-film/",
-        "video:video": Object {
+        "video:video": {
           "video:category": "Video",
           "video:content_loc": "https://d3ujdjwa458jgt.cloudfront.net/out/v1/87998c783fb94bf0b965847d5c8b4392/index.m3u8",
           "video:duration": 789,
@@ -72,38 +72,38 @@ Object {
 `;
 
 exports[`returns template with headlines.title, description.basic 2000 values 1`] = `
-Object {
-  "urlset": Object {
+{
+  "urlset": {
     "@xmlns": "http://www.sitemaps.org/schemas/sitemap/0.9",
     "@xmlns:video": "http://www.google.com/schemas/sitemap-video/1.1",
-    "url": Array [
-      Object {
+    "url": [
+      {
         "lastmod": "2020-04-16T19:55:14Z",
         "loc": "http://demo-prod.origin.arcpublishing.com/video/2020/04/16/inexact-odyssey-a-volcom-snowboarding-film/",
-        "video:video": Object {
+        "video:video": {
           "video:category": "Video",
           "video:content_loc": "https://d3ujdjwa458jgt.cloudfront.net/out/v1/87998c783fb94bf0b965847d5c8b4392/index.m3u8",
-          "video:description": Object {
+          "video:description": {
             "$": "Video Description",
           },
           "video:duration": 789,
           "video:thumbnail_loc": "hi/abcdefghijklmnopqrstuvwxyz=/dv8csq7v0ltdn.cloudfront.net/04-16-2020/t_95d8de29ea3b41caac132f0462c5c71a_name_file_1920x1080_5400_v4_.jpg",
-          "video:title": Object {
+          "video:title": {
             "$": "Ababe beso bela",
           },
         },
       },
-      Object {
+      {
         "lastmod": "2021-04-16T19:55:14Z",
         "loc": "http://demo-prod.origin.arcpublishing.com/video/2020/04/16/inexact-odyssey-a-volcom-snowboarding-film/",
-        "video:video": Object {
+        "video:video": {
           "video:category": "Video",
           "video:content_loc": "https://d3ujdjwa458jgt.cloudfront.net/out/v1/87998c783fb94bf0b965847d5c8b4392/index.m3u8",
-          "video:description": Object {
+          "video:description": {
             "$": "Video Description",
           },
           "video:duration": 789,
-          "video:title": Object {
+          "video:title": {
             "$": "Ababe beso bela",
           },
         },
@@ -114,25 +114,25 @@ Object {
 `;
 
 exports[`returns template with subheadlines.basic values 1`] = `
-Object {
-  "urlset": Object {
+{
+  "urlset": {
     "@xmlns": "http://www.sitemaps.org/schemas/sitemap/0.9",
     "@xmlns:video": "http://www.google.com/schemas/sitemap-video/1.1",
-    "url": Array [
-      Object {
+    "url": [
+      {
         "lastmod": "2020-04-16T19:55:25Z",
         "loc": "http://demo-prod.origin.arcpublishing.com/video/2020/04/16/inexact-odyssey-a-volcom-snowboarding-film/",
-        "video:video": Object {
+        "video:video": {
           "video:category": "Video",
           "video:content_loc": "https://d3ujdjwa458jgt.cloudfront.net/out/v1/87998c783fb94bf0b965847d5c8b4392/index.m3u8",
           "video:duration": 789,
           "video:thumbnail_loc": "hi/abcdefghijklmnopqrstuvwxyz=/dv8csq7v0ltdn.cloudfront.net/04-16-2020/t_95d8de29ea3b41caac132f0462c5c71a_name_file_1920x1080_5400_v4_.jpg",
         },
       },
-      Object {
+      {
         "lastmod": "2021-04-16T19:55:25Z",
         "loc": "http://demo-prod.origin.arcpublishing.com/video/2020/04/16/inexact-odyssey-a-volcom-snowboarding-film/",
-        "video:video": Object {
+        "video:video": {
           "video:category": "Video",
           "video:content_loc": "https://d3ujdjwa458jgt.cloudfront.net/out/v1/87998c783fb94bf0b965847d5c8b4392/index.m3u8",
           "video:duration": 789,

--- a/jest.config.js
+++ b/jest.config.js
@@ -16,4 +16,7 @@ module.exports = {
 
   // The directory where Jest should output its coverage files
   coverageDirectory: 'coverage',
+  transform: {
+    '^.+\\.jsx?$': 'babel-jest',
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
         "utils/*"
       ],
       "dependencies": {
-        "@wpmedia/signing-service-content-source-block": "^0.1.1-arc-themes-release-version-2.0.3.4646",
         "axios": "^1.6.7",
         "react": "^18.2.0"
       },
@@ -6546,23 +6545,6 @@
     "node_modules/@wpmedia/rss-msn-feature-block": {
       "resolved": "blocks/rss-msn-feature-block",
       "link": true
-    },
-    "node_modules/@wpmedia/signing-service-content-source-block": {
-      "version": "0.1.1-arc-themes-release-version-2.0.3.4646",
-      "resolved": "https://npm.pkg.github.com/download/@wpmedia/signing-service-content-source-block/0.1.1-arc-themes-release-version-2.0.3.4646/be61489b1a57a67f136476cf85eeeda48a3d6f08",
-      "integrity": "sha512-/rZaUZFUdnxPDxOdxxJ4lbUiKuMCckFfBlNsV9ysC8Vd2GPw7tuHbA/tIdlaZ9orNS/Ls6sBSAihcHZS38c4Xw==",
-      "license": "CC-BY-NC-ND-4.0",
-      "dependencies": {
-        "axios": "^0.26.0"
-      }
-    },
-    "node_modules/@wpmedia/signing-service-content-source-block/node_modules/axios": {
-      "version": "0.26.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
-      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
-      "dependencies": {
-        "follow-redirects": "^1.14.8"
-      }
     },
     "node_modules/@wpmedia/sitemap-feature-block": {
       "resolved": "blocks/sitemap-feature-block",

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@changesets/cli": "^2.27.1",
         "@manypkg/cli": "^0.21.2",
         "@preconstruct/cli": "^2.8.3",
+        "babel-jest": "^29.7.0",
         "eslint": "^8.56.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-config-standard": "^17.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,41 +5,14 @@
   "packages": {
     "": {
       "name": "@feed-components/root",
+      "hasInstallScript": true,
+      "workspaces": [
+        "blocks/*",
+        "utils/*"
+      ],
       "dependencies": {
-        "@wpmedia/ans-feature-block": "file:blocks/ans-feature-block",
-        "@wpmedia/feeds-content-elements": "file:utils/content-elements",
-        "@wpmedia/feeds-content-source-utils": "file:blocks/feeds-content-source-utils",
-        "@wpmedia/feeds-find-video-stream": "file:utils/find-video-stream",
-        "@wpmedia/feeds-promo-items": "file:blocks/feeds-promo-items",
-        "@wpmedia/feeds-prop-types": "file:utils/prop-types",
-        "@wpmedia/feeds-resizer": "file:blocks/feeds-resizer",
-        "@wpmedia/feeds-source-collections-block": "file:blocks/feeds-source-collections-block",
-        "@wpmedia/feeds-source-content-api-block": "file:blocks/feeds-source-content-api-block",
-        "@wpmedia/feeds-source-content-api-by-day-block": "file:blocks/feeds-source-content-api-by-day-block",
-        "@wpmedia/feeds-source-content-api-by-day2-block": "file:blocks/feeds-source-content-api-by-day2-block",
-        "@wpmedia/feeds-source-content-api-by-day3-block": "file:blocks/feeds-source-content-api-by-day3-block",
-        "@wpmedia/feeds-source-single-content-block": "file:blocks/feeds-source-single-content-block",
-        "@wpmedia/feeds-source-video-api-block": "file:blocks/feeds-source-video-api-block",
-        "@wpmedia/feeds-xml-output": "file:utils/xml-output",
-        "@wpmedia/json-output-block": "file:blocks/json-output-block",
-        "@wpmedia/mrss-feature-block": "file:blocks/mrss-feature-block",
-        "@wpmedia/rss-alexa-feature-block": "file:blocks/rss-alexa-feature-block",
-        "@wpmedia/rss-fbia-feature-block": "file:blocks/rss-fbia-feature-block",
-        "@wpmedia/rss-feature-block": "file:blocks/rss-feature-block",
-        "@wpmedia/rss-flipboard-feature-block": "file:blocks/rss-flipboard-feature-block",
-        "@wpmedia/rss-google-news-feature-block": "file:blocks/rss-google-news-feature-block",
-        "@wpmedia/rss-msn-feature-block": "file:blocks/rss-msn-feature-block",
-        "@wpmedia/signing-service-content-source-block": "*",
-        "@wpmedia/sitemap-feature-block": "file:blocks/sitemap-feature-block",
-        "@wpmedia/sitemap-index-by-day-feature-block": "file:blocks/sitemap-index-by-day-feature-block",
-        "@wpmedia/sitemap-index-feature-block": "file:blocks/sitemap-index-feature-block",
-        "@wpmedia/sitemap-news-feature-block": "file:blocks/sitemap-news-feature-block",
-        "@wpmedia/sitemap-section-feature-block": "file:blocks/sitemap-section-feature-block",
-        "@wpmedia/sitemap-section-index-feature-block": "file:blocks/sitemap-section-index-feature-block",
-        "@wpmedia/sitemap-video-feature-block": "file:blocks/sitemap-video-feature-block",
-        "@wpmedia/story-feed-querybuilder-content-source-block": "file:blocks/story-feed-querybuilder-content-source-block",
-        "@wpmedia/text-output-block": "file:blocks/text-output-block",
-        "@wpmedia/textfile-block": "file:blocks/textfile-block",
+        "@wpmedia/signing-service-content-source-block": "^0.1.1-arc-themes-release-version-2.0.3.4646",
+        "axios": "^1.6.7",
         "react": "^18.2.0"
       },
       "devDependencies": {
@@ -63,15 +36,10 @@
         "husky": "^9.0.10",
         "jest": "^29.7.0",
         "jest-watch-typeahead": "^2.2.2",
+        "jsdom": "^24.0.0",
         "lerna": "^8.1.2",
         "prettier": "^3.2.5",
         "pretty-quick": "^4.0.0"
-      },
-      "workspaces": {
-        "packages": [
-          "blocks/*",
-          "utils/*"
-        ]
       }
     },
     "blocks/ans-feature-block": {
@@ -84,10 +52,12 @@
     },
     "blocks/feeds-content-source-utils": {
       "version": "1.0.8",
+      "extraneous": true,
       "license": "CC-BY-NC-ND-4.0"
     },
     "blocks/feeds-promo-items": {
       "version": "1.0.8",
+      "extraneous": true,
       "license": "CC-BY-NC-ND-4.0",
       "dependencies": {
         "@wpmedia/feeds-find-video-stream": "1.0.8",
@@ -97,6 +67,7 @@
     },
     "blocks/feeds-resizer": {
       "version": "1.0.8",
+      "extraneous": true,
       "license": "CC-BY-NC-ND-4.0",
       "dependencies": {
         "thumbor-lite": "^0.1.8"
@@ -118,7 +89,6 @@
       "version": "1.15.0",
       "license": "CC-BY-NC-ND-4.0",
       "dependencies": {
-        "@wpmedia/arc-themes-components": "*",
         "@wpmedia/feeds-content-source-utils": "1.0.8"
       },
       "devDependencies": {
@@ -6349,12 +6319,6 @@
       "resolved": "blocks/ans-feature-block",
       "link": true
     },
-    "node_modules/@wpmedia/arc-themes-components": {
-      "version": "0.0.1",
-      "resolved": "https://npm.pkg.github.com/download/@WPMedia/arc-themes-components/0.0.1/f9ff4b987c296ed8e615b4acbbf9fb8576e437e4",
-      "integrity": "sha512-2z4L9mf76dtwpIqDCIb70HxrlLW4KL5QkEeQSh9sHY0kkhz5MHx9rW8WcNSuYBmjbYr0rKtV3jl10Vt6WTgyUw==",
-      "license": "CC-BY-NC-ND-4.0"
-    },
     "node_modules/@wpmedia/engine-theme-sdk": {
       "version": "2.9.0",
       "resolved": "https://npm.pkg.github.com/download/@WPMedia/engine-theme-sdk/2.9.0/89335d013bc75cc2bb2242aee8f1900a990bd947",
@@ -6487,7 +6451,7 @@
       "link": true
     },
     "node_modules/@wpmedia/feeds-content-source-utils": {
-      "resolved": "blocks/feeds-content-source-utils",
+      "resolved": "utils/content-source-utils",
       "link": true
     },
     "node_modules/@wpmedia/feeds-find-video-stream": {
@@ -6495,7 +6459,7 @@
       "link": true
     },
     "node_modules/@wpmedia/feeds-promo-items": {
-      "resolved": "blocks/feeds-promo-items",
+      "resolved": "utils/promo-items",
       "link": true
     },
     "node_modules/@wpmedia/feeds-prop-types": {
@@ -6503,7 +6467,7 @@
       "link": true
     },
     "node_modules/@wpmedia/feeds-resizer": {
-      "resolved": "blocks/feeds-resizer",
+      "resolved": "utils/resizer",
       "link": true
     },
     "node_modules/@wpmedia/feeds-source-collections-block": {
@@ -6583,9 +6547,9 @@
       "link": true
     },
     "node_modules/@wpmedia/signing-service-content-source-block": {
-      "version": "0.1.0",
-      "resolved": "https://npm.pkg.github.com/download/@wpmedia/signing-service-content-source-block/0.1.0/6cd83c0dbdc269abb734525f3b97e9367fa6a181",
-      "integrity": "sha512-w0+kqN+Zj2Xnmp8sKkVu8lYRcfQgZ3cnO3TTAITjtVWvNwd6z41lHfoAnw2kD2OYyIZe2Yw/FXIZhpLe4ne9xA==",
+      "version": "0.1.1-arc-themes-release-version-2.0.3.4646",
+      "resolved": "https://npm.pkg.github.com/download/@wpmedia/signing-service-content-source-block/0.1.1-arc-themes-release-version-2.0.3.4646/be61489b1a57a67f136476cf85eeeda48a3d6f08",
+      "integrity": "sha512-/rZaUZFUdnxPDxOdxxJ4lbUiKuMCckFfBlNsV9ysC8Vd2GPw7tuHbA/tIdlaZ9orNS/Ls6sBSAihcHZS38c4Xw==",
       "license": "CC-BY-NC-ND-4.0",
       "dependencies": {
         "axios": "^0.26.0"
@@ -7051,8 +7015,7 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/at-least-node": {
       "version": "1.0.0",
@@ -7079,7 +7042,6 @@
       "version": "1.6.7",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
       "integrity": "sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==",
-      "dev": true,
       "dependencies": {
         "follow-redirects": "^1.15.4",
         "form-data": "^4.0.0",
@@ -8057,7 +8019,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -8861,6 +8822,18 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
+    "node_modules/cssstyle": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.0.1.tgz",
+      "integrity": "sha512-8ZYiJ3A/3OkDd093CBT/0UKDWry7ak4BdPTFP2+QEP7cmhouyq/Up709ASSj2cK02BbZiMgk7kYjZNS4QP5qrQ==",
+      "dev": true,
+      "dependencies": {
+        "rrweb-cssom": "^0.6.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
@@ -8907,6 +8880,53 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/data-urls/node_modules/tr46": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.0.0.tgz",
+      "integrity": "sha512-tk2G5R2KRwBd+ZN0zaEXpmzdKyOYksXwywulIX95MBODjSzMIuQnQ3m8JxgbhnL1LeVo7lqQKsYa1O3Htl7K5g==",
+      "dev": true,
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/data-urls/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.0.0.tgz",
+      "integrity": "sha512-1lfMEm2IEr7RIV+f4lUNPOqfFL+pO+Xw3fJSqmjX9AbXcXcYOkCe1P6+9VBZB6n94af16NfZf+sSk0JCBZC9aw==",
+      "dev": true,
+      "dependencies": {
+        "tr46": "^5.0.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/dataloader": {
@@ -8978,6 +8998,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
+      "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==",
+      "dev": true
     },
     "node_modules/decompress-response": {
       "version": "6.0.0",
@@ -9110,7 +9136,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -10725,7 +10750,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
       "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dev": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -11744,6 +11768,18 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -12523,6 +12559,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true
     },
     "node_modules/is-react": {
       "version": "1.5.4",
@@ -14869,6 +14911,80 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsdom": {
+      "version": "24.0.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-24.0.0.tgz",
+      "integrity": "sha512-UDS2NayCvmXSXVP6mpTj+73JnNQadZlr9N68189xib2tx5Mls7swlTNao26IoHv46BZJFvXygyRtyXd1feAk1A==",
+      "dev": true,
+      "dependencies": {
+        "cssstyle": "^4.0.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.2",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.7",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.6.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^4.1.3",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.16.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/tr46": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.0.0.tgz",
+      "integrity": "sha512-tk2G5R2KRwBd+ZN0zaEXpmzdKyOYksXwywulIX95MBODjSzMIuQnQ3m8JxgbhnL1LeVo7lqQKsYa1O3Htl7K5g==",
+      "dev": true,
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/jsdom/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-url": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.0.0.tgz",
+      "integrity": "sha512-1lfMEm2IEr7RIV+f4lUNPOqfFL+pO+Xw3fJSqmjX9AbXcXcYOkCe1P6+9VBZB6n94af16NfZf+sSk0JCBZC9aw==",
+      "dev": true,
+      "dependencies": {
+        "tr46": "^5.0.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -16319,7 +16435,6 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -16328,7 +16443,6 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dev": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -17551,6 +17665,12 @@
       "funding": {
         "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.7.tgz",
+      "integrity": "sha512-ub5E4+FBPKwAZx0UwIQOjYWGHTEq5sPqHQNRN8Z9e4A7u3Tj1weLJsL59yH9vmvqEtBHaOmT6cYQKIZOxp35FQ==",
+      "dev": true
     },
     "node_modules/nx": {
       "version": "18.0.2",
@@ -19347,13 +19467,18 @@
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "dev": true
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
       "integrity": "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==",
+      "dev": true
+    },
+    "node_modules/psl": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
+      "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==",
       "dev": true
     },
     "node_modules/punycode": {
@@ -19380,6 +19505,12 @@
           "url": "https://opencollective.com/fast-check"
         }
       ]
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "dev": true
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -20105,6 +20236,12 @@
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true
     },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "dev": true
+    },
     "node_modules/resolve": {
       "version": "1.22.8",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
@@ -20245,6 +20382,12 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.6.0.tgz",
+      "integrity": "sha512-APM0Gt1KoXBz0iIkkdB/kfvGOwC4UuJFeG/c+yV7wSc7q96cG/kJ0HiYCnzivD9SB53cLV1MlHFNfOuPaadYSw==",
+      "dev": true
+    },
     "node_modules/run-async": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
@@ -20345,6 +20488,18 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
     },
     "node_modules/scheduler": {
       "version": "0.19.1",
@@ -21384,6 +21539,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true
+    },
     "node_modules/synckit": {
       "version": "0.8.8",
       "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.8.8.tgz",
@@ -21635,6 +21796,30 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.3.tgz",
+      "integrity": "sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==",
+      "dev": true,
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tough-cookie/node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4.0.0"
       }
     },
     "node_modules/tr46": {
@@ -22306,6 +22491,16 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dev": true,
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -22370,6 +22565,18 @@
       "integrity": "sha512-uYBjakWipfaO/bXI7E8rq6kpwHRZK5cNYrUv2OzZSI/FvmdMyXJ2tG9dKcjEC5YHmHpUAwsargWIZNWdxb/bnQ==",
       "dev": true
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/walker": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
@@ -22402,6 +22609,39 @@
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "dev": true
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "dev": true,
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
@@ -22746,6 +22986,36 @@
         "node": ">=6"
       }
     },
+    "node_modules/ws": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
+      "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/xmlbuilder2": {
       "version": "2.1.7",
       "resolved": "https://registry.npmjs.org/xmlbuilder2/-/xmlbuilder2-2.1.7.tgz",
@@ -22758,6 +23028,12 @@
       "engines": {
         "node": ">=10.0"
       }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true
     },
     "node_modules/xtend": {
       "version": "4.0.2",
@@ -22936,7 +23212,6 @@
     "utils/content-source-utils": {
       "name": "@wpmedia/feeds-content-source-utils",
       "version": "1.0.8",
-      "extraneous": true,
       "license": "CC-BY-NC-ND-4.0"
     },
     "utils/find-video-stream": {
@@ -22950,7 +23225,6 @@
     "utils/promo-items": {
       "name": "@wpmedia/feeds-promo-items",
       "version": "1.0.8",
-      "extraneous": true,
       "license": "CC-BY-NC-ND-4.0",
       "dependencies": {
         "@wpmedia/feeds-find-video-stream": "1.0.8",
@@ -22969,7 +23243,6 @@
     "utils/resizer": {
       "name": "@wpmedia/feeds-resizer",
       "version": "1.0.8",
-      "extraneous": true,
       "license": "CC-BY-NC-ND-4.0",
       "dependencies": {
         "thumbor-lite": "^0.1.8"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     ]
   },
   "dependencies": {
-    "@wpmedia/signing-service-content-source-block": "^0.1.1-arc-themes-release-version-2.0.3.4646",
     "axios": "^1.6.7",
     "react": "^18.2.0"
   },

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@changesets/cli": "^2.27.1",
     "@manypkg/cli": "^0.21.2",
     "@preconstruct/cli": "^2.8.3",
+    "babel-jest": "^29.7.0",
     "eslint": "^8.56.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-config-standard": "^17.1.0",

--- a/package.json
+++ b/package.json
@@ -2,12 +2,10 @@
   "name": "@feed-components/root",
   "version:": "1.0.0",
   "private": true,
-  "workspaces": {
-    "packages": [
-      "blocks/*",
-      "utils/*"
-    ]
-  },
+  "workspaces": [
+    "blocks/*",
+    "utils/*"
+  ],
   "preconstruct": {
     "distFilenameStrategy": "unscoped-package-name",
     "packages": [
@@ -15,40 +13,8 @@
     ]
   },
   "dependencies": {
-    "@wpmedia/ans-feature-block": "file:blocks/ans-feature-block",
-    "@wpmedia/feeds-content-elements": "file:utils/content-elements",
-    "@wpmedia/feeds-content-source-utils": "file:utils/content-source-utils",
-    "@wpmedia/feeds-find-video-stream": "file:utils/find-video-stream",
-    "@wpmedia/feeds-promo-items": "file:utils/promo-items",
-    "@wpmedia/feeds-prop-types": "file:utils/prop-types",
-    "@wpmedia/feeds-resizer": "file:utils/resizer",
-    "@wpmedia/feeds-source-collections-block": "file:blocks/feeds-source-collections-block",
-    "@wpmedia/feeds-source-content-api-block": "file:blocks/feeds-source-content-api-block",
-    "@wpmedia/feeds-source-content-api-by-day-block": "file:blocks/feeds-source-content-api-by-day-block",
-    "@wpmedia/feeds-source-content-api-by-day2-block": "file:blocks/feeds-source-content-api-by-day2-block",
-    "@wpmedia/feeds-source-content-api-by-day3-block": "file:blocks/feeds-source-content-api-by-day3-block",
-    "@wpmedia/feeds-source-single-content-block": "file:blocks/feeds-source-single-content-block",
-    "@wpmedia/feeds-source-video-api-block": "file:blocks/feeds-source-video-api-block",
-    "@wpmedia/feeds-xml-output": "file:utils/xml-output",
-    "@wpmedia/json-output-block": "file:blocks/json-output-block",
-    "@wpmedia/mrss-feature-block": "file:blocks/mrss-feature-block",
-    "@wpmedia/rss-alexa-feature-block": "file:blocks/rss-alexa-feature-block",
-    "@wpmedia/rss-fbia-feature-block": "file:blocks/rss-fbia-feature-block",
-    "@wpmedia/rss-feature-block": "file:blocks/rss-feature-block",
-    "@wpmedia/rss-flipboard-feature-block": "file:blocks/rss-flipboard-feature-block",
-    "@wpmedia/rss-google-news-feature-block": "file:blocks/rss-google-news-feature-block",
-    "@wpmedia/rss-msn-feature-block": "file:blocks/rss-msn-feature-block",
-    "@wpmedia/signing-service-content-source-block": "*",
-    "@wpmedia/sitemap-feature-block": "file:blocks/sitemap-feature-block",
-    "@wpmedia/sitemap-index-by-day-feature-block": "file:blocks/sitemap-index-by-day-feature-block",
-    "@wpmedia/sitemap-index-feature-block": "file:blocks/sitemap-index-feature-block",
-    "@wpmedia/sitemap-news-feature-block": "file:blocks/sitemap-news-feature-block",
-    "@wpmedia/sitemap-section-feature-block": "file:blocks/sitemap-section-feature-block",
-    "@wpmedia/sitemap-section-index-feature-block": "file:blocks/sitemap-section-index-feature-block",
-    "@wpmedia/sitemap-video-feature-block": "file:blocks/sitemap-video-feature-block",
-    "@wpmedia/story-feed-querybuilder-content-source-block": "file:blocks/story-feed-querybuilder-content-source-block",
-    "@wpmedia/text-output-block": "file:blocks/text-output-block",
-    "@wpmedia/textfile-block": "file:blocks/textfile-block",
+    "@wpmedia/signing-service-content-source-block": "^0.1.1-arc-themes-release-version-2.0.3.4646",
+    "axios": "^1.6.7",
     "react": "^18.2.0"
   },
   "devDependencies": {
@@ -72,6 +38,7 @@
     "husky": "^9.0.10",
     "jest": "^29.7.0",
     "jest-watch-typeahead": "^2.2.2",
+    "jsdom": "^24.0.0",
     "lerna": "^8.1.2",
     "prettier": "^3.2.5",
     "pretty-quick": "^4.0.0"
@@ -82,6 +49,7 @@
     }
   },
   "scripts": {
+    "postinstall": "preconstruct dev",
     "lint": "npm run lint:eslint && npm run lint:prettier",
     "lint:eslint": "eslint . --ext .js --ext .jsx",
     "lint:prettier": "prettier --check \"./{blocks,utils}/**/*.js\"",

--- a/utils/prop-types/src/__snapshots__/props.test.js.snap
+++ b/utils/prop-types/src/__snapshots__/props.test.js.snap
@@ -1,9 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`generates proptypes for rss 1`] = `
-Object {
-  "channelCategory": Object {
-    "tags": Object {
+{
+  "channelCategory": {
+    "tags": {
       "defaultValue": "",
       "description": "Category that describes this RSS feed, if blank it will be excluded",
       "group": "Channel",
@@ -11,8 +11,8 @@ Object {
     },
     "type": "string",
   },
-  "channelCopyright": Object {
-    "tags": Object {
+  "channelCopyright": {
+    "tags": {
       "defaultValue": "",
       "description": "RSS Copyright value otherwise it will be excluded",
       "group": "Channel",
@@ -20,17 +20,17 @@ Object {
     },
     "type": "string",
   },
-  "channelDescription": Object {
-    "tags": Object {
+  "channelDescription": {
+    "tags": {
       "defaultValue": "",
-      "description": "RSS Channel Description, defaults to website name + \\" News Feed\\"",
+      "description": "RSS Channel Description, defaults to website name + " News Feed"",
       "group": "Channel",
       "label": "RSS Description",
     },
     "type": "string",
   },
-  "channelLanguage": Object {
-    "tags": Object {
+  "channelLanguage": {
+    "tags": {
       "defaultValue": "",
       "description": "ISO-639 Language code, if blank uses value from feedLanguage in blocks.json. Use Exclude to remove this field.",
       "group": "Channel",
@@ -38,8 +38,8 @@ Object {
     },
     "type": "string",
   },
-  "channelLogo": Object {
-    "tags": Object {
+  "channelLogo": {
+    "tags": {
       "defaultValue": "",
       "description": "URL to the logo for this RSS feed",
       "group": "Channel",
@@ -47,8 +47,8 @@ Object {
     },
     "type": "string",
   },
-  "channelTTL": Object {
-    "tags": Object {
+  "channelTTL": {
+    "tags": {
       "defaultValue": "1",
       "description": "Number of minutes to wait to check for new content, defaults to 1, hint to bots",
       "group": "Channel",
@@ -56,8 +56,8 @@ Object {
     },
     "type": "string",
   },
-  "channelTitle": Object {
-    "tags": Object {
+  "channelTitle": {
+    "tags": {
       "defaultValue": "",
       "description": "RSS Channel Title, defaults to website name",
       "group": "Channel",
@@ -65,8 +65,8 @@ Object {
     },
     "type": "string",
   },
-  "channelUpdateFrequency": Object {
-    "tags": Object {
+  "channelUpdateFrequency": {
+    "tags": {
       "defaultValue": "1",
       "description": "Number of Update Periods to wait to check for new content, defaults to 1",
       "group": "Channel",
@@ -74,8 +74,8 @@ Object {
     },
     "type": "string",
   },
-  "channelUpdatePeriod": Object {
-    "args": Array [
+  "channelUpdatePeriod": {
+    "args": [
       "hourly",
       "daily",
       "weekly",
@@ -83,7 +83,7 @@ Object {
       "yearly",
       "Exclude field",
     ],
-    "tags": Object {
+    "tags": {
       "defaultValue": "hourly",
       "description": "How frequently should bots revisit page, defaults to hourly",
       "group": "Channel",
@@ -92,8 +92,8 @@ Object {
     },
     "type": "oneOf",
   },
-  "imageCaption": Object {
-    "tags": Object {
+  "imageCaption": {
+    "tags": {
       "defaultValue": "caption",
       "description": "ANS field to use for image caption in <media:caption> tag, defaults to caption",
       "group": "Featured Media",
@@ -101,8 +101,8 @@ Object {
     },
     "type": "string",
   },
-  "imageCredits": Object {
-    "tags": Object {
+  "imageCredits": {
+    "tags": {
       "defaultValue": "credits.by[].name",
       "description": "ANS field to use for image credits in <media:credits> tag, defaults to credits.by[].name",
       "group": "Featured Media",
@@ -110,8 +110,8 @@ Object {
     },
     "type": "string",
   },
-  "imageTitle": Object {
-    "tags": Object {
+  "imageTitle": {
+    "tags": {
       "defaultValue": "title",
       "description": "ANS field to use for featured media title in <media:title> tag, defaults to title",
       "group": "Featured Media",
@@ -119,8 +119,8 @@ Object {
     },
     "type": "string",
   },
-  "includeContent": Object {
-    "args": Array [
+  "includeContent": {
+    "args": [
       "0",
       "1",
       "2",
@@ -134,7 +134,7 @@ Object {
       "10",
       "all",
     ],
-    "tags": Object {
+    "tags": {
       "defaultValue": "all",
       "description": "Number of paragraphs to include, defaults to all",
       "group": "Item",
@@ -142,8 +142,8 @@ Object {
     },
     "type": "oneOf",
   },
-  "includePromo": Object {
-    "tags": Object {
+  "includePromo": {
+    "tags": {
       "defaultValue": true,
       "description": "Include featured media in <media:content>",
       "group": "Featured Media",
@@ -151,8 +151,8 @@ Object {
     },
     "type": "bool",
   },
-  "itemCategory": Object {
-    "tags": Object {
+  "itemCategory": {
+    "tags": {
       "defaultValue": "",
       "description": "ANS field to use for article category, if blank will be excluded",
       "group": "Item",
@@ -160,8 +160,8 @@ Object {
     },
     "type": "string",
   },
-  "itemCredits": Object {
-    "tags": Object {
+  "itemCredits": {
+    "tags": {
       "defaultValue": "credits.by[].name",
       "description": "ANS value for credits in the <dc:creator> tag, will join multiple names with a comma. defaults to credits.by[].name",
       "group": "Item",
@@ -169,8 +169,8 @@ Object {
     },
     "type": "string",
   },
-  "itemDescription": Object {
-    "tags": Object {
+  "itemDescription": {
+    "tags": {
       "defaultValue": "description.basic",
       "description": "ANS fields to use for article description, defaults to description.basic",
       "group": "Item",
@@ -178,8 +178,8 @@ Object {
     },
     "type": "string",
   },
-  "itemTitle": Object {
-    "tags": Object {
+  "itemTitle": {
+    "tags": {
       "defaultValue": "headlines.basic",
       "description": "ANS fields to use for article title, defaults to headlines.basic",
       "group": "Item",
@@ -187,8 +187,8 @@ Object {
     },
     "type": "string",
   },
-  "promoItemsJmespath": Object {
-    "tags": Object {
+  "promoItemsJmespath": {
+    "tags": {
       "defaultValue": "promo_items.basic || promo_items.lead_art",
       "description": "ANS fields to use for featured media, defaults to promo_items.basic || promo_items.lead_art",
       "group": "Featured Media",
@@ -196,15 +196,15 @@ Object {
     },
     "type": "string",
   },
-  "pubDate": Object {
-    "args": Array [
+  "pubDate": {
+    "args": [
       "created_date",
       "display_date",
       "first_publish_date",
       "last_updated_date",
       "publish_date",
     ],
-    "tags": Object {
+    "tags": {
       "defaultValue": "display_date",
       "description": "Which date field should be used, defaults to display_date",
       "group": "Item",
@@ -212,9 +212,9 @@ Object {
     },
     "type": "oneOf",
   },
-  "resizerKVP": Object {
-    "tags": Object {
-      "defaultValue": Object {
+  "resizerKVP": {
+    "tags": {
+      "defaultValue": {
         "height": 0,
         "width": 0,
       },
@@ -224,13 +224,13 @@ Object {
     },
     "type": "kvp",
   },
-  "videoSelect": Object {
-    "tags": Object {
-      "defaultValue": Object {
+  "videoSelect": {
+    "tags": {
+      "defaultValue": {
         "bitrate": 2000,
         "stream_type": "mp4",
       },
-      "description": "Which criteria should be used to filter video encodings, defaults to { bitrate: 2000, stream_type: \\"mp4\\" }",
+      "description": "Which criteria should be used to filter video encodings, defaults to { bitrate: 2000, stream_type: "mp4" }",
       "group": "Video",
       "label": "Video Encoding",
     },
@@ -240,9 +240,9 @@ Object {
 `;
 
 exports[`generates proptypes for sitemap 1`] = `
-Object {
-  "changeFreq": Object {
-    "args": Array [
+{
+  "changeFreq": {
+    "args": [
       "always",
       "hourly",
       "daily",
@@ -252,7 +252,7 @@ Object {
       "never",
       "Exclude field",
     ],
-    "tags": Object {
+    "tags": {
       "defaultValue": "always",
       "description": "What is the expected Change frequency of the sitemap, hint for bots",
       "group": "Format",
@@ -261,8 +261,8 @@ Object {
     },
     "type": "oneOf",
   },
-  "includePromo": Object {
-    "tags": Object {
+  "includePromo": {
+    "tags": {
       "defaultValue": true,
       "description": "Include featured media in the sitemap",
       "group": "Featured Media",
@@ -270,15 +270,15 @@ Object {
     },
     "type": "bool",
   },
-  "lastMod": Object {
-    "args": Array [
+  "lastMod": {
+    "args": [
       "created_date",
       "display_date",
       "first_publish_date",
       "last_updated_date",
       "publish_date",
     ],
-    "tags": Object {
+    "tags": {
       "defaultValue": "last_updated_date",
       "description": "Which date field should be used in the sitemap",
       "group": "Format",
@@ -286,8 +286,8 @@ Object {
     },
     "type": "oneOf",
   },
-  "priority": Object {
-    "args": Array [
+  "priority": {
+    "args": [
       "0.0",
       "0.1",
       "0.2",
@@ -301,7 +301,7 @@ Object {
       "1.0",
       "Exclude field",
     ],
-    "tags": Object {
+    "tags": {
       "defaultValue": "0.5",
       "description": "What is the priority of the content in the sitemap, hint for bots",
       "group": "Format",
@@ -309,8 +309,8 @@ Object {
     },
     "type": "oneOf",
   },
-  "promoItemsJmespath": Object {
-    "tags": Object {
+  "promoItemsJmespath": {
+    "tags": {
       "defaultValue": "promo_items.basic || promo_items.lead_art",
       "description": "ANS fields to use for featured media, defaults to promo_items.basic || promo_items.lead_art",
       "group": "Featured Media",
@@ -318,9 +318,9 @@ Object {
     },
     "type": "string",
   },
-  "resizerKVP": Object {
-    "tags": Object {
-      "defaultValue": Object {
+  "resizerKVP": {
+    "tags": {
+      "defaultValue": {
         "height": 0,
         "width": 0,
       },
@@ -334,9 +334,9 @@ Object {
 `;
 
 exports[`omits specified properties from sitemap propypes 1`] = `
-Object {
-  "changeFreq": Object {
-    "args": Array [
+{
+  "changeFreq": {
+    "args": [
       "always",
       "hourly",
       "daily",
@@ -346,7 +346,7 @@ Object {
       "never",
       "Exclude field",
     ],
-    "tags": Object {
+    "tags": {
       "defaultValue": "always",
       "description": "What is the expected Change frequency of the sitemap, hint for bots",
       "group": "Format",
@@ -355,15 +355,15 @@ Object {
     },
     "type": "oneOf",
   },
-  "lastMod": Object {
-    "args": Array [
+  "lastMod": {
+    "args": [
       "created_date",
       "display_date",
       "first_publish_date",
       "last_updated_date",
       "publish_date",
     ],
-    "tags": Object {
+    "tags": {
       "defaultValue": "last_updated_date",
       "description": "Which date field should be used in the sitemap",
       "group": "Format",
@@ -371,8 +371,8 @@ Object {
     },
     "type": "oneOf",
   },
-  "priority": Object {
-    "args": Array [
+  "priority": {
+    "args": [
       "0.0",
       "0.1",
       "0.2",
@@ -386,7 +386,7 @@ Object {
       "1.0",
       "Exclude field",
     ],
-    "tags": Object {
+    "tags": {
       "defaultValue": "0.5",
       "description": "What is the priority of the content in the sitemap, hint for bots",
       "group": "Format",
@@ -394,8 +394,8 @@ Object {
     },
     "type": "oneOf",
   },
-  "promoItemsJmespath": Object {
-    "tags": Object {
+  "promoItemsJmespath": {
+    "tags": {
       "defaultValue": "promo_items.basic || promo_items.lead_art",
       "description": "ANS fields to use for featured media, defaults to promo_items.basic || promo_items.lead_art",
       "group": "Featured Media",
@@ -403,9 +403,9 @@ Object {
     },
     "type": "string",
   },
-  "resizerKVP": Object {
-    "tags": Object {
-      "defaultValue": Object {
+  "resizerKVP": {
+    "tags": {
+      "defaultValue": {
         "height": 0,
         "width": 0,
       },

--- a/utils/resizer/src/handle-fetch-error/index.js
+++ b/utils/resizer/src/handle-fetch-error/index.js
@@ -1,0 +1,22 @@
+const handleFetchError = (error) => {
+	if (error.response?.status === 404) {
+		const NotFoundError = (message = "Not Found") => {
+			const err = new Error(message);
+			err.statusCode = 404;
+			return err;
+		};
+		throw NotFoundError();
+	} else if (error?.statusCode === 302 || error.statusCode === 404) {
+		throw error;
+	} else if (error?.response) {
+		throw new Error(
+			`The response from the server was an error with the status code ${error?.response?.status}.`
+		);
+	} else if (error?.request) {
+		throw new Error("The request to the server failed with no response.");
+	} else {
+		throw new Error("An error occured creating the request.");
+	}
+};
+
+export default handleFetchError;

--- a/utils/resizer/src/handle-fetch-error/index.test.js
+++ b/utils/resizer/src/handle-fetch-error/index.test.js
@@ -1,0 +1,45 @@
+import handleFetchError from ".";
+
+describe("handleFetchError()", () => {
+	it("handles 404 errors", () => {
+		try {
+			handleFetchError({ response: { status: 404 } });
+		} catch (e) {
+			expect(e.message).toEqual("Not Found");
+		}
+	});
+
+	it("handles 302 redirects", () => {
+		try {
+			handleFetchError({ location: "test.com", statusCode: 302 });
+		} catch (e) {
+			expect(e).toEqual({ location: "test.com", statusCode: 302 });
+		}
+	});
+
+	it("handles errors with the response", () => {
+		try {
+			handleFetchError({ response: { status: "400" } });
+		} catch (e) {
+			expect(e.message).toEqual(
+				"The response from the server was an error with the status code 400."
+			);
+		}
+	});
+
+	it("handles errors with the request", () => {
+		try {
+			handleFetchError({ request: {} });
+		} catch (e) {
+			expect(e.message).toEqual("The request to the server failed with no response.");
+		}
+	});
+
+	it("handles errors creating the request", () => {
+		try {
+			handleFetchError({});
+		} catch (e) {
+			expect(e.message).toEqual("An error occured creating the request.");
+		}
+	});
+});

--- a/utils/resizer/src/image-ans-to-image-src/index.js
+++ b/utils/resizer/src/image-ans-to-image-src/index.js
@@ -1,0 +1,25 @@
+/**
+ * Helper to take an ANS image object and return an src string
+ *
+ * @param data ANS Image Object
+ *
+ * @return an image string to be used in the src of a image tag
+ */
+const imageANSToImageSrc = (data) => {
+	const { _id: id, auth, url } = data || {};
+	if (url) {
+		if (id) {
+			const fileExtension = url.match(/\.\w{3,4}$/);
+			if (fileExtension) {
+				return `${id}${fileExtension[0]}`;
+			}
+			// Return the id as a string if no file extension is found.
+			return `${id}`
+		} else if (auth) {
+			return encodeURIComponent(url);
+		}
+	}
+	return null;
+};
+
+export default imageANSToImageSrc;

--- a/utils/resizer/src/image-ans-to-image-src/index.test.js
+++ b/utils/resizer/src/image-ans-to-image-src/index.test.js
@@ -1,0 +1,25 @@
+import imageANSToImageSrc from ".";
+
+describe("imageANSToImageSrc", () => {
+	it("return image src with ext", () => {
+		expect(imageANSToImageSrc({ _id: 123, url: "http://image.com/test.jpg" })).toBe("123.jpg");
+		expect(imageANSToImageSrc({ _id: 123, url: "http://image.com/test.test.jpg" })).toBe("123.jpg");
+		expect(imageANSToImageSrc({ _id: 321, url: "http://image.com/test.test.jpeg" })).toBe("321.jpeg");
+	});
+
+	it("return image src without ext", () => {
+		expect(imageANSToImageSrc({ _id: 123, url: "http://image.com/123" })).toBe("123");
+	});
+
+	it("return image src as encoded url when no _id but an auth exists", () => {
+		expect(imageANSToImageSrc({ url: "http://image.com/test.jpg", auth: { 1: "123" } })).toBe(
+			encodeURIComponent("http://image.com/test.jpg")
+		);
+	});
+
+	it("will return null if incorrect ANS data", () => {
+		expect(imageANSToImageSrc({ _id: 123 })).toBe(null);
+		expect(imageANSToImageSrc({ url: "testjpg" })).toBe(null);
+		expect(imageANSToImageSrc()).toBe(null);
+	});
+});

--- a/utils/resizer/src/index.js
+++ b/utils/resizer/src/index.js
@@ -2,6 +2,8 @@ import { RESIZER_TOKEN_VERSION } from 'fusion:environment'
 
 import imageANSToImageSrc from './image-ans-to-image-src'
 import signImagesInANSObject from './sign-images-in-ans-object'
+import handleFetchError from './handle-fetch-error'
+import signingService from './signing-service'
 
 import calculateWidthAndHeight from './calculateWidthAndHeight'
 
@@ -58,4 +60,4 @@ export function buildResizerURL(
   return null
 }
 
-export { imageANSToImageSrc, signImagesInANSObject }
+export { imageANSToImageSrc, signImagesInANSObject, handleFetchError, signingService}

--- a/utils/resizer/src/index.js
+++ b/utils/resizer/src/index.js
@@ -32,7 +32,6 @@ export function buildResizerURL(
       height,
       ansImage,
     })
-
     const defaultSrc = formatSrc(
       resizerURL.concat('/', imageANSToImageSrc(ansImage)),
       {
@@ -57,7 +56,6 @@ export function buildResizerURL(
     }
     return _url
   }
-  return null
 }
 
 export { imageANSToImageSrc, signImagesInANSObject, handleFetchError, resizerFetch }

--- a/utils/resizer/src/index.js
+++ b/utils/resizer/src/index.js
@@ -1,6 +1,7 @@
 import { RESIZER_TOKEN_VERSION } from 'fusion:environment'
 
-import imageANSToImageSrc from '@wpmedia/arc-themes-components/src/utils/image-ans-to-image-src'
+import imageANSToImageSrc from './image-ans-to-image-src'
+import signImagesInANSObject from './sign-images-in-ans-object'
 
 import calculateWidthAndHeight from './calculateWidthAndHeight'
 
@@ -56,3 +57,5 @@ export function buildResizerURL(
   }
   return null
 }
+
+export { imageANSToImageSrc, signImagesInANSObject }

--- a/utils/resizer/src/index.js
+++ b/utils/resizer/src/index.js
@@ -18,7 +18,7 @@ const formatSrc = (srcWithResizerUrl, resizedOptions) => {
   )
 }
 
-export function buildResizerURL(
+function buildResizerURL(
   _url,
   resizerKey,
   resizerURL,
@@ -58,4 +58,4 @@ export function buildResizerURL(
   }
 }
 
-export { imageANSToImageSrc, signImagesInANSObject, handleFetchError, resizerFetch }
+export { buildResizerURL, imageANSToImageSrc, signImagesInANSObject, handleFetchError, resizerFetch }

--- a/utils/resizer/src/index.js
+++ b/utils/resizer/src/index.js
@@ -3,7 +3,7 @@ import { RESIZER_TOKEN_VERSION } from 'fusion:environment'
 import imageANSToImageSrc from './image-ans-to-image-src'
 import signImagesInANSObject from './sign-images-in-ans-object'
 import handleFetchError from './handle-fetch-error'
-import signingService from './signing-service'
+import { fetch as resizerFetch } from './signing-service'
 
 import calculateWidthAndHeight from './calculateWidthAndHeight'
 
@@ -60,4 +60,4 @@ export function buildResizerURL(
   return null
 }
 
-export { imageANSToImageSrc, signImagesInANSObject, handleFetchError, signingService}
+export { imageANSToImageSrc, signImagesInANSObject, handleFetchError, resizerFetch }

--- a/utils/resizer/src/index.test.js
+++ b/utils/resizer/src/index.test.js
@@ -1,0 +1,71 @@
+import { buildResizerURL } from '.'; // Adjust the path as necessary
+
+
+describe('buildResizerURL', () => {
+    beforeEach(() => {
+        // Reset mocks
+        jest.resetModules();
+        jest.clearAllMocks();
+    
+        // Mock 'thumbor-lite' for each test to ensure a fresh mock
+        jest.mock('thumbor-lite', () => {
+          return function () {
+            return {
+              setImagePath: jest.fn().mockReturnThis(),
+              resize: jest.fn().mockReturnThis(),
+              buildUrl: jest.fn().mockReturnValue('http://resizer.url/resized-image.jpg'),
+            };
+          };
+        });
+        jest.mock('./calculateWidthAndHeight', () => ({
+            __esModule: true, // This is required to mock a module that has a default export
+            default: jest.fn(),
+        }));
+          
+    });
+
+    it('formats URL correctly for ANS image with auth token', () => {
+        const ansImage = {
+        auth: { 'token_v1': 'someAuthToken' },
+        };
+        require('./calculateWidthAndHeight').default.mockReturnValue({ width: 100, height: 100 });
+
+        const result = buildResizerURL(
+        'http://example.com/image.jpg',
+        'dummyResizerKey',
+        'http://resizer.url',
+        100,
+        100,
+        ansImage
+        );
+
+        expect(result).toContain('http://resizer.url/');
+        expect(result).toContain('width=100');
+        expect(result).toContain('height=100');
+        expect(result).toContain('auth=someAuthToken');
+        expect(result).toContain('smart=true');
+    });
+
+    it('uses Thumbor for resizing', () => {
+        const originalUrl = 'http://example.com/image.jpg';
+        const resizerKey = 'dummyResizerKey';
+        const resizerURL = 'http://resizer.url';
+
+        const result = buildResizerURL(
+          originalUrl,
+          resizerKey,
+          resizerURL,
+          100,
+          100
+        );
+    
+        expect(result).toEqual('http://resizer.url/resized-image.jpg');
+    });
+
+    it('returns the original URL if no resizing is needed and no auth token is present', () => {
+        const originalUrl = 'http://example.com/image.jpg';
+        const result = buildResizerURL(originalUrl, '', '', 0, 0);
+        
+        expect(result).toEqual(originalUrl);
+    });
+});

--- a/utils/resizer/src/index.test.js
+++ b/utils/resizer/src/index.test.js
@@ -1,3 +1,7 @@
+jest.mock('fusion:environment', () => ({
+    RESIZER_TOKEN_VERSION: 1, 
+}));
+// eslint-disable-next-line import/first
 import { buildResizerURL } from '.'; // Adjust the path as necessary
 
 
@@ -26,8 +30,9 @@ describe('buildResizerURL', () => {
 
     it('formats URL correctly for ANS image with auth token', () => {
         const ansImage = {
-        auth: { 'token_v1': 'someAuthToken' },
+            auth: { 1: 'someAuthToken' },
         };
+
         require('./calculateWidthAndHeight').default.mockReturnValue({ width: 100, height: 100 });
 
         const result = buildResizerURL(

--- a/utils/resizer/src/sign-images-in-ans-object/index.js
+++ b/utils/resizer/src/sign-images-in-ans-object/index.js
@@ -1,0 +1,45 @@
+const signImagesInANSObject =
+	(cachedCall, fetcher, resizerAppVersion, cacheKey = "image-token") =>
+	({ data, ...rest }) => {
+		const replacements = new Set();
+
+		const stringData = JSON.stringify(data, (key, value) => {
+			if (value === null || typeof value === "undefined") {
+				return value;
+			}
+			const { _id, type, auth, url } = value;
+			if (!auth?.[resizerAppVersion] && type === "image") {
+				replacements.add(_id || url);
+				return {
+					...value,
+					auth: {
+						...value.auth,
+						[resizerAppVersion]: `__replaceMe${_id || url}__`,
+					},
+				};
+			}
+			return value;
+		});
+
+		return Promise.all(
+			Array.from(replacements).map((id) =>
+				cachedCall(`${cacheKey}-${id}`, fetcher, {
+					query: { id },
+					ttl: 31536000,
+					independent: true,
+				}).then((auth) => ({ id, auth }))
+			)
+		).then((authResults) => {
+			const replaced = authResults.reduce(
+				(accumulator, { id, auth }) =>
+					accumulator.replace(new RegExp(`__replaceMe${id}__`, "g"), auth.hash),
+				stringData
+			);
+			return {
+				data: JSON.parse(replaced),
+				...rest,
+			};
+		});
+	};
+
+export default signImagesInANSObject;

--- a/utils/resizer/src/sign-images-in-ans-object/index.test.js
+++ b/utils/resizer/src/sign-images-in-ans-object/index.test.js
@@ -1,0 +1,162 @@
+import signImagesInANSObject from ".";
+
+const data = {
+	_id: "43UU6MCQERAMRPTD23B3CEXE7E",
+	type: "story",
+	undefinedValue: undefined,
+	content_elements: [
+		{
+			_id: "LJJSIEXMZ5FTDBP7PFHXI5A4XY",
+			type: "image", // should fill auth
+		},
+		{
+			_id: "LJJSIEXMZ5FTDBP7PFHXI5A4XY",
+			type: "image", // should fill with first items auth
+		},
+		{
+			_id: "LJJSIEXMZ5FTDBP7PFHXI5A4XZ",
+			type: "image",
+			auth: {
+				1: "40b3b900866998ec98c4a286eef727080a10ac968d5eed7bd4a6a084511db6c1",
+			}, // should get 2
+		},
+		{
+			_id: "LJJSIEXMZ5FTDBP7PFHXI5A4X2",
+			type: "image",
+			auth: {
+				2: "40b3b900866998ec98c4a286eef727080a10ac968d5eed7bd4a6a084511db6c2",
+			}, // should skip
+		},
+	],
+	promo_items: {
+		basic: {
+			_id: "OYRQQIJJLNBVNN4QLERLG2FZZ4",
+			type: "image", // should fill auth
+		},
+	},
+};
+
+const noIDImageData = {
+	_id: "43UU6MCQERAMRPTD23B3CEXE7E",
+	type: "story",
+	promo_items: {
+		lead_art: {
+			embed_html: "<embededVideo />",
+			promo_items: {
+				basic: {
+					type: "image",
+					url: "https://test.img/filename.jpg",
+				},
+			},
+			type: "video",
+		},
+	},
+};
+
+const idAuthMap = {
+	LJJSIEXMZ5FTDBP7PFHXI5A4XY: {
+		hash: "40b3b900866998ec98c4a286eef727080a10ac968d5eed7bd4a6a084511db6cy",
+	},
+	LJJSIEXMZ5FTDBP7PFHXI5A4XZ: {
+		hash: "40b3b900866998ec98c4a286eef727080a10ac968d5eed7bd4a6a084511db6cz",
+	},
+	LJJSIEXMZ5FTDBP7PFHXI5A4X2: {
+		hash: "40b3b900866998ec98c4a286eef727080a10ac968d5eed7bd4a6a084511db6c2",
+	},
+	OYRQQIJJLNBVNN4QLERLG2FZZ4: {
+		hash: "545c018dbf2bbc8e4488c7546167e6afacc259cf4fe0b2f28c8043990f689e40",
+	},
+	"https://test.img/filename.jpg": {
+		hash: "545c018dbf2bbc8e4488c7546167e6afacc259cf4fe0b2f28c8043990f689e41",
+	},
+};
+
+const fetcher = jest.fn((id) => idAuthMap[id]);
+const cachedCall = jest.fn((cacheId, fetchMethod, options) =>
+	Promise.resolve(fetchMethod(options.query.id))
+);
+
+describe("Sign Images In ANS Object", () => {
+	beforeEach(() => {
+		cachedCall.mockClear();
+	});
+
+	it("returns the correct auth key values in the returned ans object", async () => {
+		const signIt = signImagesInANSObject(cachedCall, fetcher, 2);
+
+		const { data: signedData, status } = await signIt({ data, status: 2 });
+
+		expect(status).toBe(2);
+		expect(cachedCall).toHaveBeenCalledWith(
+			"image-token-LJJSIEXMZ5FTDBP7PFHXI5A4XY",
+			fetcher,
+			expect.objectContaining({
+				query: { id: "LJJSIEXMZ5FTDBP7PFHXI5A4XY" },
+				ttl: 31536000,
+				independent: true,
+			})
+		);
+		expect(cachedCall).toHaveBeenCalledWith(
+			"image-token-LJJSIEXMZ5FTDBP7PFHXI5A4XZ",
+			fetcher,
+			expect.objectContaining({
+				query: { id: "LJJSIEXMZ5FTDBP7PFHXI5A4XZ" },
+				ttl: 31536000,
+				independent: true,
+			})
+		);
+		expect(cachedCall).toHaveBeenCalledWith(
+			"image-token-OYRQQIJJLNBVNN4QLERLG2FZZ4",
+			fetcher,
+			expect.objectContaining({
+				query: { id: "OYRQQIJJLNBVNN4QLERLG2FZZ4" },
+				ttl: 31536000,
+				independent: true,
+			})
+		);
+		expect(cachedCall).not.toHaveBeenCalledWith(
+			"image-token-LJJSIEXMZ5FTDBP7PFHXI5A4X2",
+			fetcher,
+			expect.objectContaining({
+				query: { id: "LJJSIEXMZ5FTDBP7PFHXI5A4X2" },
+				ttl: 31536000,
+				independent: true,
+			})
+		);
+		expect(cachedCall).toHaveBeenCalledTimes(3);
+		expect(signedData.promo_items.basic.auth[2]).toBe(
+			"545c018dbf2bbc8e4488c7546167e6afacc259cf4fe0b2f28c8043990f689e40"
+		);
+		expect(signedData.content_elements[0].auth[2]).toBe(
+			"40b3b900866998ec98c4a286eef727080a10ac968d5eed7bd4a6a084511db6cy"
+		);
+		expect(signedData.content_elements[1].auth[2]).toBe(
+			"40b3b900866998ec98c4a286eef727080a10ac968d5eed7bd4a6a084511db6cy"
+		);
+		expect(signedData.content_elements[2].auth[2]).toBe(
+			"40b3b900866998ec98c4a286eef727080a10ac968d5eed7bd4a6a084511db6cz"
+		);
+	});
+
+	it("returns the correct auth key for a non-id image (third party url)", async () => {
+		const signIt = signImagesInANSObject(cachedCall, fetcher, 2);
+
+		const { data: signedData } = await signIt({ data: noIDImageData });
+
+		expect(cachedCall).toHaveBeenCalledWith(
+			"image-token-https://test.img/filename.jpg",
+			fetcher,
+			expect.objectContaining({
+				query: { id: "https://test.img/filename.jpg" },
+				ttl: 31536000,
+				independent: true,
+			})
+		);
+
+		expect(cachedCall).toHaveBeenCalledTimes(1);
+
+		expect(signedData.promo_items.lead_art.promo_items.basic.auth[2]).toBe(
+			"545c018dbf2bbc8e4488c7546167e6afacc259cf4fe0b2f28c8043990f689e41"
+		);
+	});
+});

--- a/utils/resizer/src/signing-service/index.js
+++ b/utils/resizer/src/signing-service/index.js
@@ -1,0 +1,42 @@
+import axios from "axios";
+import {
+	ARC_ACCESS_TOKEN,
+	CONTENT_BASE,
+	SIGNING_SERVICE_DEFAULT_APP,
+	RESIZER_TOKEN_VERSION,
+} from "fusion:environment";
+import handleFetchError from "../handle-fetch-error";
+
+const params = {
+	id: "text",
+	service: "text",
+	serviceVersion: "text",
+};
+
+const fetch = ({
+	id,
+	service = SIGNING_SERVICE_DEFAULT_APP,
+	serviceVersion = RESIZER_TOKEN_VERSION,
+}) => {
+	const urlSearch = new URLSearchParams({
+		value: id,
+	});
+	return axios({
+		url: `${CONTENT_BASE}/signing-service/v2/sign/${service}/${serviceVersion}?${urlSearch.toString()}`,
+		headers: {
+			"content-type": "application/json",
+			Authorization: `Bearer ${ARC_ACCESS_TOKEN}`,
+		},
+		method: "GET",
+	})
+		.then(({ data: content }) => content)
+		.catch(handleFetchError);
+};
+
+export default {
+	fetch,
+	params,
+	http: false,
+	// 365 day ttl
+	ttl: 31536000,
+};

--- a/utils/resizer/src/signing-service/index.test.js
+++ b/utils/resizer/src/signing-service/index.test.js
@@ -1,0 +1,25 @@
+import contentSource from ".";
+
+jest.mock("fusion:environment", () => ({
+	CONTENT_BASE: "",
+	SIGNING_SERVICE_DEFAULT_APP: "resizer",
+	RESIZER_TOKEN_VERSION: 1,
+}));
+
+jest.mock("axios", () => ({
+	__esModule: true,
+	default: jest.fn((data) => Promise.resolve({ data })),
+}));
+
+describe("Test Signing Service content source", () => {
+	it("should build the correct url", async () => {
+		const key = {
+			id: "test://id",
+		};
+		const contentSourceRequest = await contentSource.fetch(key);
+
+		expect(contentSourceRequest.url).toEqual(
+			`/signing-service/v2/sign/resizer/1?value=test%3A%2F%2Fid`
+		);
+	});
+});

--- a/utils/xml-output/src/xmlOutput.test.js
+++ b/utils/xml-output/src/xmlOutput.test.js
@@ -1,4 +1,8 @@
 import { XmlOutput } from './index'
+const { JSDOM } = require('jsdom');
+
+const dom = new JSDOM();
+global.DOMParser = dom.window.DOMParser;
 
 const exampleData = [
   {


### PR DESCRIPTION
Initially the goal was to just remove any arc-themes-components deps because it's just pulling in more than needed and causes more customer config that isn't ideal. So these resizer related utils that are needed in OBF are duplicated by copying them into the resizer utils. 

Longer term plan is that a separate resizer utils package could be published that both themes blocks and feed blocks use and so it isn't duplicated. 


As I stepped through though, I then found the arc-themes-block/signing-service-content-source to _also_ have an arc-themes-component dependency on a util. This is unfortunate in another way because that package doesn't define arc-themes-components as a dependency, it just assumes it's available because you're probably already installing it via blocks.json.

In that regard, it isn't really an isolated npm package at the moment - it assumes it must be run in a specific environment with specific dependencies already available. As you can see jest fails `    Cannot find module '@wpmedia/arc-themes-components/src/utils/handle-fetch-error' from 'node_modules/@wpmedia/signing-service-content-source-block/sources/signing-service.js'`
<img width="1095" alt="image" src="https://github.com/WPMedia/feed-components/assets/2506649/80bb425c-8872-4f2a-ab5f-c19b062b7d52">

So what is the solution? Definitely not including arc-themes-components since we want to avoid that. It means further duplication as a temporary solution to eventually decouple all of these and have a common set of utils.


Note:
Every feed block (all the content sources) that depends on feeds-resizer needs to get the dependency added into their package.json
feeds-resizer util should get axios added as well (since the fetchResizer is now in there).